### PR TITLE
Add MIT license and update README with description and topics

### DIFF
--- a/TritRPC-v1-full/LICENSE
+++ b/TritRPC-v1-full/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 TritRPC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/TritRPC-v1-full/README.md
+++ b/TritRPC-v1-full/README.md
@@ -1,5 +1,10 @@
 # TritRPC v1 (Repository)
 
+**Description:** TritRPC v1 is a deterministic, ternary-native RPC protocol with
+authenticated envelope framing, reference fixtures, and Rust/Go implementations.
+
+**Topics:** ternary, rpc, protocol, deterministic-encoding, fixtures, rust, go, avro, aead
+
 This repository contains reference material, fixtures, and two language ports (Rust and Go)
 for **TritRPC v1**, a protocol that blends ternary-native encodings with conventional
 byte-transport, along with authenticated envelope framing. The focus of this repo is


### PR DESCRIPTION
### Motivation

- Ensure the repository has a clear open-source license for downstream use and distribution.
- Provide a succinct repository description and topics metadata to improve discoverability and match the example image's style.
- Surface key repository themes (ternary, RPC, fixtures, Rust/Go) for users and tooling.

### Description

- Added a `TritRPC-v1-full/LICENSE` file containing the MIT License text.
- Updated `TritRPC-v1-full/README.md` to include a short `Description` and a `Topics` list covering `ternary`, `rpc`, `protocol`, `deterministic-encoding`, `fixtures`, `rust`, `go`, `avro`, and `aead`.
- Changes are documentation-only and do not modify implementation code or fixtures.

### Testing

- No automated tests were run because the changes are documentation-only.
- CI should be unaffected; existing tests remain unchanged and will run as usual on future code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e0d13d108323916e870f0959adee)