### PR TITLE
Add pedantic repository documentation (THEORY.md, REPOSITORY_GUIDE.md) and expand README

### DIFF
--- a/TritRPC-v1-full/README.md
+++ b/TritRPC-v1-full/README.md
@@ -1,37 +1,123 @@
+# TritRPC v1 (Repository)
 
+This repository contains reference material, fixtures, and two language ports (Rust and Go)
+for **TritRPC v1**, a protocol that blends ternary-native encodings with conventional
+byte-transport, along with authenticated envelope framing. The focus of this repo is
+**deterministic, byte-for-byte reproducibility** across implementations.
+
+## Quick navigation
+
+- **Theory & conceptual model:** `docs/THEORY.md`
+- **Full specification:** `spec/README-full-spec.md`
+- **Reference implementation:** `reference/tritrpc_v1.py`
+- **Fixtures (canonical vectors):** `fixtures/`
+- **Rust port:** `rust/`
+- **Go port:** `go/`
+
+## What this repository guarantees
+
+1. **Canonical encoding:** Trits, lengths, payloads, and envelopes encode to a canonical
+   byte sequence.
+2. **Cross-language parity:** Rust and Go implementations produce identical bytes for
+   the same semantic input.
+3. **Strict verification:** Fixtures and tests reject any non-canonical or malformed
+   outputs.
+4. **Traceable theory:** The theory and spec are included in-repo and linked here for
+   easy, long-term reference.
+
+## Theory at a glance (summary)
+
+TritRPC v1 is built on these conceptual layers:
+
+- **Trits (base-3 digits)** are packed into bytes using **TritPack243**, which encodes
+  5 trits per byte and uses a tail marker for 1–4 trailing trits.
+- **TLEB3** encodes lengths as base-9 digits expressed as tritlets, then packs those
+  trits via TritPack243.
+- **Envelope framing** separates routing metadata (SERVICE + METHOD), AUX structures,
+  payload bytes, and the AEAD authentication lane.
+- **Path-A** payloads are encoded with Avro Binary Encoding (used by the reference
+  implementation and most fixtures).
+- **Path-B** payloads are ternary-native (toy subset fixtures demonstrate this).
+- **AEAD integrity** uses XChaCha20-Poly1305 (or a deterministic MAC fallback) with
+  24-byte nonces for authenticated frames.
+
+For complete detail, read `docs/THEORY.md` and the full spec.
+
+## Repository layout
+
+A more detailed guide lives in `docs/REPOSITORY_GUIDE.md`. At a glance:
+
+- `docs/`: Theory and repository guide.
+- `spec/`: Full specification (normative requirements).
+- `reference/`: Python reference implementation and fixture generator.
+- `fixtures/`: Canonical hex fixtures and their nonce files.
+- `rust/`, `go/`: Language implementations.
+- `scripts/`, `tools/`: Utility scripts and regeneration tooling.
+
+## Build and test (ports)
 
 ### Build the ports
+
 - Rust: `cd rust/tritrpc_v1 && cargo test`
 - Go: `cd go/tritrpcv1 && go test`
 
-
 ### Fixture verification
-- Rust: `cargo test -p tritrpc_v1` validates AEAD tags using `.nonces` and checks Avro payload bytes for key frames.
+
+- Rust: `cargo test -p tritrpc_v1` validates AEAD tags using `.nonces` and checks Avro
+  payload bytes for key frames.
 - Go: `cd go/tritrpcv1 && go test` performs the same validations.
 
-
 ### CLI tools
-- Rust: `cargo run -p tritrpc_v1 --bin trpc -- pack --service hyper.v1 --method AddVertex_a.REQ --json payload.json --nonce <hex> --key <hex>`
-- Go: `cd go/tritrpcv1/cmd/trpc && go build && ./trpc verify --fixtures ../../fixtures/vectors_hex_unary_rich.txt --nonces ../../fixtures/vectors_hex_unary_rich.txt.nonces`
 
+- Rust:
+  ```bash
+  cargo run -p tritrpc_v1 --bin trpc -- pack \
+    --service hyper.v1 \
+    --method AddVertex_a.REQ \
+    --json payload.json \
+    --nonce <hex> \
+    --key <hex>
+  ```
+- Go:
+  ```bash
+  cd go/tritrpcv1/cmd/trpc
+  go build
+  ./trpc verify --fixtures ../../fixtures/vectors_hex_unary_rich.txt \
+    --nonces ../../fixtures/vectors_hex_unary_rich.txt.nonces
+  ```
+
+## Fixtures and determinism
+
+Fixtures are the **interoperability contract** between implementations. The reference
+implementation generates canonical frames in `fixtures/*.txt`, and both Rust and Go
+implementations must reproduce those bytes exactly. Each fixture line has a paired nonce
+file (`*.nonces`) used to recompute AEAD tags.
 
 ## Path-B (ternary) vectors (toy subset)
-See `fixtures/vectors_hex_pathB.txt` (+ `.nonces`). These use ternary-native encodings (TLEB3 lengths, balanced-ternary ints) and are AEAD-authenticated like Path-A.
+
+See `fixtures/vectors_hex_pathB.txt` (+ `.nonces`). These use ternary-native encodings
+(TLEB3 lengths, balanced-ternary ints) and are AEAD-authenticated like Path-A.
 
 ## CI
-A GitHub Actions workflow is included in `.github/workflows/ci.yml` to run `cargo test` and `go test` on push/PR.
 
+A GitHub Actions workflow is included in `.github/workflows/ci.yml` to run `cargo test`
+and `go test` on push/PR.
 
 ## Release workflow
-- On tag push (`v*`), builds Rust + Go CLIs, zips them with fixtures, and attaches to the GitHub Release.
+
+- On tag push (`v*`), builds Rust + Go CLIs, zips them with fixtures, and attaches
+  them to the GitHub Release.
 - See `.github/workflows/release.yml`.
 
 ## Repack check
-- CI job `repack-check` rebuilds a canonical AddVertex_a frame with Rust and Go CLIs and diffs it against fixtures.
 
+CI job `repack-check` rebuilds a canonical AddVertex_a frame with Rust and Go CLIs and
+compares it against the fixtures.
 
 ## Pre-commit hook (strict AEAD verification)
-To prevent committing drifted fixtures, enable the pre-commit hook that re-computes **XChaCha20-Poly1305** tags for every `fixtures/*.txt` line using the paired `.nonces`:
+
+To prevent committing drifted fixtures, enable the pre-commit hook that re-computes
+**XChaCha20-Poly1305** tags for every `fixtures/*.txt` line using the paired `.nonces`:
 
 ```bash
 pip install cryptography   # required for local verification
@@ -40,6 +126,7 @@ bash scripts/install_hooks.sh
 ```
 
 If you need to refresh tags intentionally, run:
+
 ```bash
 python tools/regenerate_aead_tags.py
 ```

--- a/TritRPC-v1-full/docs/REPOSITORY_GUIDE.md
+++ b/TritRPC-v1-full/docs/REPOSITORY_GUIDE.md
@@ -1,0 +1,72 @@
+# Repository Guide (Pedantic)
+
+This guide explains the structure of the repository and the intent behind each major
+folder. It complements the top-level README by giving concrete navigation hints.
+
+## Top-level layout
+
+- `README.md`: Project summary, build instructions, and high-level navigation.
+- `docs/`: Conceptual and procedural documentation.
+  - `THEORY.md`: Theory and conceptual model for TritRPC v1.
+  - `REPOSITORY_GUIDE.md`: This file.
+- `spec/`: Specification material.
+  - `README-full-spec.md`: The full spec text (repo copy).
+  - `salad/`: Supporting artifacts for the spec (schemas, adjunct docs, etc.).
+- `reference/`: Reference implementation used to generate fixture vectors.
+  - `tritrpc_v1.py`: Reference pack/parse and encoding logic.
+- `fixtures/`: Canonical fixture vectors used for verification tests.
+  - `*.txt`: Hex vectors (canonical frames).
+  - `*.nonces`: Per-line nonces aligned with fixtures for AEAD verification.
+- `rust/`: Rust implementation of TritRPC v1.
+- `go/`: Go implementation of TritRPC v1.
+- `scripts/`: Utility scripts (e.g., pre-commit hook install).
+- `tools/`: Maintenance utilities (e.g., fixture or AEAD tag regeneration).
+
+## Implementations
+
+### Rust
+
+The Rust implementation is organized under `rust/` and is validated through the fixture
+vectors. It contains:
+
+- Core encoding/decoding logic for TritRPC v1.
+- CLI tooling to pack frames, verify fixtures, and inspect envelopes.
+- Tests that enforce deterministic outputs.
+
+### Go
+
+The Go implementation lives under `go/` and mirrors the Rust functionality. It focuses on:
+
+- Byte-for-byte parity with fixtures.
+- CLI tools and verification routines.
+- Integration of the same encoding theory as the Rust version.
+
+## Reference implementation and fixtures
+
+The reference Python code in `reference/tritrpc_v1.py` is the canonical generator used to
+produce the fixture vectors. Fixtures are the **source of truth** for interoperability:
+
+- Both Rust and Go tests re-encode frames and compare outputs to fixture bytes.
+- Nonces are stored alongside fixtures to ensure AEAD tags can be re-computed and validated.
+
+## How to navigate the spec
+
+For normative requirements, start with:
+
+- `spec/README-full-spec.md` — the full spec text.
+
+This repository's code and tests should be read as an implementation of that specification.
+The spec defines how the envelope layout, encoding schemes, AEAD lane, and negotiation flows
+are expected to behave.
+
+## Reproducibility and determinism checklist
+
+When working in this repository, these expectations should always hold:
+
+- A given logical frame should encode to a stable, identical byte sequence in Rust and Go.
+- Fixtures should never change except when protocol rules change (and then only with
+  regenerated tags).
+- Any non-canonical encodings should be rejected by decoders.
+
+If you modify encoding rules or envelope layout, you must regenerate fixtures and ensure
+all tests still pass.

--- a/TritRPC-v1-full/docs/THEORY.md
+++ b/TritRPC-v1-full/docs/THEORY.md
@@ -1,0 +1,128 @@
+# TritRPC v1 Theory (Conceptual Model)
+
+This document captures the conceptual and mathematical ideas that underpin the TritRPC v1
+protocol. It is intentionally verbose so that the theory is available alongside the
+implementation details in this repository.
+
+## 1. Trits and base-3 representation
+
+TritRPC models some data using **trits**, the ternary analogue of bits. A trit has three
+possible values: `0`, `1`, or `2`. Representing data in base-3 can be useful for protocols
+or domains that want ternary-native encodings, compactness for ternary symbols, or explicit
+distinction of three-state logic.
+
+Trits are still carried over bytes. The protocol defines a canonical mapping so that binary
+transport remains deterministic and independent of platform endianness.
+
+## 2. TritPack243 (packed trits in bytes)
+
+The **TritPack243** scheme packs trits into bytes using base-3 arithmetic:
+
+- Five trits can be packed into a single byte because `3^5 = 243`, which fits in one byte.
+- A single packed byte therefore represents a 5-trit group as a base-3 integer in the range
+  `0..242`.
+- If the total number of trits is not a multiple of five, TritPack243 emits a **tail marker**
+  byte in the range `243..246` indicating how many trits follow (1–4), plus one extra byte
+  containing those trailing trits encoded as a base-3 integer.
+- Bytes in the range `247..255` are invalid in canonical output.
+
+This packing is deterministic and is used by other encoding layers in the protocol, such as
+TLEB3.
+
+## 3. TLEB3 (ternary length encoding)
+
+TLEB3 is the protocol's **length encoding** scheme. It encodes non-negative integers using
+base-9 digits, which are themselves carried as trits:
+
+- An integer `n` is written in base-9 as digits `d0, d1, ...` (least significant first).
+- Each digit is stored as a **tritlet**: `C, P1, P0`, where `P1:P0` (two trits) represent a
+  value `0..8`, and `C` is a continuation trit (`2` = more digits follow, `0` = final digit).
+- These trits are concatenated and then packed using TritPack243.
+
+The combination of base-9 digits and TritPack243 allows lengths to be encoded compactly and
+unambiguously over byte streams.
+
+## 4. Envelope model
+
+Every TritRPC frame is built as an **envelope** that separates routing metadata from the
+payload and integrity layer. The envelope has multiple logical regions:
+
+1. **SERVICE and METHOD identifiers** (routing keys)
+2. **AUX structures** (optional, used for traces, signatures, or Proof-of-Execution)
+3. **Payload** (user-defined or service-defined data)
+4. **AEAD lane** (authentication tag or full authenticated encryption)
+
+The reference implementation models these pieces explicitly and uses them to produce canonical
+fixture vectors.
+
+## 5. Path-A vs Path-B
+
+TritRPC v1 defines multiple profiles for payload encoding:
+
+- **Path-A**: Uses Avro Binary Encoding for payloads. This is the main path exercised in the
+  reference implementation and fixture vectors.
+- **Path-B**: Uses ternary-native encodings (e.g., TLEB3 lengths and balanced-ternary integers)
+  and is currently represented by a smaller “toy subset” of fixtures in `fixtures/`.
+
+Path-B remains compatible with the same envelope and AEAD structure; only the payload encoding
+changes.
+
+## 6. AEAD and integrity layer
+
+The protocol authenticates frames using an **AEAD lane**:
+
+- The preferred suite in the reference implementation is **XChaCha20-Poly1305**.
+- Some fixtures allow a deterministic MAC fallback when AEAD primitives are not available.
+- The AEAD tag is computed over the envelope's AAD (associated data) and the payload, using
+  a 24-byte nonce. This makes integrity checks deterministic and replay-resistant.
+
+A strict verification mode is used by fixtures and tooling to ensure tags remain correct if
+any portion of the envelope or payload changes.
+
+## 7. Streaming and rolling nonces
+
+For streaming sequences of frames, TritRPC uses **rolling nonces**:
+
+- A base nonce is derived or agreed upon.
+- Each subsequent frame increments or derives the next nonce in a deterministic way.
+- This keeps AEAD authentication safe across a stream while retaining deterministic test
+  fixtures.
+
+## 8. AUX structures
+
+AUX structures are optional fields that can be inserted into an envelope for additional
+metadata. The reference implementation includes:
+
+- **Trace**: tracing and correlation metadata
+- **Sig**: placeholder for signature material
+- **PoE (Proof-of-Execution)**: a strict-initial placeholder for execution proofs
+
+These are designed to be extensible so that additional metadata can be added without breaking
+existing envelope parsing.
+
+## 9. Hypergraph service model
+
+The repository ships a reference **hypergraph service** for example RPCs and fixture
+generation. Its payloads are encoded using Avro (Path-A) and are meant to be canonical and
+stable across Rust and Go implementations.
+
+Examples include vertex and hyperedge creation, with payload schemas that are encoded
+deterministically and verified in fixture tests.
+
+## 10. Determinism as a design goal
+
+A recurring theme in TritRPC is determinism:
+
+- **Canonical encodings** for trits, lengths, and payloads
+- **Stable fixture vectors** to ensure cross-language reproducibility
+- **Strict verification** that rejects any non-canonical or malformed encoding
+
+This determinism is what makes the repository's fixture verification and repack tests
+meaningful: every language implementation should produce identical bytes for the same
+semantic input.
+
+## Further reading
+
+- Full specification: `spec/README-full-spec.md`
+- Reference implementation: `reference/tritrpc_v1.py`
+- Fixtures: `fixtures/`


### PR DESCRIPTION
### Motivation
- Provide an in-repo, pedantic exposition of the protocol's conceptual model so the theory behind TritRPC v1 is available alongside the implementation. 
- Make repository structure, navigation, and determinism expectations explicit so implementers can reproduce canonical fixtures across languages. 
- Surface encoding primitives and envelope design (e.g. `TritPack243`, `TLEB3`, AEAD lane, Path-A/Path-B) in human-readable form to reduce ambiguity.

### Description
- Expanded `TritRPC-v1-full/README.md` with a theory-at-a-glance, repo layout, build/test snippets, and determinism/fixtures guidance. 
- Added `TritRPC-v1-full/docs/THEORY.md` documenting trits, `TritPack243`, `TLEB3`, envelope model, AEAD/nonce handling, AUX structures, and Path-A/Path-B differences. 
- Added `TritRPC-v1-full/docs/REPOSITORY_GUIDE.md` describing the repository layout, reference implementation usage, fixture generation, and a reproducibility checklist. 
- These are documentation-only changes and do not alter runtime code or tests.

### Testing
- No automated tests were run because this is a documentation-only change. 
- CI workflows are unchanged and continue to reference `cargo test` and `go test` for the language ports, but they were not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955bfdaeba4832385672ba52406b142)