### PR TITLE
Convert trit-to-trust RTF sources to UTF-8 Markdown and add TritRPC docs

### DIFF
--- a/docs/trit-to-trust_sources/From Trits to Trust-.md
+++ b/docs/trit-to-trust_sources/From Trits to Trust-.md
@@ -1,0 +1,789 @@
+# From Trits to Trust-
+
+.SFNS-Regular;HelveticaNeue-Bold;.SFNS-RegularItalic;
+Helvetica;.SFNS-Semibold;LucidaGrande-Bold;
+TimesNewRomanPSMT;Courier;.AppleSystemUIFontMonospaced-Regular;
+AppleSymbols;HiraginoSans-W6;
+;;;;;
+;
+;;;;;
+;
+
+
+Below is a
+publication‑grade whitepaper
+ that consolidates and deepens everything we have designed so far—Airflow→AtomSpace orchestration; Kafka+Avro+JSON‑LD (SALAD) semantics; Open Data Catalog + CommonKnowledge (CK) repository integration; Ray for ML/AI; local‑first edge/fog with K8s/KubeEdge; and the ternary
+TritRPC
+ bridge (balanced‑ternary, TLEB3, TritPack243, Q3) you drafted. It is intentionally
+pedagogical
+: it explains
+why
+ and
+how
+, traces historical precedents, surfaces trade‑offs, and motivates why this matters globally for knowledge coordination and the quantum/classical AGI bridge.Where I cite the TritRPC spec details (TLEB3, TritPack243, envelope fields, etc.), I attribute to your uploaded spec.
+
+
+⸻
+
+
+From Trits to Trust:
+
+
+A Local‑First, Semantically‑Governed, Hybrid Quantum/Classical Platform for Global Neurosymbolic Intelligence
+
+
+Abstract.
+We present a practical, end‑to‑end architecture for building a
+global neurosymbolic reasoning platform
+ that remains privacy‑preserving and locally sovereign while scaling from single‑device cognition to planetary knowledge coordination. The control plane uses
+Apache Airflow
+ (with Apache Beam semantics for batch/stream unification), the symbolic core is
+OpenCog AtomSpace
+, the semantic canon is
+RDF(/OWL)
+* on
+Blazegraph/Neptune
+, and the data+model plane is
+Kafka + Avro + JSON‑LD (SALAD)
+ with a local mirror for edge IPC. ML/AI training and serving run on
+Ray
+. We formalize a ternary wire standard—
+TritRPC
+—that binds schemata (Avro) and meaning (JSON‑LD contexts) to a canonical, balanced‑ternary frame with deterministic byte packing (
+TritPack243
+) and base‑9 varints (
+TLEB3
+), with a direct
+Q3 (qutrit) bridge
+ for quantum links.    This paper motivates
+why
+ such a standard is needed now (history, trade‑offs, market reality),
+how
+ to implement it (spec fragments, worked examples, ops patterns), and
+what
+ it unlocks (privacy‑preserving, anti‑weaponization semantics; p‑adic extensions for hierarchical knowledge; bi‑directional quantum/classical interoperability).
+
+
+⸻
+
+
+1. Why this standard matters (history → now)
+
+
+1.1 A brief history of “how we share meaning”
+
+	•
+Mainframe
+→
+ Unix
+ gave us a process model and files;
+TCP/IP
+→
+ HTTP
+ gave us packets and documents;
+RDBMS
+→
+ SQL
+ gave us tables and declarative joins;
+XML
+→
+ REST/JSON
+ lowered interop friction but lost formal semantics.	•	The
+Semantic Web
+ proposed
+RDF/OWL
+ and
+linked data
+—machine‑interpretable meaning shared via URIs and vocabularies. In practice, adoption was uneven: many systems kept
+schema‑and‑shape
+ (Avro/JSON) but dropped
+meaning
+.	•
+Data engineering
+ industrialized streams (Kafka), schemas (Avro, Schema Registry), and reproducibility (Airflow, Beam, Terraform). But it still struggled to keep
+semantics
+ and
+security
+ aligned with
+scale
+.
+
+1.2 Why “Local‑first, semantics‑first”
+
+	•
+Local‑first
+: data and models should execute near their source (edge/fog), honor user sovereignty, and sync outward intentionally (KubeEdge, on‑device MQ).	•
+Semantics‑first
+: every message is more than bytes. It needs (1) an enforced
+shape
+ (Avro) and (2) a stable
+meaning
+ (JSON‑LD @context) so knowledge merges remain safe and reversible.
+
+1.3 Why a ternary bridge now?
+
+	•
+Balanced ternary
+ aligns naturally with signed arithmetic and
+qutrit
+ channels; it lets us define a
+single canonical trit stream
+ that packs deterministically to bytes (today) and maps 1:1 to qutrit symbols (tomorrow). That is
+TritRPC
+—a wire that holds
+schema, meaning,
+ and
+cryptographic accountability
+ across binary, ternary, and quantum links.
+
+
+⸻
+
+
+2. Design goals (what this solves)
+
+
+	1.
+Dual‑world consistency.
+One canonical trit stream, deterministic byte packing, and 1:1 qutrit mapping. Transport changes do not change meaning.
+	2.
+Schema + semantics bound at the envelope.
+Avro schema ID validates structure; JSON‑LD context ID locks the vocabulary/ontology, satisfying SALAD. This preserves
+identity + meaning
+ end‑to‑end.
+	3.
+Local‑first execution, global governance.
+On device, an IPC/MQ mirrors Kafka topics and Schema Registry; at the edge/core, Kafka/Avro persist the same contract; the semantic projection promotes into RDF*/OWL with provenance.
+	4.
+Neurosymbolic control loop.
+AtomSpace is the
+control plane
+ for plans, rules, and proofs; Ray executes data/ML planes; Blazegraph/Neptune holds curated facts; Airflow/Beam orchestrate batch/stream with one logic.
+	5.
+Privacy, trust, and anti‑weaponization semantics.
+We bind content‑addressed identities, local dictionaries (Solid‑like pods), capability tokens, and
+named‑graph contexts
+ to ensure that semantics remain
+node‑scoped
+ until promoted.
+
+
+⸻
+
+
+3. The end‑to‑end architecture (pedagogical view)
+
+
+3.1 Compute tiers
+
+	•
+Device (home/IoT, KubeEdge):
+ on‑device MQ (e.g., NATS/ZeroMQ) + Avro SerDes + JSON‑LD context cache mirroring Kafka topics; AtomSpace “working set” for immediate reasoning; FAISS for vector recall;
+Vault Agent
+ for keys.	•
+Fog/Region (K8s):
+ Kafka (Redpanda/Kafka), Schema Registry, Airflow, Ray, AtomSpace pods; gateway to Blazegraph; OpenTelemetry pipeline;
+Tekton/Argo
+ builds;
+Terraform
+ for infra as code.	•
+Core/Cloud:
+ Blazegraph/Neptune SPARQL, long‑lived Ray clusters, model registry, CK repository integration, enterprise policy enforcement.
+
+3.2 Data/control planes
+
+	•
+Data plane (Beam semantics across batch/stream):
+ unify micro‑batch and streaming with identical transforms; materialize per‑entity projections; produce Avro records to Kafka; perform DQ gates.	•
+Control plane (Airflow DAGs):
+ manage promotions Hypergraph→RDF*; backfills; policy windows; SLA/SLI; DAGs coordinate Ray jobs + AtomSpace updates.
+
+3.3 Knowledge planes
+
+	•
+Exploratory hypergraph (AtomSpace‑Staging):
+ ingested from events; links carry confidences and provenance; local contexts protect semantics.	•
+RDF Staging:
+* deterministic Atom→RDF* mapping;
+SHACL
+ constraints; scores, justifications, and human/agent gates.	•
+Curated OWL Graph:
+ immutable named graphs; SPARQL endpoint; public/partner‑safe facts.
+
+
+⸻
+
+
+4. Messaging & semantics: Kafka + Avro + JSON‑LD (SALAD)
+
+
+4.1 Contract pattern
+
+	•	Each topic has
+Avro schema
+ (shape) and a
+JSON‑LD @context
+ (meaning). The message envelope carries both IDs (hashes). This is mirrored locally for IPC so edge and core never drift conceptually.	•
+Why Avro (not Parquet/Proto)?
+ We need
+row‑oriented, schema‑validated
+ records with strong
+SerDes
+ in Kafka and a
+JSON‑LD alignment
+; Avro fits all three and integrates natively with Schema Registry.
+
+4.2 A canonical event (example)
+
+
+{  "event_id": "urn:ck:evt:9f…",  "ts_event": "2025-08-20T12:00:00Z",  "actor": "did:key:z6Mk…",  "payload": { "subject": "urn:ck:img:…", "labels": ["Cat"] },  "_meta": {    "avro_schema_id": "sha3-256:…",    "jsonld_context_id": "sha3-256:…",    "prov": { "wasGeneratedBy": "urn:flow:airflow:run:…" },    "sign": "ed25519:…"  }}
+
+
+Airflow and Beam use the same Avro schema; the JSON‑LD context yields stable URIs so promotion to RDF* is mechanical.
+
+4.3 Open Data Catalog + CK repository
+
+	•	Every dataset/model has a
+dataset card
+ (Avro metadata record + JSON‑LD context) checked into
+CommonKnowledge (CK)
+. The card maps to Kafka topic(s), retention policy, and SPARQL named graph(s), guaranteeing that a “data product” is self‑describing from sensor → SPARQL.
+
+
+⸻
+
+
+5. TritRPC: the canonical, ternary‑aware wire
+
+
+Goal:
+ the same message is valid on
+binary
+ links today,
+ternary
+ links tomorrow, and
+qutrit
+ links in quantum channels—
+without re‑schematizing
+.
+
+5.1 Envelope (logical trits)
+
+
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD]
+
+
+	•
+MAGIC
+: literal base‑3 digits for “TritRPC”.	•
+VER
+: 2 trits.	•
+MODE
+: B2 (byte‑packed), B3 (raw trits), Q3 (qutrit mapping).	•
+FLAGS
+: AEAD/compression bits.	•
+SCHEMA‑ID
+: SHA3‑256 of Avro canonical schema, rendered as trits.	•
+CONTEXT‑ID
+: SHA3‑256 of JSON‑LD @context, as trits.	•
+PAYLOAD
+: the message body.
+
+Why two IDs?
+ Avro enforces structure; JSON‑LD locks meaning. Both are required for safe knowledge merges.
+
+5.2 Tags and varints in base‑9 (field headers)
+
+	•
+Field tag
+ =
+field_number * 9 + wire_type
+, encoded as a base‑9 varint.	•	Wire types include unsigned varint (0),
+balanced‑ternary signed
+ (1),
+length‑delimited
+ (2), fixed‑27, fixed‑54, etc.  	•
+TLEB3
+ (ternary little‑endian base‑9 varint): tritlets
+[C][P1][P0]
+ with
+C=2
+ for “continue” and
+C=0
+ for “end”; digits are little‑endian base‑9.
+
+5.3 Balanced‑ternary integers (no ZigZag)
+Signed ints are represented in balanced ternary (−1,0,+1); map to transport digits by offset (+1):
+−1→0, 0→1, +1→2
+. Length prefix with TLEB3, then emit digits (endianness is spec‑locked).
+5.4 Canonical byte packing: TritPack243 (B2 mode)
+Pack
+5 trits
+ (0..242) into
+1 byte
+ (0..242). If tail has k
+∈
+{1..4} trits, emit a marker byte
+243+(k−1)
+ then one data byte for those k trits. Bytes 247..255 are invalid in canonical form. This makes byte mode deterministic and hashable/signable.
+5.5 Q3 (qutrit) bridge
+Map trit 0,1,2 to qutrit |0
+⟩
+,|1
+⟩
+,|2
+⟩
+. Keep the same frame; use ternary stabilizer or Reed–Solomon over
+GF(3^m)
+ at the link layer; gateways do
+Q3
+⇄
+ B3
+⇄
+ B2
+ without re‑interpretation.
+
+Pedagogical payoff:
+ With a single canonical trit stream, we avoid “semantic drift” when upgrading transports. You can sign once, route anywhere, and still have verifiable semantics at the other end.
+
+
+⸻
+
+
+6. Airflow→AtomSpace→Blazegraph: the promotion pipeline
+
+
+6.1 Three rings of truth
+
+
+	1.
+Exploratory Hypergraph (AtomSpace‑Staging).
+Ingested atoms/links carry confidences, provenance, and privacy tags.
+	2.
+RDF Staging.
+*Deterministic Atom→RDF* mapping (n‑ary links become reified resources or RDF* annotations),
+SHACL
+ constraints, quality scores, proofs/justifications.
+	3.
+Curated OWL Graph.
+Immutable named graphs, policy‑gated; exposed via SPARQL for enterprise interop.
+
+6.2 Airflow DAG (conceptual)
+
+	•
+Beam transforms
+ normalize/validate Avro records (same code path for stream/batch).	•	AtomSpace writes (insert/update) occur in
+Staging
+ context.	•
+Promotion task
+ materializes RDF* with provenance; SHACL gate fails closed; on success, named graph is versioned and published.	•
+Backfill = re‑run with deterministic inputs
+ (event‑sourced logs), preserving bitemporality (event_time vs ingest_time).
+
+
+⸻
+
+
+7. Local‑first privacy, anti‑weaponization semantics
+
+
+7.1 Namespaces and self‑describing pods
+Following the same spirit as Tim Berners‑Lee’s
+Solid
+ (personal data pods), each node maintains:
+	•	A
+private context
+ (local JSON‑LD dictionaries) with DID‑scoped URIs;	•
+Capability tokens
+ that control
+which
+ concepts/graphs can be exported;	•
+Context projection rules
+: local names map to shared ontologies
+only
+ at promotion time; otherwise, they remain private and unresolvable.This prevents global actors from hijacking meanings (“weaponizing definitions”). Local concepts are minted per node (DID‑namespaced), and only
+intended
+ alignments are published via promotion.
+
+7.2 Cryptographic provenance and revocation
+All frames are
+AEAD‑sealed
+, signed, and
+content‑addressed
+; named‑graph contexts carry PROV assertions so
+redaction
+ or
+rollback
+ is possible without semantic residue.
+
+
+⸻
+
+
+8. ML/AI with Ray (and why this helps symbols)
+
+	•
+Feature/embedding services
+ (FAISS/Milvus) are fed by Kafka (Avro) and registered in CK; retrieval returns candidates with provenance that can be asserted into AtomSpace as weighted links.	•
+Hopfield/Product‑Key memory + Graph Attention
+ form the “cross‑memory attention fabric”: choose, per query, among AtomSpace, vector store, SPARQL, or event log. It’s the
+deployable
+ analogue to “quantum entanglement”: coherent retrieval with measurable p50/p95 latencies and circuit‑breaker fallbacks.	•
+Ray DAG/Workflows
+ execute plans externalized from AtomSpace (procedures as code), returning outcomes to the hypergraph for learning.
+
+
+⸻
+
+
+9. P‑adic and balanced‑ternary: why number theory matters
+
+	•
+Balanced ternary
+ is the finite‑width reflection of
+3‑adic
+ intuition: nearby numbers share long common suffixes in base‑3, mirroring
+hierarchical refinement
+ in knowledge (concepts become “closer” as you add trailing agreement).	•	Extending encodings with
+p‑adic metrics
+ lets us (a) compress hierarchies, (b) build ultrametric indexes for fast clustering, and (c) perform
+graceful generalization
+ (drop least‑significant trits to move “up” an abstraction). TritRPC’s balanced‑ternary digits give us a clean substrate for these operations.
+
+
+⸻
+
+
+10. Security model (zero‑trust by construction)
+
+	•
+Capabilities
+: query tokens encode allowed contexts/predicates/TTL; SPARQL named‑graph ACLs; HQL capability nodes in AtomSpace.	•
+PII controls
+: field‑level AEAD, consent tags, differential privacy where needed; redaction transforms applied at promotion/export.	•
+Attestation
+: optional enclave execution for agents; signatures on promotions;
+event‑sourced
+ audit for replay and forensics.
+
+
+⸻
+
+
+11. Worked TritRPC fragments (educational)
+
+
+11.1 Field tags and base‑9 varints
+
+	•
+tag = field_number * 9 + wire_type
+	•	Encode with
+TLEB3
+ (ternary little‑endian base‑9 varint): tritlets
+[C][P1][P0]
+,
+C=2
+ continue,
+C=0
+ end.
+
+11.2 Balanced‑ternary long (example)
+
+	•
++,+,0
+ → transport digits
+2,2,1
+, length via TLEB3, then digits (endianness locked in spec).
+
+11.3 Canonical byte packing (TritPack243)
+
+	•	Pack 5 trits to one byte (0..242). For tails (k=1..4), emit marker 243..246 then a data byte for the k‑trit value; 247..255 invalid. Hash/sign these canonical bytes.
+
+11.4 Q3 link
+
+	•	Trits map to qutrit basis; link‑layer ECC defaults to ternary stabilizer or RS over GF(3^m). Gateways never reinterpret—just convert carriers.
+
+
+⸻
+
+
+12. Ops blueprint (what to run, where)
+
+
+12.1 Day‑1 platform
+
+	•
+Kubernetes
+ (core + edge via
+KubeEdge
+),
+Vault
+ (secrets),
+Terraform
+ (IaC),
+Tekton/Argo
+ (CI/CD),
+Kafka/Redpanda
+ +
+Schema Registry
+,
+Airflow
+,
+Ray
+,
+Blazegraph
+,
+Jena Fuseki
+ for dev SPARQL,
+OpenTelemetry
+.	•
+Local IPC
+: NATS/ZeroMQ mirror of Kafka topics; identical Avro + JSON‑LD IDs to keep semantics aligned.
+
+12.2 Airflow DAGs (governed ingestion → promotion)
+
+	•
+Beam transforms
+ for deterministic logic across stream/batch,
+Data Quality gates
+,
+AtomSpace staging writes
+,
+RDF promotion
+* with SHACL,
+CK dataset card
+ updates,
+SPARQL publish
+,
+Vault‑mediated keys
+.
+
+12.3 Topic hygiene
+
+	•	Names:
+domain.product.version.event
+	•	Keys: deterministic (entity ID or method name); partition by entity or hash; retention aligned with legal policy; DLQs with automatic redaction/quarantine.
+
+
+⸻
+
+
+13. Trade‑offs & precedent (why these choices)
+
+	•
+Binary won
+ historically for simplicity and economics—every tool in our stack is binary at its core. TritRPC accepts that: it gives you a
+canonical trit view
+
+and
+ a
+deterministic byte view
+, so you can sign once and move fluidly between worlds.    	•
+Avro over Parquet/Proto
+ for transport: row‑oriented, streaming‑friendly, Schema Registry integration, and harmonious with JSON‑LD (SALAD).	•
+Beam
+ (Google Dataflow model →
+Apache Beam
+): one set of semantics for batch/stream to avoid “two codepaths, two truths”.	•
+Solid‑style pods for local semantics
+: prevents central authorities from coercing meaning; promotion is explicit, auditable, and reversible.
+
+
+⸻
+
+
+14. What this unlocks (for people, enterprises, and science)
+
+
+	1.
+Human dignity and safety.
+Local semantics, private contexts, capability tokens, and verifiable promotions mean communities can
+own their meanings
+ and still interoperate—reducing semantic capture and abuse.
+	2.
+Planetary research fabric.
+Named‑graph provenance + event‑sourced logs enable
+reproducibility
+ across institutions; hybrid quantum/classical links let labs share
+the same
+ frames whether a message rode a fiber, a chip, or a qutrit channel.
+	3.
+Global AGI coordination (neurosymbolic).
+A cross‑memory attention fabric (vector + symbolic + semantic + log) with explicit costs, latencies, and circuit breakers; plans encoded as graphs; models invoked as services; truths curated with proofs.
+
+
+⸻
+
+
+15. Self‑critique & next refinements (honest gaps)
+
+	•
+Spec maturity.
+ TritRPC needs
+worked examples
+, a formal grammar/ABNF, and
+reference SerDes
+ (Rust/Go/Python), including
+Kafka serializers
+ and Avro logicalType plugins for
+balancedTernary
+ and
+trits
+. (Open items in your spec’s self‑critique are right on target.)  	•
+Performance.
+ SPARQL Update can bottleneck at promotion time; plan for batched
+CONSTRUCT/INSERT DATA
+ and materialized named graphs; use
+backpressure
+ and
+circuit breakers
+.	•
+Interoperability.
+ Keep TritRPC
+supplementary
+ to Avro/JSON‑LD (not a fork). The envelope binds schema+semantics; payload remains
+standard Avro
+.	•
+Security defaults.
+ Publish
+AEAD/signing test vectors
+; choose a
+default Q3 ECC
+ profile (ternary stabilizer or RS over GF(3^m)) so vendors interoperate reproducibly. Also finalize
+endianness
+ for balanced‑ternary digits and codify a
+ternary union tag
+ convention for Avro unions.
+
+
+⸻
+
+
+16. Concrete “ship‑now” checklist (30 days)
+
+
+Week 1 — Foundations
+
+	•	Kafka/Redpanda + Schema Registry;
+Avro envelope
+ with
+{schema_id, context_id}
+;
+Vault
+;
+OTel
+ tracing.	•	AtomSpace (RocksDB persistence) + Jena Fuseki dev SPARQL.
+
+Week 2 — Neuro‑symbolic & memory
+
+	•	ESN/HDC microservice; embeddings attached to Atoms; Hopfield recall API;
+SHACL
+ skeleton; manual promotion gate v0.
+
+Week 3 — Blazegraph + StorageNode
+
+	•	Blazegraph (RDF*); Atom→RDF* mapping for 3–5 Atom types (e.g.,
+EvaluationLink
+);
+Airflow DAG
+ for promotion; SPARQL named‑graph ACLs.
+
+Week 4 — Federation & hardening
+
+	•	Hypercore‑style Merkle log prototype (signed, content‑addressed diffs); foreign contexts import; backpressure & chaos tests; SLO dashboards; optional Neptune parity.
+
+(These milestones align with your earlier execution plan and keep TritRPC supplementary to Avro/JSON‑LD while we standardize packing/varints and Q3 ECC.)
+
+
+⸻
+
+
+Appendix A — TritRPC mini‑spec (excerpt)
+
+	•
+Envelope:
+
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD]
+ (logical trits). MODE
+∈
+{B2,B3,Q3}. AEAD signs canonical bytes.  	•
+Field tag:
+
+field_number*9 + wire_type
+ (base‑9 varint via
+TLEB3
+). Wire types: 0=varint‑u, 1=balanced‑ternary, 2=len, 3=fixed‑27, 4=fixed‑54, 5..8 reserved.  	•
+Balanced integers:
+ (−1,0,+1) digits mapped to (0,1,2) for transport; length via TLEB3; digits emitted in spec‑locked order.  	•
+Canonical bytes:
+
+TritPack243
+: 5 trits → 1 byte; tail markers 243..246; 247..255 invalid.  	•
+Q3 bridge:
+ 0/1/2 ↔ |0
+⟩
+/|1
+⟩
+/|2
+⟩
+; link ECC via GF(3^m) RS or ternary stabilizers; gateways do carrier conversion only.  	•
+Service method field:
+ first field length‑delimited method name or numeric ID (varint); Avro payload follows under the envelope.
+
+
+⸻
+
+
+Appendix B — What to measure (so it stays real)
+
+	•
+SLOs:
+ per‑tier latency (AtomSpace <5 ms; local cache <15 ms; SPARQL hot <50 ms; cold <250 ms), promotion SHACL fail rate, cache hit rate, cost/1k ops.	•
+Backpressure:
+ bounded queues; degrade gracefully from semantic → vector lookup; SPARQL circuit breakers.	•
+Reproducibility:
+ event‑sourced replay time; content‑hash verification; promotion rollback tests.
+
+
+⸻
+
+
+Final self‑assessment
+
+	•
+Strengths:
+ This unifies
+schema, semantics, and security
+ from edge to graph and gives a hard path to
+quantum interop
+ without re‑schematization. It keeps
+human governance
+ (promotion, SHACL, proofs) at the center and makes
+local meaning
+ first‑class to resist semantic hijack.	•
+Weak spots:
+ We still need (1)
+reference SerDes
+ and Kafka serializers, (2) a public
+test‑vector suite
+, (3) a first set of
+Atom
+→
+RDF
+* mappings with proofs and SHACL shapes, and (4) a chosen
+Q3 ECC
+ profile. Your spec’s to‑do list matches these exactly; I recommend we tackle them next in that order.  If you want, I can immediately draft: (a) the
+Atom
+↔
+RDF
+* mini‑schema for
+EvaluationLink
+ (with SHACL), (b)
+TritPack243/TLEB3
+ SerDes reference (Rust+Python), and (c) a
+Beam‑style
+ ingestion template +
+Airflow
+ promotion DAG seeded with Avro + JSON‑LD IDs—so this architecture is not only principled, but
+running
+.

--- a/docs/trit-to-trust_sources/From Trits to Trust.md
+++ b/docs/trit-to-trust_sources/From Trits to Trust.md
@@ -1,0 +1,1010 @@
+# From Trits to Trust
+
+.SFNS-Regular;HelveticaNeue-Bold;LucidaGrande-Bold;
+HiraginoSans-W6;Helvetica;.SFNS-Semibold;
+.SFNS-RegularItalic;.AppleSystemUIFontMonospaced-Regular;AppleSymbols;
+TimesNewRomanPSMT;
+;;;
+;;;
+
+
+Below is a
+publication‑grade, pedagogical whitepaper
+ that expands each concept into
+context
+→
+ mechanics
+→
+ consequence
+ so a reader can understand
+why
+,
+how
+, and
+what it enables
+. It consolidates our entire design—
+Airflow
+→
+ AtomSpace
+,
+Kafka + Avro + JSON‑LD (SALAD)
+,
+Apache Beam (Google Dataflow model)
+,
+Ray
+,
+RDF
+š
+/SPARQL/SHACL on Blazegraph/Neptune
+,
+Kubernetes/KubeEdge
+,
+Vault/Tekton/Argo/Terraform
+,
+OpenTelemetry/OpenLineage
+,
+Solid‑style semantic sovereignty
+,
+DCAT + CommonKnowledge (CK)
+,
+Merkle federation
+, and the
+TritRPC
+ ternary wire (balanced‑ternary, TLEB3 base‑9 varints, TritPack243 byte canonical, Q3/qutrit bridge). Where appropriate, each “one‑liner” is intentionally expanded into
+three sentences
+ (context, detail, conclusion) so it reads like a tutorial rather than a checklist.
+
+
+⸻
+
+
+From Trits to Trust
+
+
+A Local‑First, Semantically‑Governed, Hybrid Quantum/Classical Platform for Global Neurosymbolic Intelligence
+
+
+Abstract — three sentences.
+Modern AI systems need to coordinate knowledge across edge devices, enterprise clusters, and emerging quantum links without losing meaning, provenance, privacy, or performance. Our architecture unifies
+Kafka + Avro + JSON‑LD/SALAD
+ (for schema+semantics),
+Apache Beam
+ (for one dataflow semantics across batch/stream),
+Airflow
+ (for orchestration),
+OpenCog AtomSpace
+ (for symbolic reasoning),
+RDF
+š
+/SPARQL/SHACL
+ (for curated semantics), and
+Ray
+ (for ML training/serving) on
+Kubernetes/KubeEdge
+. We add
+TritRPC
+, a ternary‑aware, canonical wire that binds schema and meaning into a single frame that can traverse binary, ternary, and
+qutrit (Q3)
+ rails without re‑schematization, enabling
+privacy‑preserving
+,
+pedagogically transparent
+, and
+future‑proof
+ global AGI coordination.
+
+
+⸻
+
+
+1) Why this standard matters (history → need → consequence)
+
+
+Historical context — three sentences.
+For fifty years, computing standardized
+transport
+ (TCP/IP),
+structure
+ (SQL/relational; later Avro/JSON), and
+interfaces
+ (HTTP/REST), but never truly standardized
+meaning
+ at operational scale. The Semantic Web (RDF/OWL) offered a universal meaning layer, yet industry largely adopted partial measures (loose JSON, ad‑hoc labels), creating data swamps and governance gaps. Our proposal reconciles practice and theory by
+binding structure and meaning in every message
+ and
+curating meaning in graphs
+, so data pipelines and knowledge graphs finally speak the same language.
+Current need — three sentences.
+Edge computing and privacy regulation demand
+local‑first
+ processing where semantics and security travel with the data, not after it. AI pipelines need
+one programming model
+ for streaming, micro‑batch, and batch so results remain consistent regardless of time scale. Knowledge systems must integrate
+symbolic reasoning
+ (logic, plans, proofs) with
+statistical learning
+ (embeddings, retrieval), while maintaining
+lineage, audit, and user sovereignty
+.
+Consequence — three sentences.
+By standardizing the
+message envelope
+ (schema+context+signature) and the
+promotion pipeline
+ (hypergraph → RDF★ → OWL with SHACL), we make correctness, reproducibility, and governance routine. By adopting a
+ternary‑aware wire (TritRPC)
+ that has canonical bytes
+and
+ canonical trits, we make quantum/classical interop a transport choice, not a re‑platforming. The result is a platform that can
+start on a phone
+,
+scale to a cluster
+, and
+bridge to quantum links
+, all while preserving meaning and rights.
+
+
+⸻
+
+
+2) Architectural overview (device → cluster → federation)
+
+
+Device/edge tier (KubeEdge) — three sentences.
+At the edge, we mirror Kafka topics using a local IPC/MQ (e.g., NATS/ZeroMQ) so
+the same Avro schemas and JSON‑LD contexts
+ apply on‑device, offline, or intermittently connected. The device runs a small
+AtomSpace
+ for immediate symbolic reasoning and a lightweight vector index for local retrieval; keys and policies are enforced via
+Vault Agent
+ and capabilities. When connectivity appears, the device
+syncs canonical frames
+ (identical semantics) with the cluster, ensuring replayable, auditable ingestion.
+Cluster/core tier (Kubernetes) — three sentences.
+In the cluster,
+Kafka/Redpanda
+ and
+Schema Registry
+ anchor event‑sourced pipelines;
+Apache Beam
+ provides one dataflow semantics across stream/batch;
+Airflow
+ orchestrates DAGs for ingestion, AtomSpace updates, promotion to RDF★, ML training in
+Ray
+, and catalog publishing.
+Blazegraph/Neptune
+ serve curated graphs with
+SPARQL
+ and
+SHACL
+ validation;
+OpenTelemetry/OpenLineage
+ instrument everything.
+Vault/Tekton/Argo/Terraform
+ cover secrets, CI/CD, and infrastructure as code, enabling repeatable deployments and rapid evolution.
+Federation/quantum — three sentences.
+Peers exchange signed
+Merkle knowledge feeds
+ or federate queries via
+SPARQL SERVICE
+ with named‑graph access control, so knowledge can flow without sacrificing provenance or consent.
+TritRPC
+ enables the same envelope to ride
+binary
+,
+raw ternary
+, or
+qutrit
+ rails, with a default ternary ECC profile so vendors interoperate out‑of‑the‑box. The federation is
+context‑scoped
+ and
+capability‑bound
+, so meaning cannot be hijacked and private vocabularies stay private unless intentionally mapped.
+
+
+⸻
+
+
+3) Framework explainers — each with context → mechanics → why it matters
+
+
+3.1 Apache Kafka / Redpanda (event backbone)
+
+	•
+Context.
+ Kafka (or Redpanda) is the durable, partitioned log where
+every fact is an event
+ and
+every event is re‑playable
+. It gives us
+ordering per key
+, backpressure via consumer lag, and exactly‑once sinks for deterministic pipelines. Using it as the backbone means our system’s truth is
+append‑only, time‑stamped, and auditable
+.	•
+Mechanics.
+ Producers write Avro‑encoded messages with a
+schema ID
+ and a
+context ID
+; brokers persist them; consumers read, transform, and write results to new topics. We configure compaction where keys are “state” and retention where streams are “history”, and we isolate PII in dedicated topics with field‑level AEAD. Because topics are
+typed and versioned
+, we can replay any window to rebuild downstream state or bootstrap new services.	•
+Why it matters.
+ Kafka makes
+reproducibility and forensics
+ a feature, not a chore; you can re‑run yesterday with today’s code and compare outcomes. Its partitioned design aligns naturally with
+entity‑centric
+ knowledge (keys as entities), enabling locality and scale. With identical schemas and contexts at the edge (local MQ), meaning and behavior remain
+consistent
+ across tiers.
+
+
+⸻
+
+
+3.2 Avro + Schema Registry + JSON‑LD (SALAD) (the semantics chain)
+
+	•
+Context.
+ Avro gives us a canonical, compact way to describe
+structure
+ (fields, types, defaults), while JSON‑LD gives us a canonical way to describe
+meaning
+ (terms, IRIs, vocabularies). Schema SALAD links these worlds by formalizing how JSON‑LD contexts are bound to typed records. Together they ensure
+machines validate shape
+ and
+deduce semantics
+ without guessing.	•
+Mechanics.
+ Each message carries
+SCHEMA_ID=SHA3(schema_canonical)
+ and
+CONTEXT_ID=SHA3(jsonld_context)
+, so downstream can fetch or trust pinned definitions. Producers never invent labels at runtime; they reference a
+versioned @context
+ that maps human‑friendly keys to stable IRIs. Promotion to RDF★ is mechanical because every field is already semantically grounded by its JSON‑LD term.	•
+Why it matters.
+ This eliminates
+semantic drift
+ where two teams use “account_id” to mean different things, and it stops
+label injection
+ attacks because labels are not semantics. It enables
+deterministic promotion
+ into graphs, because the same payload always maps to the same triples/annotations. It also makes
+migration safe
+: you change a context/version intentionally, not accidentally.
+
+
+⸻
+
+
+3.3 TritRPC (canonical ternary wire: balanced‑ternary + TLEB3 + TritPack243 + Q3)
+
+	•
+Context.
+ Binary dominated because of hardware, but
+ternary mathematics
+ (balanced ternary, 3‑adic) is more natural for signed values and maps cleanly to
+qutrit
+ channels. TritRPC defines a single logical trit stream that has
+deterministic bytes (B2)
+ today and
+direct qutrit mapping (Q3)
+ tomorrow. The envelope pins
+both schema and meaning
+ inside the same canonical, signable frame.	•
+Mechanics.
+ The frame is
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD]
+ where MODE
+∈
+{B2,B3,Q3}. Field tags use
+base‑9
+ varints (
+TLEB3
+), signed integers use
+balanced‑ternary digits
+ (−1,0,+1 mapped to 0,1,2), and
+TritPack243
+ packs
+5 trits
+→
+ 1 byte
+ with stable tail markers so hashes and signatures are reproducible. Q3 mode maps trits to |0
+⟩
+,|1
+⟩
+,|2
+⟩
+ with a standard
+ternary ECC
+ (e.g., GF(3^m) Reed–Solomon or ternary stabilizers) so two vendors’ quantum links can interoperate.	•
+Why it matters.
+ One envelope works across
+on‑device IPC
+,
+Kafka
+, and
+quantum rails
+ without re‑schematizing or re‑signing, which means governance and audit survive transport shifts. Balanced‑ternary makes signed arithmetic
+compact and symmetric
+, and base‑9 tags keep parsers
+branch‑explicit
+. When quantum links mature, we flip
+MODE=B2
+→
+Q3
+, not the platform.
+
+
+⸻
+
+
+3.4 Apache Beam (Google Dataflow model) (one semantics for batch/stream)
+
+	•
+Context.
+ Historically teams built separate code paths for streaming and batch, and then fought “two different truths.” Google’s Dataflow model, now
+Apache Beam
+, unifies the semantics: windows, watermarks, triggers, and stateful transforms behave the same regardless of runner or timing. This makes data logic portable, testable, and explainable.	•
+Mechanics.
+ We write Beam pipelines once, and run them on Flink/Spark/Dataflow runners; the same code handles late data, session windows, and exactly‑once sinks.
+Avro decoders
+ and
+JSON‑LD validators
+ sit at the edges;
+promotion transforms
+ create RDF★ patches; and
+quality gates
+ become reusable steps. Pipelines emit both
+events
+ (Kafka) and
+materialized views
+ (for fast graph writes), so downstream systems see consistent state.	•
+Why it matters.
+ Beam eliminates divergence between real‑time and batch, so
+debugging, governance, and audit
+ get dramatically simpler. Its portability means we can scale without vendor lock‑in, and we can simulate live behavior offline. For pedagogy, Beam’s model lets us explain
+exactly when and why
+ a record appears, which is essential for correctness proofs.
+
+
+⸻
+
+
+3.5 Apache Airflow (orchestration of data, graphs, and ML)
+
+	•
+Context.
+ Airflow turns workflows into DAGs that are
+code‑reviewed, versioned, and observable
+, rather than screenshots or tribal knowledge. It excels at
+dependency management
+, retries, SLAs, callbacks, and event‑driven triggering (Datasets/Sensors). In our platform, Airflow coordinates
+ingestion
+→
+ AtomSpace updates
+→
+ RDF
+š
+ promotion
+→
+ SHACL gates
+→
+ catalog publish
+→
+ ML training/serving
+.	•
+Mechanics.
+ Operators call Beam jobs, AtomSpace APIs, SPARQL Update endpoints, Ray clusters, and the catalog.
+Pools
+ limit concurrent calls to sensitive systems;
+task groups
+ keep DAGs readable;
+OpenLineage
+ emits run‑level lineage; and
+OpenTelemetry
+ ties logs and spans to message IDs. Backfills are deterministic because the source of truth is Kafka’s
+event log
+, not last Tuesday’s CSV.	•
+Why it matters.
+ Airflow makes pipelines
+auditable and reproducible
+, which is the bedrock for compliance and trust. It also stitches symbolic and statistical layers naturally, so “produce features, promote facts, and serve models” looks like
+one orchestrated story
+. This pedagogy turns governance from paperwork into
+executable code
+.
+
+
+⸻
+
+
+3.6 OpenCog AtomSpace (symbolic hypergraph core)
+
+	•
+Context.
+ AtomSpace is a
+generalized hypergraph
+ for symbolic AI—nodes, links, n‑ary relations, pattern matching, and graph rewriting are first‑class. It is optimized for
+in‑memory reasoning
+ with pluggable persistence; it thrives at plans, rules, and proofs. We use it as the
+control plane
+ for agents and as the staging ground for new knowledge.	•
+Mechanics.
+ Edge devices keep a small AtomSpace (RocksDB overflow); clusters use CogServer/Postgres or remote proxies; promotion extracts subgraphs into
+RDF
+š
+ with provenance. Procedure nodes invoke
+Ray
+ jobs or Beam transforms; results return as weighted links with timestamps and truth values. Caches and proxies ensure pattern matching remains fast even when the authoritative store is remote.	•
+Why it matters.
+ Symbolic reasoning explains
+why
+ a conclusion follows, not just
+what
+ the score is, which helps debugging, safety, and pedagogy. AtomSpace’s expressivity captures
+n‑ary
+ relations naturally (no awkward triple explosion), easing the mapping to HyperKnowledge and RDF★. As the control plane, it lets agents
+plan, act, and learn
+ in a loop we can inspect.
+
+
+⸻
+
+
+3.7 RDF★ / SPARQL / SHACL on Blazegraph/Neptune (curated semantics)
+
+	•
+Context.
+ RDF★ extends RDF with annotations on triples; SPARQL provides the query/update language;
+SHACL
+ enforces graph constraints. Blazegraph (and Neptune) serve these at scale with named graphs, access control, and federation. This is the
+canonical place
+ for interop with the broader semantic web.	•
+Mechanics.
+ Promotion from AtomSpace creates RDF★ structures for n‑ary links (reified relation nodes with role properties or annotated triples).
+SHACL shapes
+ validate domain rules, and violations halt promotion with precise errors. Named graphs partition data by context/source/provenance, and
+SPARQL SERVICE
+ federates across peers.	•
+Why it matters.
+ The curated graph is
+the public truth
+: queryable, consistent, explorable, and integrable with partners and regulators. SHACL and named graphs make governance
+explicit and enforceable
+, not implied. Because contexts are versioned and signed,
+semantics cannot be silently swapped
+ underfoot.
+
+
+⸻
+
+
+3.8 HyperKnowledge (bridge for n‑ary relations and contexts)
+
+	•
+Context.
+ HyperKnowledge models relations with
+connectors and roles
+, supports edges‑to‑edges, and organizes knowledge into
+contexts
+—a natural match to AtomSpace. It explains how to map rich hypergraphs to semantic graphs without flattening meaning. We use its patterns to structure RDF★ promotion and context management.	•
+Mechanics.
+ N‑ary AtomSpace links become nodes with role‑properties; contexts become named graphs; higher‑order links become identified resources so they can be subjects and objects. Role constraints and type systems map to OWL/SHACL shapes. Cross‑context mapping is done with
+signed crosswalks
+ (SKOS/OWL links), not global rewrites.	•
+Why it matters.
+ This preserves
+expressivity
+ while gaining
+interoperability
+, so “what we meant” survives the translation. It also keeps
+perspective and provenance
+ explicit via contexts, which is essential for multi‑agent reasoning. Pedagogically, HyperKnowledge makes the n‑ary story easy to teach: “a relation is an object with typed roles.”
+
+
+⸻
+
+
+3.9 Ray (distributed ML training and serving)
+
+	•
+Context.
+ Ray is a distributed execution framework that keeps ML pipelines
+simple to scale
+ and
+easy to serve
+. It integrates with Python ecosystems, supports stateful actors, and provides
+Ray Serve
+ for microservice‑style inference. We use it wherever learning happens: embeddings, Hopfield recall, product‑key memory, graph attention, and model serving.	•
+Mechanics.
+ Training jobs read curated RDF★ views and event windows; they produce
+artifacts
+ (models, indices) registered in CK with content hashes and SLOs. Inference services expose
+TritRPC
+ endpoints so every prediction is
+schema‑ and context‑pinned
+ with provenance. Ray DAGs are triggered by Airflow, returning results that AtomSpace can treat as weighted links.	•
+Why it matters.
+ ML stops being a black box when artifacts, inputs, and outputs are
+typed, versioned, and signed
+. Ray lets us run
+the same code
+ on a laptop or a cluster, and Serve gives low‑latency, horizontally scalable inference. The neurosymbolic loop becomes tangible: learn, assert, explain, and improve.
+
+
+⸻
+
+
+3.10 Vector stores (FAISS/Milvus) + modern Hopfield / product‑key memory / graph attention
+
+	•
+Context.
+ Symbolic systems need fast approximate recall of similar items; vector stores excel at this, but need governance and provenance. Hopfield networks (modern continuous variants) provide
+associative memory
+, and product‑key memory scales soft lookups; graph attention layers provide
+coherent reasoning
+ on symbolic structure. Combined, they form a
+cross‑memory attention fabric
+.	•
+Mechanics.
+ Beam populates vectors from curated data; Ray builds indices; AtomSpace holds links from concepts to embedding IDs with timestamps and confidence. A router consults vector store, AtomSpace, SPARQL, and even the event log based on
+cost/latency budget
+ and
+SLA envelopes
+; graph attention reconciles the candidates into consistent subgraphs. Circuit breakers degrade gracefully to vector lookup when graphs are slow, then re‑enrich later.	•
+Why it matters.
+ This gives the “
+quantum‑like entanglement
+” feel—global, fast association—using
+deployable, measurable primitives
+. It makes retrieval
+explainable
+ because candidates, costs, and choices are logged per hop. It also teaches teams to think in
+tiers of memory
+, not “one model fits all.”
+
+
+⸻
+
+
+3.11 Kubernetes + KubeEdge (orchestration across cloud and home/fog)
+
+	•
+Context.
+ Kubernetes schedules containers, enforces limits, and gives you
+declarative control
+ over infrastructure; KubeEdge extends this to devices and fog. Running at both ends means
+policy, secrets, and updates
+ look the same everywhere. This reduces cognitive load and class differences between edge and core.	•
+Mechanics.
+ Core cluster runs Kafka/Beam/Airflow/Ray/Blazegraph; edge nodes run minimal subsets with local IPC and AtomSpace. Manifests in Git (via Argo/Tekton) describe desired states;
+Vault
+ distributes secrets;
+Terraform
+ builds the substrate. Health, metrics, and traces propagate via
+OpenTelemetry
+, even from edge pods.	•
+Why it matters.
+ You operate one platform, not two, which means fewer foot‑guns and faster iteration. You can
+enforce privacy at the edge
+ (data never leaves) while still reusing schemas and contexts. It also makes
+disaster recovery
+ scripting natural: redeploy the same manifests in another region.
+
+
+⸻
+
+
+3.12 Vault (secrets), Tekton/Argo (CI/CD), Terraform (IaC)
+
+	•
+Context.
+ Secrets, builds, and infrastructure must be
+automated, auditable, and reversible
+ to be safe. Vault centralizes secrets with rotation and dynamic creds; Tekton/Argo automate builds/tests/promotions; Terraform codifies the substrate. These tools shrink the “unknown unknowns” radius.	•
+Mechanics.
+ Airflow and Ray pull short‑lived credentials from Vault; TritRPC signing keys live in HSMs or Vault; CI pipelines run linting, tests, Beam/Airflow DAG sanity checks, and SHACL validation on sample graphs. Terraform describes clusters, networks, storage, and ensures drift detection. Everything is policy‑guarded and emits OTel spans and logs.	•
+Why it matters.
+ Security and reliability aren’t “after the fact”—they are
+first‑class code
+. Rebuilds and rollbacks become routine, not heroic. For pedagogy, these tools make compliance explainable: “the code you see is the system you run.”
+
+
+⸻
+
+
+3.13 OpenTelemetry + OpenLineage (observability + lineage)
+
+	•
+Context.
+ Without traces and lineage, complex AI/ETL systems become opaque and ungovernable. OpenTelemetry standardizes traces/metrics/logs; OpenLineage links jobs, datasets, and runs. Together they let us debug logic and
+prove
+ where a fact came from.	•
+Mechanics.
+ Every Kafka message carries correlation IDs; Beam emits spans as records traverse windows; Airflow tasks emit lineage for inputs/outputs; SPARQL updates are logged with named graph and SHACL result; TritRPC signing and hashes are captured. Dashboards show SLOs (latency percentiles, promotion fail rates), with drill‑downs per entity/run.	•
+Why it matters.
+ Observability makes optimization scientific, not superstitious, and lineage makes compliance
+answerable
+ in minutes, not weeks. It also makes pedagogy action‑oriented: engineers learn from traces, not theories. This is how we keep a global system
+safe under change
+.
+
+
+⸻
+
+
+3.14 Solid‑style semantics (pods, capabilities, anti‑weaponization)
+
+	•
+Context.
+ Tim Berners‑Lee’s
+Solid
+ promotes user‑controlled pods and access rules for data, preserving autonomy. We adopt the spirit for
+semantics
+: each node can host its own JSON‑LD contexts and lexicons, signed and versioned. Global vocabularies are
+referenced and cross‑walked
+, not forced.	•
+Mechanics.
+ Messages carry
+CONTEXT_ID
+ and a context URI; promotion policies accept contexts from allow‑listed issuers (DIDs/WebIDs). Crosswalks (SKOS/OWL) live as first‑class datasets in CK, signed and versioned; promotion can only use trusted crosswalks. UI strings live in separate
+LEXICON_ID
+ so
+presentation ≠ meaning
+.	•
+Why it matters.
+ No one can hijack a community’s words by redefining terms centrally. Interop becomes
+consensual and explicit
+, not accidental, and revocation is possible. This preserves diversity while enabling federation—vital for a
+humane
+ knowledge web.
+
+
+⸻
+
+
+3.15 DCAT/Open Data Catalog + CommonKnowledge (CK) (asset lifecycle)
+
+	•
+Context.
+ A working platform needs a
+catalog
+ for schemas, contexts, datasets, models, and policies.
+DCAT
+ standardizes dataset metadata; CK is our repository layout and governance rules. A dataset becomes a
+contract
+ not just a directory of files.	•
+Mechanics.
+ CK stores:
+/schemas
+ (Avro canonical),
+/contexts
+ (JSON‑LD),
+/beam
+ (transforms),
+/airflow
+ (DAGs),
+/atomspace
+ (link/type specs),
+/rdf
+ (ontologies/SHACL),
+/ray
+ (training/serve),
+/tritrpc
+ (SerDes + test vectors),
+/k8s
+ (manifests),
+/terraform
+ (IaC),
+/policies
+ (PII/retention). DCAT entries point to Kafka topics, named graphs, and SLOs, with lineage hooks.	•
+Why it matters.
+ CK makes
+everything visible and reviewable
+, which accelerates onboarding and reduces mistakes. DCAT bridges dev and compliance by explaining artifacts in a shared language. Pedagogically, CK is where newcomers learn
+how the system fits together
+.
+
+
+⸻
+
+
+3.16 Merkle logs + SPARQL federation (knowledge exchange)
+
+	•
+Context.
+ Knowledge must cross organizational boundaries without losing provenance or control. Merkle logs give
+tamper‑evident
+, append‑only streams of deltas;
+SPARQL SERVICE
+ enables federated queries across named graphs. Both are selective and revocable by design.	•
+Mechanics.
+ Each node appends signed deltas (CONSTRUCT patches or Atom diffs) to its feed; peers replicate with allow‑lists and capability tokens; imports land in
+Foreign
+ contexts until promoted. Federation composes remote graphs with local ones and respects named‑graph ACLs. Everything is signed and content‑addressed, so “who said what, when” always has a proof.	•
+Why it matters.
+ This enables
+collaborative intelligence
+ without surrendering control or privacy. It also supports
+offline‑first
+ operation—agents can sync later and reconcile with proofs. Pedagogically, it clarifies the difference between
+seeing
+ someone’s truth and
+adopting
+ it.
+
+
+⸻
+
+
+4) Dataflow storyline (step‑by‑step, each step in three sentences)
+
+
+	1.
+Ingest.
+ A device captures an event and encodes it via Avro with a pinned JSON‑LD context; the
+TritRPC
+ envelope binds both into canonical bytes. It posts to local IPC, which mirrors the Kafka topic shape; when online, the same frame is forwarded to Kafka unchanged. The event is now
+replayable, verifiable, and semantically grounded
+.
+	2.
+Transform.
+ Beam reads from Kafka, validates Avro/JSON‑LD, applies windowed transforms, and writes normalized events to a staging topic and materialized views. The same code runs streaming and batch, so QA and prod share logic. Everything emits OTel spans so we can
+retrace the data’s path
+.
+	3.
+Symbolic staging.
+ An Airflow task writes new assertions into
+AtomSpace
+ (Staging context) with provenance and truth values. Lightweight reasoning and retrieval enrich the subgraph; suspicious facts remain low‑confidence. Nothing is “public truth” yet; it’s
+exploratory
+.
+	4.
+Promotion.
+ A promotion task maps candidates to RDF★, validates with
+SHACL
+, and either publishes to a named graph or sends the run to a dead‑letter review with a structured diagnostic. On success, the curated graph updates and a DCAT entry is version‑bumped in CK. This step is
+reversible
+, and it leaves a complete audit trail.
+	5.
+ML loop.
+ Ray consumes curated views, trains/updates models, and exposes a
+TritRPC
+ inference API with schema/context IDs and cryptographic proofs. Inference outputs are attached to AtomSpace as weighted links, closing the loop between signals and symbols. Airflow governs schedules, resources, and SLAs.
+	6.
+Federation.
+ Named graphs replicate via Merkle feeds or are queried directly via SPARQL SERVICE; imports land in
+Foreign
+ contexts until a promotion gate approves them. Crosswalks translate foreign terms to local ones safely. The system scales from
+one node to many
+ without sacrificing autonomy or provability.
+
+
+⸻
+
+
+5) Quantum and p‑adic bridge (why theory helps practice)
+
+	•
+Balanced‑ternary
+→
+ qutrits — three sentences.
+ Balanced‑ternary digits (−1, 0, +1) map naturally to three‑level quantum states |0
+⟩
+,|1
+⟩
+,|2
+⟩
+, which makes
+MODE=Q3
+ a literal re‑encoding of the same logical trits. Because the envelope is
+transport‑agnostic
+, we do not rebuild schemas or contexts when swapping rails; we only change link‑layer ECC. This preserves
+auditability and signatures
+, giving continuity as quantum links mature.	•
+p‑adic intuition — three sentences.
+ 3‑adic norms define distance by
+suffix agreement
+ in base‑3, which mirrors how concepts refine—longer matching suffixes mean
+closer meaning
+. Encoding identifiers or hierarchical codes in ternary enables ultrametric indexing, fast cluster searches, and graceful generalization (drop least‑significant trits to abstract). This ties number theory to
+practical retrieval, compression, and error localization
+ in neurosymbolic memory.
+
+
+⸻
+
+
+6) Security, privacy, and anti‑weaponization (each principle in three sentences)
+
+	•
+Capability‑scoped semantics.
+ Tokens specify which contexts, predicates, and TTLs a caller may touch, so authority is
+least‑privilege and auditable
+. Named‑graph ACLs in SPARQL and capability nodes in AtomSpace prevent unauthorized inference or promotion. Foreign contexts are read‑only until promotion, making
+seeing ≠ adopting
+ by default.	•
+PII and consent.
+ Field‑level AEAD encrypts sensitive attributes even inside frames, and consent tags travel with data to bound use. Redaction transforms run before any export; promotion pipelines refuse mixed‑consent graphs. Privacy becomes code, not policy prose.	•
+Attestation and signing.
+ Agents can run in enclaves with remote attestation; all frames and promotions are signed and content‑addressed. Event sourcing makes forensics exact: you can prove
+what happened, when, and why
+. Trust becomes
+measurable
+, not assumed.
+
+
+⸻
+
+
+7) Trade‑offs we accept (and why)
+
+	•
+Binary vs. ternary.
+ We keep
+binary
+ today for compatibility but define a
+canonical trit view
+ so future ternary/qutrit rails are easy; this avoids “big bang” rewrites. The cost is a small overhead for canonical packing (
+TritPack243
+) and base‑9 parsing (
+TLEB3
+). The gain is transport‑independent semantics and long‑term agility.	•
+RDF
+š
+/SPARQL vs. property graphs.
+ RDF★ gives annotations and global interop; property graphs give algorithm convenience. We store curated truth in RDF★ and, where needed, read into property‑graph views for algorithms. The cost is a mapping layer; the gain is
+governed interoperability
+.	•
+Symbolic + statistical.
+ Symbolic layers can be slower; statistical layers can be opaque. We combine them with a
+cross‑memory attention fabric
+ and enforce SLAs/circuit breakers so UX remains responsive. The gain is
+explainability with speed
+.
+
+
+⸻
+
+
+8) What this means for people, enterprises, and science (three sentences each)
+
+	•
+People.
+ Your device becomes a
+first‑class citizen
+ in a global network without surrendering your meanings or data. You can collaborate across communities with proofs and revocation, not trust and luck. Technology bends to human autonomy, not the reverse.	•
+Enterprises.
+ You can adopt a
+single semantics chain
+ from sensor to SPARQL, prove lineage, and test promotion gates in CI. You can orchestrate AI at scale while meeting compliance and cost SLOs. Modernization becomes
+incremental and reversible
+.	•
+Science.
+ Labs can exchange
+curated, signed graphs
+ and replay analyses deterministically across institutions. Quantum and classical links carry the
+same canonical frames
+, accelerating interdisciplinary collaboration. Reproducibility stops being a slogan and becomes a property of the system.
+
+
+⸻
+
+
+9) Operations and SLOs (each line, three sentences)
+
+	•
+SLO envelopes.
+ Define p50/p95 budgets per hop (AtomSpace hot<5ms; Rocks fetch<15ms; SPARQL hot<50ms; cold<250ms). Instrument every path with OTel and watch budget burn‑down per run. Treat SLO breaches as
+first‑class incidents
+, not “best effort.”	•
+Backpressure and resilience.
+ Use bounded queues, adaptive sampling, and circuit breakers around SPARQL and remote CogServers. Under stress, degrade to vector‑only recall and re‑enrich when load subsides. Periodically snapshot AtomSpace and curated RDF★ for
+time‑travel and disaster recovery
+.	•
+Spec hardening.
+ Publish
+ABNF grammar
+, endianness MUSTs,
+union discriminant
+ rules, and
+AEAD/signing test vectors
+. Ship reference SerDes (Rust/Go/Python) and
+Kafka serializers
+ with
+ten canonical test frames
+. Choose a default
+Q3 ECC profile
+ (ternary stabilizer or RS over GF(3^m)) so multi‑vendor interop is real from day one.
+
+
+⸻
+
+
+10) Self‑critique and immediate refinements (candid)
+
+	•
+What’s strong.
+ The architecture draws clean lines between
+exploration and curation
+, makes semantics
+transport‑independent
+, and turns governance into
+executable code
+. It is
+deployable today
+ with mainstream tools and
+upgradable tomorrow
+ to ternary/qutrit rails. The pedagogy—context → mechanics → consequence—helps new teams learn it correctly.	•
+What’s missing.
+ We still owe the community
+reference implementations
+ (TritPack243/TLEB3 SerDes + AEAD/signing) and a
+starter pack of Atom
+→
+RDF
+š
+ mappings
+ with SHACL shapes and proofs. We also need to publish
+Q3 ECC defaults
+ and a “
+why promotion failed
+” diagnostics library so ops can act fast.	•
+What to do next.
+ In this order: (1) publish
+ten TritRPC test vectors
+ and Rust/Python SerDes with Kafka serializers; (2) ship the
+Airflow + Beam + AtomSpace + RDF
+š
+ starter repo wired to CK/DCAT; (3) finalize
+Q3 ECC
+ and a gateway reference; (4) add
+Solid‑style
+ context hosting and crosswalk signing to CK. Those four moves make the system
+undeniably real
+ for users, regulators, and partners.
+
+
+⸻
+
+
+Closing thought — three sentences.
+Standards only matter if they make the right thing
+easy
+, the wrong thing
+hard
+, and the future
+compatible
+ with the present. This platform makes meaning and rights travel with data, makes proofs and rollbacks routine, and makes quantum/classical interop a mode switch—not a new religion. If we build it this way, we don’t just connect machines;
+we connect communities, safely
+, and we do it in a form that can grow from
+bytes to trits to qutrits
+ without breaking trust.
+
+
+⸻
+
+
+(Optional next deliverables I can produce immediately)
+
+	•	Ten
+TritRPC
+ test vectors (raw trits, TritPack243 bytes, AEAD inputs/outputs, SHA3 digests) plus
+Rust/Python SerDes
+ and Kafka serializer stubs.	•	A
+starter repository
+ (Beam ingestion → Airflow promotion → AtomSpace staging → RDF★ + SHACL → CK/DCAT + Ray Serve) with example DAGs and contexts.	•	An initial
+Atom
+→
+RDF
+š
+ mini‑schema
+ (e.g.,
+EvaluationLink
+,
+InheritanceLink
+,
+SimilarityLink
+) with SHACL shapes and SPARQL Update templates.

--- a/docs/trit-to-trust_sources/Hypothetical Ternary TritRPC.md
+++ b/docs/trit-to-trust_sources/Hypothetical Ternary TritRPC.md
@@ -1,0 +1,4767 @@
+# Hypothetical Ternary TritRPC
+
+.SFNS-Semibold;.SFNS-Regular;HelveticaNeue-Bold;
+.SFNS-RegularItalic;.AppleSystemUIFontMonospaced-Regular;TimesNewRomanPSMT;
+Helvetica;Courier;.SFNS-Bold;
+
+;;;;;
+;;;;;
+
+;;;;;
+;;;;;
+
+
+Why Binary Streams Prevail (and a Hypothetical Ternary “TritRPC”)
+
+
+In modern computing and RPC frameworks, binary (base-2) data streams are universal.
+ This is no accident: it reflects deep practical realities of hardware and engineering. Below we break down why binary won out, examine analogous multi-level tricks in current tech, sketch a hypothetical base-3 “TritRPC” for illustration, and highlight the theoretical allure of ternary logic.
+The Overwhelming Practical Hurdle: Why Binary Won
+Ultimately,
+hardware
+ dictates why everything is binary. Modern digital electronics are built on
+transistors
+ using CMOS logic, which behave like near-perfect on/off switches. They naturally support two stable states (on = 1, off = 0), and it’s
+much easier to make components with two stable states than three
+ :
+	•
+Simplicity and Reliability:
+ A CMOS transistor in logic circuits is either
+ON
+ (conducting, representing ‘1’) or
+OFF
+ (non-conducting, ‘0’). These two states are
+stable, low-power, and noise-resistant
+. Using binary “bits” kept early computer hardware simple and reliable . By contrast, a stable third state (e.g. a precise half-on voltage) is an engineering nightmare. Any analog intermediate level would be
+highly sensitive
+ to noise, temperature, and voltage drift, undermining reliability.	•
+The “Forbidden Zone”:
+ In CMOS logic, the transition region between fully on and off is unstable and power-hungry. A transistor that is half-on will draw significant current (both the pull-up and pull-down networks partly conduct), wasting energy as heat. Designing circuits to idle in a mid-level state would be
+inefficient and difficult to control
+. Essentially, there’s no convenient third “rail” for logic that doesn’t incur huge costs in power and circuit complexity.These hardware factors created an overwhelming inertia in favor of binary. The entire ecosystem – CPU gates, memory cells, and even communication protocols – was built on robust two-state logic. Overcoming this with ternary would require a
+revolutionary
+ new device offering an order-of-magnitude (10×) benefit to justify breaking from the binary standard. So far, ternary devices haven’t shown such a payoff, and binary remains the Goldilocks solution.
+
+Closest Analogues in Modern Tech: Multi-Level Signaling
+Interestingly, some
+physical signaling techniques
+ use more than two voltage levels per symbol – but crucially, they still interface with binary computers. For example, high-speed Ethernet links and Wi-Fi use
+multi-level modulation
+ to boost data rates. A scheme like
+PAM-4
+ (Pulse Amplitude Modulation with 4 levels) encodes
+2 bits per symbol
+ by using four distinct voltage levels :
+	•
+How it works:
+ Each voltage level represents a 2-bit pattern: for instance, in PAM-4 we might map Level_0 =
+00
+, Level_1 =
+01
+, Level_2 =
+10
+, Level_3 =
+11
+. This doubles the data throughput
+per clock
+ because one symbol carries 2 bits (instead of 1 in binary NRZ encoding). Likewise, modern Wi-Fi uses QAM constellations (e.g. 16-QAM, 64-QAM) where combinations of amplitude and phase encode multiple bits per carrier wave.	•
+But still binary at heart:
+ These multi-level signals are purely a
+physical layer optimization
+. The receiver (e.g. your network card) immediately decodes each multi-level symbol back into a standard binary bit stream before passing it up to any software or RPC layer. The computer’s logic still only understands 1s and 0s. In other words, the wire might momentarily carry more than two voltage states, but
+the information ultimately becomes bits
+. The same is true in storage: NAND flash memory with
+TLC
+ (Triple-Level Cell) stores 3 bits in one cell by distinguishing 8 charge levels , and QLC (Quad-Level Cell) uses 16 levels for 4 bits. These analog tricks increase density, but internally error-correcting controllers ensure the output is still a stream of binary data.In summary, no mainstream
+computing system
+ uses ternary logic throughout. Where we do see multi-level encodings, they serve as efficiency hacks at the analog transmission/storage layer, not as ternary computation. The hardware always converts the data back to binary because the logic circuits themselves remain binary.
+
+Sketch of a Hypothetical “TritRPC” Framework
+For the sake of argument,
+imagine
+ we had a true ternary computer that processes trits (-1, 0, +1). What might a serialization/RPC format look like in base-3? It turns out it could closely mirror something like Protocol Buffers, just with a different number system. Let’s use
+balanced ternary
+ digits – say
+N
+ for -1,
+Z
+ for 0, and
+P
+ for +1 – because balanced ternary elegantly handles negatives without a separate sign bit . We’ll outline two key components of a made-up
+“TritRPC”
+:
+
+	1.
+Basic Encoding – Varintᵀ (Variable-length Trits):
+ In binary ProtoBuf, integers are encoded as
+varints
+ where each byte uses 7 bits for value and 1 bit as a “continue” flag. In our ternary version, we can use a similar scheme with trits. For example, use the most significant trit of each tryte (a group of ternary digits) as a continuation flag: say
+P
+ or
+N
+ in that position means “more trits follow”, and
+Z
+ means “stop here”.
+	•
+Encoding the number 5:
+ In balanced ternary, 5 is represented as
+PNN
+ (because $5 = 1 \cdot 3^2 + (-1) \cdot 3^1 + (-1) \cdot 3^0 = 9 - 3 - 1$). This fits in one tryte, so we mark it as the final chunk with a leading
+Z
+.
+Wire format:
+
+Z P N N
+ (a four-trit sequence).	•
+Encoding the number 13:
+ In balanced ternary, 13 is
+PPP
+ ($13 = 1\cdot9 + 1\cdot3 + 1\cdot1$). We again only need one group, so the wire representation is
+Z P P P
+.(In practice, just like binary varints, larger numbers would span multiple groups of trits with
+P/N
+ flags indicating continuation.)
+
+	2.
+Message Structure – Tagged Fields:
+ The message would be a series of fields with headers, analogous to ProtoBuf’s field tags. Each field tag would combine the field number and type (but now encoded in base-3). For instance, consider a message:
+
+
+message User {    string name = 1;    int32  points = 2;}
+
+
+Suppose we want to encode
+User{name="Al", points=5}
+ in TritRPC:
+	•
+Field 1 (name):
+ Field number 1, type=string. In a ProtoBuf-like scheme, we might assign a type code (say
+PZ
+ for “string”). The field tag in base-3 could be the field number (1, which is
+1
+ in ternary) combined with type code, yielding something like
+PZZ
+ (this is a hypothetical encoding for illustration). Next comes the length of the string. “Al” is 2 characters, so we encode 2 as
+Z P N
+ (ternary 2 = $2_{10} = 2_{3}$, represented here as
+PN
+ with a
+Z
+ terminator). Then the UTF-8 bytes of “Al” would be represented in ternary form (each byte would be converted to a couple of trytes).
+On the wire
+, the field would look like:
+[Tag: PZZ] [Length: Z P N] [Payload: (ternary data for "A" and "l")]
+.	•
+Field 2 (points):
+ Field number 2, type=varint. In our scheme, maybe the type code for a varint is
+ZZ
+. The field tag for field 2 would then be something like
+PNZZ
+. The value 5 is encoded as the varintᵀ
+Z P N N
+ (from above).
+On the wire:
+
+[Tag: PNZZ] [Value: Z P N N]
+.The overall message stream is just these field segments concatenated. Notably, the
+structure
+ (field tags, lengths, values) is conceptually the same as binary ProtoBuf – we’ve just swapped out bits for trits. This exercise shows that if ternary computers existed, our RPC/serialization frameworks would look remarkably similar to today’s, only the numeric base underneath changes.
+
+The Theoretical Kicker: Why Base 3 at All?
+If binary is so dominant, why even ponder ternary? Information theory provides an intriguing answer:
+base-e (~2.718) is the mathematically optimal radix
+ for encoding numbers in terms of efficiency, and 3 is the nearest integer to
+e
+. In fact, a ternary digit (trit) carries about
+log₂3 ≈ 1.585 bits
+ of information . In theory, that means a ternary system could be slightly more information-dense than a binary one. A 64-trit number, for example, can represent a larger range than a 64-bit number (it’s equivalent to ~101.4 bits) .Historically, this led to some experimentation with ternary computers. Notably, the Soviet
+Setun
+ computer (1958) used balanced ternary logic. It was reported to have some advantages like lower power usage and cheaper circuits. However, those benefits were not big enough to overcome the sheer momentum of binary technology (and Setun was eventually left behind by binary machines). The complexity of building reliable ternary hardware outweighed the marginal gains in efficiency .
+In conclusion,
+ binary won because it hit the sweet spot between simplicity and functionality. Our entire digital world – from logic gates to RPC protocols – is built on that robust foundation of 1s and 0s. While ternary computing is elegant in theory and may see niche use (or a revival if new tech makes it viable), any “trinary RPC” would require a fundamentally different hardware paradigm. Until then, binary streams remain the practical choice for virtually all engineering purposes.Got it—let’s ground the whole design in
+Avro
+ (not Protobuf) and make Avro the schema “source of truth,” with JSON-LD/SALAD for semantics. I’ll give you two compatible implementation paths, then a full worked example, resolution/evolution rules, and Kafka/Schema-Registry fit. I’ll also include a short self-critique + refinements at the end.
+
+⸻
+
+
+TritRPC for Avro: A Spec Sketch
+
+
+0) Goals (Avro-first)
+
+	•
+Avro is authoritative
+: structure, defaults, evolution, and resolution follow Avro specs.	•
+JSON-LD/SALAD
+ binds semantics; we carry a context hash alongside the Avro schema hash.	•
+One canonical trit stream
+ that round-trips across:
+	•
+B2
+ (binary transport): trit stream packed into bytes	•
+B3
+ (native ternary transport): raw trits	•
+Q3
+ (qutrit rail): trits mapped to |0⟩,|1⟩,|2⟩
+	•
+Deterministic canonicalization
+ for hashing/signing, independent of transport.	•
+Kafka-compatible
+: value is bytes (B2), keyed by Avro Schema ID (+ JSON-LD Context ID).
+
+⸻
+
+
+1) Two Avro-Compatible Encodings (choose one or support both)
+
+
+Path A — Avro Binary-in-TritRPC (ABT)
+Keep Avro’s
+existing binary encoding
+ for the payload, unchanged. TritRPC provides the envelope, IDs, AEAD, and byte/trit bridging.
+	•
+Pros
+: 100% Avro-compatible; use stock Avro libraries; minimal risk.	•
+Cons
+: You don’t get ternary-native arithmetic internally (it’s still Avro’s zigzag varints, byte order, etc.).
+
+How it works
+
+	•	Envelope header has MAGIC/VER/MODE/FLAGS + IDs (below).	•
+PAYLOAD
+ is the
+Avro Binary Encoding (ABE)
+ of the datum, verbatim bytes.	•	For
+B2
+ mode, we can either:
+	•	store the Avro bytes as-is, or	•	(optionally) wrap them inside the canonical TritPack243 block so all modes share identical canonicalization rules.
+	•	For
+B3/Q3
+ modes, we
+must
+ pack: ABE bytes → trits using
+TritPack243
+ (so the raw channel carries trits/qutrits).
+In Path A, Avro’s binary is king; TritRPC is a thin, secure, transport-agnostic envelope.
+
+⸻
+
+
+Path B — Avro-T3 (native ternary encoding with Avro semantics)
+Define a
+ternary-native encoding
+ that respects Avro’s
+semantics
+ and
+resolution rules
+ but swaps in ternary-friendly primitives (balanced ternary integers, a base-9 varint, etc.). Useful if you want a truly trit-native payload.
+	•
+Pros
+: Native ternary integers, clean mapping to qutrit rails, less impedance.	•
+Cons
+: You must implement a new codec (encoder/decoder), though schema/resolve logic still comes from Avro.
+
+How it works
+
+	•	Keep Avro types and resolution rules intact (records, arrays, maps, unions, etc.).	•	Replace primitive encodings with ternary equivalents:
+	•
+int
+,
+long
+:
+balanced-ternary
+ varints (
+varint-bt
+)	•
+bytes
+,
+string
+: length as ternary varint; payload bytes as-is; strings as UTF-8 bytes (to avoid inventing “trit-UTF”)	•
+boolean
+: single
+trit
+:
+0
+=false,
+2
+=true (reserve
+1
+ for future/NA)	•
+float
+,
+double
+: length-delimited IEEE bit patterns as bytes (so values are bit-exact), or optional ternary fixed-point logical type	•
+fixed
+: exact length, opaque bytes	•
+enum
+: index as ternary varint	•
+array
+/
+map
+: block counts as ternary varints; match Avro’s block framing	•
+union
+: member index as ternary varint; then the member value
+In Path B, you get ternary-native payloads while remaining fully
+Avro-semantics-compatible
+. A resolver can still do reader/writer schema evolution exactly the Avro way.
+
+⸻
+
+
+2) TritRPC Envelope (Avro-bound)
+Logical (trit-level) frame:
+
+
+[ MAGIC ][ VER ][ MODE ][ FLAGS ][ SCHEMA-ID ][ CONTEXT-ID ][ PAYLOAD ][ (AEAD TAG?) ]
+
+
+	•
+MAGIC:
+ 9 trits unique to TritRPC.	•
+VER:
+ 2 trits (start at 1).	•
+MODE:
+ 1 trit →
+0=B2
+,
+1=B3
+,
+2=Q3
+.	•
+FLAGS:
+ 3 trits (use as binary bits: AEAD, compression, reserved).	•
+SCHEMA-ID:
+ 81 trits = multicodec’d
+SHA3-256(Avro canonical form)
+.	•
+CONTEXT-ID:
+ 81 trits = multicodec’d
+SHA3-256(JSON-LD @context canonicalization)
+.	•
+PAYLOAD:
+
+	•	Path A: the
+Avro Binary Encoding
+ (ABE) datum (bytes)	•	Path B:
+Avro-T3 encoding
+ (trits), then packed for B2 mode
+	•
+AEAD:
+ optional, as a trailing length-delimited field (authenticate everything before it).
+
+Canonical Byte Packing (shared by both paths) — TritPack243
+
+	•	Pack
+5 trits → 1 byte
+ (value 0..242).	•	Tail groups (1..4 trits) → emit
+marker 243..246
+ +
+1 data byte
+.	•	Bytes
+247..255
+ are invalid in canonical form.	•	Hash/sign
+the canonical TritPack243 bytes
+ for transport-invariant integrity.
+
+⸻
+
+
+3) Avro Type Mapping (Path B: Avro-T3 codec)
+Below, “TLEB3” is a
+base-3 varint
+ using small trit groups with a continuation trit (conceptually like varint, ternary edition).
+
+
+Avro Type
+
+Avro-T3 Encoding (ternary)
+
+
+null
+
+no bytes/trits emitted.
+
+boolean
+
+1 trit (0=false, 2=true; 1 reserved).
+
+int
+ (32b)
+
+varint-bt
+ (balanced-ternary varint).
+
+long
+ (64b)
+
+varint-bt
+.
+
+bytes
+
+len
+ as TLEB3, then that many
+bytes
+ (opaque).
+
+string
+
+len
+ as TLEB3, then UTF-8
+bytes
+.
+
+float
+
+length-delimited 4-byte IEEE 754 (opaque bytes).
+
+double
+
+length-delimited 8-byte IEEE 754 (opaque bytes).
+
+fixed(N)
+
+exactly N
+bytes
+.
+
+enum
+
+symbol index as TLEB3.
+
+array[T]
+
+Avro’s block framing:
+block_count
+ (TLEB3), then items (T3-encoded); repeat until zero block. Negative count for size-prefixed blocks can be modeled with a ternary sign (or keep Avro’s rule verbatim).
+
+map[V]
+
+block_count
+ (TLEB3), then pairs:
+len(key)
+ + key bytes, then value V; repeat; zero block terminator.
+
+union[U₀…Uₖ]
+
+member_index
+ (TLEB3), followed by value encoded as that member’s type.
+
+
+Logical types (recommended)
+
+	•
+{"type":"long","logicalType":"balancedTernary"}
+ →
+force
+ varint-bt (both paths can accept; in Path A it’s advisory).	•
+{"type":"bytes","logicalType":"trits"}
+ → payload interpreted as
+trit stream
+ (still serialized as bytes in Avro, but
+meaning
+ is trits; pack/unpack via TritPack243 when crossing modes).	•	Keep Avro’s standard logicals (decimal, date, time, timestamp, uuid) as-is (bytes/ints); define ternary alternates only if you truly need them.
+
+Unions & defaults
+
+	•	All Avro union and default behaviors remain
+unchanged
+. The codec only alters primitive encodings, not schema resolution semantics.
+
+⸻
+
+
+4) JSON-LD / SALAD Semantics
+
+	•	Carry a
+CONTEXT-ID
+ (SHA3-256 of canonicalized
+@context
+).	•	Optional: include a
+contextURI
+ field (length-delimited) in a control/handshake frame for resolvers.	•	Stores/indexers can resolve both
+structure
+ (Avro schema) and
+meaning
+ (JSON-LD) for knowledge graphs and semantic joins.
+
+⸻
+
+
+5) Kafka & Schema Registry
+
+	•
+Key:
+ typically
+{subject, schemaVersion}
+ or a stable hash.	•
+Value:
+
+B2 bytes
+ = canonical TritPack243 of the entire TritRPC envelope (header + payload [+ AEAD tag]).	•
+Schema Registry subject:
+ the Avro writer’s schema; we also pin
+SCHEMA-ID
+ in the envelope so consumers can verify they resolved the exact schema used to encode.	•
+Context pinning:
+ store
+CONTEXT-ID
+ as a header or inside the envelope to keep semantics explicit.
+
+Why put the whole envelope in Kafka value?
+
+	•	AEAD, mode, flags, and IDs ride with the message; consumers can do strict verification, not rely on out-of-band contracts.
+
+⸻
+
+
+6) Worked Example (both Path A and Path B)
+
+Avro schema
+
+
+{  "type": "record",  "name": "AddRequest",  "namespace": "calc.v1",  "fields": [    {"name":"a","type":{"type":"long","logicalType":"balancedTernary"}},    {"name":"b","type":{"type":"long","logicalType":"balancedTernary"}}  ]}
+
+
+We send:
+AddRequest{ a=12, b=5 }
+.
+
+6.1 Path A — Avro Binary in TritRPC
+
+
+Payload (ABE bytes):
+
+	•	Avro
+long
+ uses zigzag + varint.
+	•
+12
+ (zigzag) →
+24
+ → varint bytes:
+0x18
+	•
+5
+ (zigzag) →
+10
+ → varint bytes:
+0x0A
+
+	•	ABE payload =
+18 0A
+ (hex).
+
+TritRPC envelope (conceptual)
+
+
+MAGIC,VER,MODE=B2,FLAGSSCHEMA-ID  (SHA3 of Avro canonical form)CONTEXT-ID (SHA3 of JSON-LD @context)PAYLOAD = [0x18, 0x0A]     # Avro binary bytes(AEAD tag if enabled)
+
+
+If
+MODE=B2
+, we can pass
+18 0A
+ raw. If we want strict canonicalization everywhere, we instead
+TritPack243
+ the trit form of the envelope into bytes (recommended), then hash/sign those bytes.
+
+6.2 Path B — Avro-T3 (ternary-native payload)
+
+
+Balanced-ternary (big-endian digits)
+
+	•
+12
+ → base-3
+110
+ → balanced digits
+(+,+,0)
+ →
+transport trits
+
+[2,2,1]
+ (map −1→0, 0→1, +1→2)	•
+5
+  → base-3
+12
+  → balanced digits
+(+,-,-)
+ →
+transport trits
+
+[2,0,0]
+
+
+Encode each long as varint-bt:
+Let
+len=3
+ digits each. A simple TLEB3 for
+len=3
+ might be: one digit group with continuation=Z and value=3. Then emit the 3 trits in chosen endianness (spec: big-endian).
+Field order
+ follows Avro field order (no field tags in Avro):
+
+
+[a (len=3), a digits: 2 2 1] [b (len=3), b digits: 2 0 0]
+
+
+Now wrap with TritRPC header and (if MODE=B2) pack the whole trit stream via
+TritPack243
+ into bytes for Kafka.
+
+Note:
+ Path B preserves all Avro semantics; only the primitive codec differs.
+
+⸻
+
+
+7) AEAD, Hashing, Compression
+
+	•	Compute AEAD (e.g., XChaCha20-Poly1305) over the
+canonical TritPack243 bytes of the entire envelope
+, excluding the trailing AEAD tag field.	•	Include header fields (MODE, FLAGS, SCHEMA-ID, CONTEXT-ID) in the associated data so transport upgrades/downgrades can’t be replayed/misinterpreted.	•	Compress
+PAYLOAD
+ (Zstd/LZ4)
+before
+ AEAD if
+FLAGS.compression=1
+. For B3/Q3 links, compress the
+byte form
+ (i.e., after packing).
+
+⸻
+
+
+8) Avro Resolution & Evolution (Reader/Writer)
+All Avro resolution rules apply identically:
+	•
+Default values
+: reader defaults used when writer lacks a field.	•
+Aliases
+: respected as usual.	•
+Union resolution
+: reader resolves the writer’s chosen member by name/index as Avro specifies.	•
+Compatibility
+: your registry checks (backward/forward/full) are unchanged.
+
+Path A
+: Writer/reader use stock Avro libraries; envelope just carries the IDs & mode.
+Path B
+: Writer/reader use the
+Avro-T3 codec
+ (drop-in replacement layer). Schema resolution still uses Avro’s logic.
+
+⸻
+
+
+9) Control/Handshake Frames
+Define a tiny Avro record (in a control subject) for negotiation:
+
+
+{  "type":"record",  "name":"Hello",  "namespace":"tritrpc.control.v1",  "fields":[    {"name":"modes","type":{"type":"array","items":"int"}},   // 0=B2, 1=B3, 2=Q3    {"name":"aead_suites","type":{"type":"array","items":"string"}},    {"name":"contextURI","type":["null","string"],"default":null}  ]}
+
+
+Server replies with a selected mode/suite. Thereafter, data frames use that MODE.
+
+⸻
+
+
+10) Diagnostics: Pseudo Wire Dumps
+
+Envelope (logical view)
+
+
+MAGIC(9t) | VER(2t) | MODE(1t) | FLAGS(3t)| SCHEMA-ID(81t) | CONTEXT-ID(81t)| PAYLOAD(...)| [ AEAD-TAG (len-delimited) ]
+
+
+Path A — Avro bytes inside payload
+
+
+PAYLOAD = ABE bytes        # example: 0x18 0x0A
+
+
+Path B — Avro-T3 payload for AddRequest
+
+
+# a (12): len=3 → [Z:continue=stop | value=3]# digits: [2,2,1]# b (5):  len=3 → [Z       ...        ]# digits: [2,0,0]PAYLOAD = [ TLEB3(3) | 2 2 1 | TLEB3(3) | 2 0 0 ]
+
+
+If
+MODE=B2
+, pack the entire envelope with
+TritPack243
+ to obtain canonical bytes.
+
+⸻
+
+
+11) Interop Menu (what to actually ship first)
+
+	•
+Default
+ to
+Path A (ABT)
+ for zero friction:
+	•	Use existing Avro serializers.	•	Wrap in TritRPC envelope with SCHEMA-ID + CONTEXT-ID + AEAD.	•	For cross-mode, apply TritPack243 canon bytes.
+	•
+Optionally
+ add
+Path B (Avro-T3)
+ behind a feature flag:
+	•	Same Avro schemas and resolution.	•	New codec that swaps in ternary-friendly primitives.	•	Provides a clean bridge to future B3/Q3 links.
+
+⸻
+
+
+12) Quick Checklist (engineering)
+
+	•	Compute
+SCHEMA-ID
+ = SHA3-256(Avro canonical form).	•	Compute
+CONTEXT-ID
+ = SHA3-256(canonicalized JSON-LD
+@context
+).	•	Implement
+TritPack243
+ (trit↔byte).	•	Implement
+AEAD
+ over canonical TritPack243 bytes.	•
+Path A
+: drop in Avro Binary payload.	•
+Path B (optional)
+: Avro-T3 codec primitives (varint-bt, TLEB3, boolean-trit).	•	Kafka serializers/deserializers:
+	•	value = canonical bytes (full envelope)	•	headers include MODE/FLAGS for quick filtering (optional)
+	•	Test vectors: same messages encoded with Path A and Path B must produce
+different payloads
+ but identical
+envelope behaviors
+ (IDs, AEAD success, evolution, etc.).
+
+⸻
+
+
+13) Self-Critique & Recommended Refinements
+
+Strong points now:
+
+	•	Avro is truly first-class: schema, evolution, and registry integration are preserved.	•	Two clear paths: ultra-safe (Path A) and ternary-native (Path B).	•	Deterministic canonicalization via TritPack243 + AEAD story is clean and transport-agnostic.	•	JSON-LD/SALAD semantics are pinned explicitly (CONTEXT-ID).
+
+What to tighten next (I recommend doing all of these):
+
+
+	1.
+Publish test vectors
+ for both paths (nulls, unions, arrays/maps, decimals, timestamps). Include: raw trits, packed bytes, SHA3 digests, AEAD tags.
+	2.
+Lock digit endianness
+ for balanced ternary (spec currently says
+big-endian
+ for human readability; make it a MUST).
+	3.
+Decimal logical type
+: define ternary fixed-point representation (Path B) or mandate Avro’s existing bytes encoding only (Path A).
+	4.
+Union index varint size
+: cap digits for small unions to guarantee worst-case sizes (e.g., ≤ 9 members → 1 digit).
+	5.
+Streaming RPC
+ over Avro: define chunked frames with rolling AEAD and explicit flush semantics (mirroring Avro object container block ideas).
+	6.
+Registry augmentation
+: store
+CONTEXT-ID
+ and MODE support in schema metadata so readers can verify expectations before decode.
+	7.
+B3/Q3 ECC profile
+: specify a default RS(GF(3^m)) or ternary stabilizer at the link layer, and a small outer CRC in the envelope for fast failure.
+
+⸻
+
+If you want, I can follow up with (a) a
+Rust
+ reference for TritPack243 + envelope, (b)
+Kafka SerDes
+ for Path A, and (c)
+Avro-T3
+ codec scaffolding for Path B, plus a
+test-vector pack
+ that exercises unions, arrays/maps, and logical types.Got it—let’s ground the whole design in
+Avro
+ (not Protobuf) and make Avro the schema “source of truth,” with JSON-LD/SALAD for semantics. I’ll give you two compatible implementation paths, then a full worked example, resolution/evolution rules, and Kafka/Schema-Registry fit. I’ll also include a short self-critique + refinements at the end.
+
+⸻
+
+
+TritRPC for Avro: A Spec Sketch
+
+
+0) Goals (Avro-first)
+
+	•
+Avro is authoritative
+: structure, defaults, evolution, and resolution follow Avro specs.	•
+JSON-LD/SALAD
+ binds semantics; we carry a context hash alongside the Avro schema hash.	•
+One canonical trit stream
+ that round-trips across:
+	•
+B2
+ (binary transport): trit stream packed into bytes	•
+B3
+ (native ternary transport): raw trits	•
+Q3
+ (qutrit rail): trits mapped to |0⟩,|1⟩,|2⟩
+	•
+Deterministic canonicalization
+ for hashing/signing, independent of transport.	•
+Kafka-compatible
+: value is bytes (B2), keyed by Avro Schema ID (+ JSON-LD Context ID).
+
+⸻
+
+
+1) Two Avro-Compatible Encodings (choose one or support both)
+
+
+Path A — Avro Binary-in-TritRPC (ABT)
+Keep Avro’s
+existing binary encoding
+ for the payload, unchanged. TritRPC provides the envelope, IDs, AEAD, and byte/trit bridging.
+	•
+Pros
+: 100% Avro-compatible; use stock Avro libraries; minimal risk.	•
+Cons
+: You don’t get ternary-native arithmetic internally (it’s still Avro’s zigzag varints, byte order, etc.).
+
+How it works
+
+	•	Envelope header has MAGIC/VER/MODE/FLAGS + IDs (below).	•
+PAYLOAD
+ is the
+Avro Binary Encoding (ABE)
+ of the datum, verbatim bytes.	•	For
+B2
+ mode, we can either:
+	•	store the Avro bytes as-is, or	•	(optionally) wrap them inside the canonical TritPack243 block so all modes share identical canonicalization rules.
+	•	For
+B3/Q3
+ modes, we
+must
+ pack: ABE bytes → trits using
+TritPack243
+ (so the raw channel carries trits/qutrits).
+In Path A, Avro’s binary is king; TritRPC is a thin, secure, transport-agnostic envelope.
+
+⸻
+
+
+Path B — Avro-T3 (native ternary encoding with Avro semantics)
+Define a
+ternary-native encoding
+ that respects Avro’s
+semantics
+ and
+resolution rules
+ but swaps in ternary-friendly primitives (balanced ternary integers, a base-9 varint, etc.). Useful if you want a truly trit-native payload.
+	•
+Pros
+: Native ternary integers, clean mapping to qutrit rails, less impedance.	•
+Cons
+: You must implement a new codec (encoder/decoder), though schema/resolve logic still comes from Avro.
+
+How it works
+
+	•	Keep Avro types and resolution rules intact (records, arrays, maps, unions, etc.).	•	Replace primitive encodings with ternary equivalents:
+	•
+int
+,
+long
+:
+balanced-ternary
+ varints (
+varint-bt
+)	•
+bytes
+,
+string
+: length as ternary varint; payload bytes as-is; strings as UTF-8 bytes (to avoid inventing “trit-UTF”)	•
+boolean
+: single
+trit
+:
+0
+=false,
+2
+=true (reserve
+1
+ for future/NA)	•
+float
+,
+double
+: length-delimited IEEE bit patterns as bytes (so values are bit-exact), or optional ternary fixed-point logical type	•
+fixed
+: exact length, opaque bytes	•
+enum
+: index as ternary varint	•
+array
+/
+map
+: block counts as ternary varints; match Avro’s block framing	•
+union
+: member index as ternary varint; then the member value
+In Path B, you get ternary-native payloads while remaining fully
+Avro-semantics-compatible
+. A resolver can still do reader/writer schema evolution exactly the Avro way.
+
+⸻
+
+
+2) TritRPC Envelope (Avro-bound)
+Logical (trit-level) frame:
+
+
+[ MAGIC ][ VER ][ MODE ][ FLAGS ][ SCHEMA-ID ][ CONTEXT-ID ][ PAYLOAD ][ (AEAD TAG?) ]
+
+
+	•
+MAGIC:
+ 9 trits unique to TritRPC.	•
+VER:
+ 2 trits (start at 1).	•
+MODE:
+ 1 trit →
+0=B2
+,
+1=B3
+,
+2=Q3
+.	•
+FLAGS:
+ 3 trits (use as binary bits: AEAD, compression, reserved).	•
+SCHEMA-ID:
+ 81 trits = multicodec’d
+SHA3-256(Avro canonical form)
+.	•
+CONTEXT-ID:
+ 81 trits = multicodec’d
+SHA3-256(JSON-LD @context canonicalization)
+.	•
+PAYLOAD:
+
+	•	Path A: the
+Avro Binary Encoding
+ (ABE) datum (bytes)	•	Path B:
+Avro-T3 encoding
+ (trits), then packed for B2 mode
+	•
+AEAD:
+ optional, as a trailing length-delimited field (authenticate everything before it).
+
+Canonical Byte Packing (shared by both paths) — TritPack243
+
+	•	Pack
+5 trits → 1 byte
+ (value 0..242).	•	Tail groups (1..4 trits) → emit
+marker 243..246
+ +
+1 data byte
+.	•	Bytes
+247..255
+ are invalid in canonical form.	•	Hash/sign
+the canonical TritPack243 bytes
+ for transport-invariant integrity.
+
+⸻
+
+
+3) Avro Type Mapping (Path B: Avro-T3 codec)
+Below, “TLEB3” is a
+base-3 varint
+ using small trit groups with a continuation trit (conceptually like varint, ternary edition).
+
+
+Avro Type
+
+Avro-T3 Encoding (ternary)
+
+
+null
+
+no bytes/trits emitted.
+
+boolean
+
+1 trit (0=false, 2=true; 1 reserved).
+
+int
+ (32b)
+
+varint-bt
+ (balanced-ternary varint).
+
+long
+ (64b)
+
+varint-bt
+.
+
+bytes
+
+len
+ as TLEB3, then that many
+bytes
+ (opaque).
+
+string
+
+len
+ as TLEB3, then UTF-8
+bytes
+.
+
+float
+
+length-delimited 4-byte IEEE 754 (opaque bytes).
+
+double
+
+length-delimited 8-byte IEEE 754 (opaque bytes).
+
+fixed(N)
+
+exactly N
+bytes
+.
+
+enum
+
+symbol index as TLEB3.
+
+array[T]
+
+Avro’s block framing:
+block_count
+ (TLEB3), then items (T3-encoded); repeat until zero block. Negative count for size-prefixed blocks can be modeled with a ternary sign (or keep Avro’s rule verbatim).
+
+map[V]
+
+block_count
+ (TLEB3), then pairs:
+len(key)
+ + key bytes, then value V; repeat; zero block terminator.
+
+union[U₀…Uₖ]
+
+member_index
+ (TLEB3), followed by value encoded as that member’s type.
+
+
+Logical types (recommended)
+
+	•
+{"type":"long","logicalType":"balancedTernary"}
+ →
+force
+ varint-bt (both paths can accept; in Path A it’s advisory).	•
+{"type":"bytes","logicalType":"trits"}
+ → payload interpreted as
+trit stream
+ (still serialized as bytes in Avro, but
+meaning
+ is trits; pack/unpack via TritPack243 when crossing modes).	•	Keep Avro’s standard logicals (decimal, date, time, timestamp, uuid) as-is (bytes/ints); define ternary alternates only if you truly need them.
+
+Unions & defaults
+
+	•	All Avro union and default behaviors remain
+unchanged
+. The codec only alters primitive encodings, not schema resolution semantics.
+
+⸻
+
+
+4) JSON-LD / SALAD Semantics
+
+	•	Carry a
+CONTEXT-ID
+ (SHA3-256 of canonicalized
+@context
+).	•	Optional: include a
+contextURI
+ field (length-delimited) in a control/handshake frame for resolvers.	•	Stores/indexers can resolve both
+structure
+ (Avro schema) and
+meaning
+ (JSON-LD) for knowledge graphs and semantic joins.
+
+⸻
+
+
+5) Kafka & Schema Registry
+
+	•
+Key:
+ typically
+{subject, schemaVersion}
+ or a stable hash.	•
+Value:
+
+B2 bytes
+ = canonical TritPack243 of the entire TritRPC envelope (header + payload [+ AEAD tag]).	•
+Schema Registry subject:
+ the Avro writer’s schema; we also pin
+SCHEMA-ID
+ in the envelope so consumers can verify they resolved the exact schema used to encode.	•
+Context pinning:
+ store
+CONTEXT-ID
+ as a header or inside the envelope to keep semantics explicit.
+
+Why put the whole envelope in Kafka value?
+
+	•	AEAD, mode, flags, and IDs ride with the message; consumers can do strict verification, not rely on out-of-band contracts.
+
+⸻
+
+
+6) Worked Example (both Path A and Path B)
+
+Avro schema
+
+
+{  "type": "record",  "name": "AddRequest",  "namespace": "calc.v1",  "fields": [    {"name":"a","type":{"type":"long","logicalType":"balancedTernary"}},    {"name":"b","type":{"type":"long","logicalType":"balancedTernary"}}  ]}
+
+
+We send:
+AddRequest{ a=12, b=5 }
+.
+
+6.1 Path A — Avro Binary in TritRPC
+
+
+Payload (ABE bytes):
+
+	•	Avro
+long
+ uses zigzag + varint.
+	•
+12
+ (zigzag) →
+24
+ → varint bytes:
+0x18
+	•
+5
+ (zigzag) →
+10
+ → varint bytes:
+0x0A
+
+	•	ABE payload =
+18 0A
+ (hex).
+
+TritRPC envelope (conceptual)
+
+
+MAGIC,VER,MODE=B2,FLAGSSCHEMA-ID  (SHA3 of Avro canonical form)CONTEXT-ID (SHA3 of JSON-LD @context)PAYLOAD = [0x18, 0x0A]     # Avro binary bytes(AEAD tag if enabled)
+
+
+If
+MODE=B2
+, we can pass
+18 0A
+ raw. If we want strict canonicalization everywhere, we instead
+TritPack243
+ the trit form of the envelope into bytes (recommended), then hash/sign those bytes.
+
+6.2 Path B — Avro-T3 (ternary-native payload)
+
+
+Balanced-ternary (big-endian digits)
+
+	•
+12
+ → base-3
+110
+ → balanced digits
+(+,+,0)
+ →
+transport trits
+
+[2,2,1]
+ (map −1→0, 0→1, +1→2)	•
+5
+  → base-3
+12
+  → balanced digits
+(+,-,-)
+ →
+transport trits
+
+[2,0,0]
+
+
+Encode each long as varint-bt:
+Let
+len=3
+ digits each. A simple TLEB3 for
+len=3
+ might be: one digit group with continuation=Z and value=3. Then emit the 3 trits in chosen endianness (spec: big-endian).
+Field order
+ follows Avro field order (no field tags in Avro):
+
+
+[a (len=3), a digits: 2 2 1] [b (len=3), b digits: 2 0 0]
+
+
+Now wrap with TritRPC header and (if MODE=B2) pack the whole trit stream via
+TritPack243
+ into bytes for Kafka.
+
+Note:
+ Path B preserves all Avro semantics; only the primitive codec differs.
+
+⸻
+
+
+7) AEAD, Hashing, Compression
+
+	•	Compute AEAD (e.g., XChaCha20-Poly1305) over the
+canonical TritPack243 bytes of the entire envelope
+, excluding the trailing AEAD tag field.	•	Include header fields (MODE, FLAGS, SCHEMA-ID, CONTEXT-ID) in the associated data so transport upgrades/downgrades can’t be replayed/misinterpreted.	•	Compress
+PAYLOAD
+ (Zstd/LZ4)
+before
+ AEAD if
+FLAGS.compression=1
+. For B3/Q3 links, compress the
+byte form
+ (i.e., after packing).
+
+⸻
+
+
+8) Avro Resolution & Evolution (Reader/Writer)
+All Avro resolution rules apply identically:
+	•
+Default values
+: reader defaults used when writer lacks a field.	•
+Aliases
+: respected as usual.	•
+Union resolution
+: reader resolves the writer’s chosen member by name/index as Avro specifies.	•
+Compatibility
+: your registry checks (backward/forward/full) are unchanged.
+
+Path A
+: Writer/reader use stock Avro libraries; envelope just carries the IDs & mode.
+Path B
+: Writer/reader use the
+Avro-T3 codec
+ (drop-in replacement layer). Schema resolution still uses Avro’s logic.
+
+⸻
+
+
+9) Control/Handshake Frames
+Define a tiny Avro record (in a control subject) for negotiation:
+
+
+{  "type":"record",  "name":"Hello",  "namespace":"tritrpc.control.v1",  "fields":[    {"name":"modes","type":{"type":"array","items":"int"}},   // 0=B2, 1=B3, 2=Q3    {"name":"aead_suites","type":{"type":"array","items":"string"}},    {"name":"contextURI","type":["null","string"],"default":null}  ]}
+
+
+Server replies with a selected mode/suite. Thereafter, data frames use that MODE.
+
+⸻
+
+
+10) Diagnostics: Pseudo Wire Dumps
+
+Envelope (logical view)
+
+
+MAGIC(9t) | VER(2t) | MODE(1t) | FLAGS(3t)| SCHEMA-ID(81t) | CONTEXT-ID(81t)| PAYLOAD(...)| [ AEAD-TAG (len-delimited) ]
+
+
+Path A — Avro bytes inside payload
+
+
+PAYLOAD = ABE bytes        # example: 0x18 0x0A
+
+
+Path B — Avro-T3 payload for AddRequest
+
+
+# a (12): len=3 → [Z:continue=stop | value=3]# digits: [2,2,1]# b (5):  len=3 → [Z       ...        ]# digits: [2,0,0]PAYLOAD = [ TLEB3(3) | 2 2 1 | TLEB3(3) | 2 0 0 ]
+
+
+If
+MODE=B2
+, pack the entire envelope with
+TritPack243
+ to obtain canonical bytes.
+
+⸻
+
+
+11) Interop Menu (what to actually ship first)
+
+	•
+Default
+ to
+Path A (ABT)
+ for zero friction:
+	•	Use existing Avro serializers.	•	Wrap in TritRPC envelope with SCHEMA-ID + CONTEXT-ID + AEAD.	•	For cross-mode, apply TritPack243 canon bytes.
+	•
+Optionally
+ add
+Path B (Avro-T3)
+ behind a feature flag:
+	•	Same Avro schemas and resolution.	•	New codec that swaps in ternary-friendly primitives.	•	Provides a clean bridge to future B3/Q3 links.
+
+⸻
+
+
+12) Quick Checklist (engineering)
+
+	•	Compute
+SCHEMA-ID
+ = SHA3-256(Avro canonical form).	•	Compute
+CONTEXT-ID
+ = SHA3-256(canonicalized JSON-LD
+@context
+).	•	Implement
+TritPack243
+ (trit↔byte).	•	Implement
+AEAD
+ over canonical TritPack243 bytes.	•
+Path A
+: drop in Avro Binary payload.	•
+Path B (optional)
+: Avro-T3 codec primitives (varint-bt, TLEB3, boolean-trit).	•	Kafka serializers/deserializers:
+	•	value = canonical bytes (full envelope)	•	headers include MODE/FLAGS for quick filtering (optional)
+	•	Test vectors: same messages encoded with Path A and Path B must produce
+different payloads
+ but identical
+envelope behaviors
+ (IDs, AEAD success, evolution, etc.).
+
+⸻
+
+
+13) Self-Critique & Recommended Refinements
+
+Strong points now:
+
+	•	Avro is truly first-class: schema, evolution, and registry integration are preserved.	•	Two clear paths: ultra-safe (Path A) and ternary-native (Path B).	•	Deterministic canonicalization via TritPack243 + AEAD story is clean and transport-agnostic.	•	JSON-LD/SALAD semantics are pinned explicitly (CONTEXT-ID).
+
+What to tighten next (I recommend doing all of these):
+
+
+	1.
+Publish test vectors
+ for both paths (nulls, unions, arrays/maps, decimals, timestamps). Include: raw trits, packed bytes, SHA3 digests, AEAD tags.
+	2.
+Lock digit endianness
+ for balanced ternary (spec currently says
+big-endian
+ for human readability; make it a MUST).
+	3.
+Decimal logical type
+: define ternary fixed-point representation (Path B) or mandate Avro’s existing bytes encoding only (Path A).
+	4.
+Union index varint size
+: cap digits for small unions to guarantee worst-case sizes (e.g., ≤ 9 members → 1 digit).
+	5.
+Streaming RPC
+ over Avro: define chunked frames with rolling AEAD and explicit flush semantics (mirroring Avro object container block ideas).
+	6.
+Registry augmentation
+: store
+CONTEXT-ID
+ and MODE support in schema metadata so readers can verify expectations before decode.
+	7.
+B3/Q3 ECC profile
+: specify a default RS(GF(3^m)) or ternary stabilizer at the link layer, and a small outer CRC in the envelope for fast failure.
+
+⸻
+
+If you want, I can follow up with (a) a
+Rust
+ reference for TritPack243 + envelope, (b)
+Kafka SerDes
+ for Path A, and (c)
+Avro-T3
+ codec scaffolding for Path B, plus a
+test-vector pack
+ that exercises unions, arrays/maps, and logical types.You’re right—the local path shouldn’t depend on Airflow. Here’s a corrected,
+agentic, multi-tier orchestration design
+ that uses
+Jupiter-style dispersed computing
+,
+Ray task/actor placement
+, and
+K8s Poseidon/Firmament
+ for global→regional→fog→local→node scheduling—while keeping
+Avro+JSON-LD
+ contracts and the
+TritRPC
+ bridge intact.
+
+⸻
+
+
+Orchestration & Promotion (Corrected): Agentic, Dispersed, and Avro-Native
+
+
+0) Principles
+
+	•
+Local-first execution
+: no Airflow on-device; use
+Ray actors/workflows
+ and a lean
+local MQ
+.	•
+Agentic beyond one node
+: a mesh of cooperative agents (planner/dispatcher/observer/governor) spans nodes, clusters, and regions.	•
+One contract everywhere
+:
+Avro schema
+ (+ Schema Registry) and
+JSON-LD @context
+ IDs ride in the
+TritRPC envelope
+ across all tiers.
+
+⸻
+
+
+1) Roles & Tiers
+
+
+Agent Mesh (runs at every tier)
+
+	•
+Planner
+: builds task graphs; composes Ray workflows; sets placement intents.	•
+Dispatcher
+: submits jobs to the nearest capable scheduler (Ray on K8s).	•
+Observer
+: watches SLOs, locality, privacy constraints, and energy/cost.	•
+Governor
+: enforces policy (privacy/sovereignty, cost caps, residency).
+
+Schedulers by tier
+
+	•
+Global/Regional
+: Kubernetes +
+Poseidon (Firmament)
+ scheduler for multi-objective placement (CPU/GPU locality, net-cost, anti-affinity);
+Ray clusters on K8s
+ for execution.	•
+Fog/Edge Clusters
+: K8s (K3s acceptable) + Poseidon; Ray with
+placement groups
+ for gang scheduling.	•
+Node/Device
+:
+Ray runtime
+ (local) +
+NATS/JetStream
+ (or ZeroMQ) as the on-device MQ.
+
+⸻
+
+
+2) Corrected Promotion Pipelines
+
+
+A) Local/Node (no Airflow)
+
+
+[Ingest] -> [Stage] -> [Promote] -> [Publish]
+
+
+	•
+Ingest (Local)
+
+	•	Subscribe to
+NATS/JetStream
+ topics.	•	Validate
+Avro
+ using embedded Schema Registry cache; attach provenance.	•	Persist to a content-addressed local log (WAL).
+	•
+Stage (Local AtomSpace)
+
+	•	Ray
+Actor: AtomWriter
+ ingests facts/links with confidences & provenance.	•	Local JSON-LD context cache resolves terms without leaking them.
+	•
+Promote (Local Ray Workflow)
+
+	•	Ray
+Workflow
+ runs deterministic
+Atom→RDF
+* mapping.	•
+SHACL
+ constraints executed
+locally
+ (no network).	•	Produce
+immutable named graphs
+ in a local triple store (RDF4J/Blazegraph embedded).	•	If privacy policy requires, promotion stays local; otherwise, prepare a
+TritRPC envelope
+ for uplink.
+	•
+Publish (Local)
+
+	•	Optional: expose a
+local SPARQL endpoint
+.	•	For uplink, send
+TritRPC(B2)
+ frames into a fog/regional ingress topic (NATS→Kafka bridge).	•
+No Airflow involvement
+ here.
+
+B) Fog/Regional
+
+	•	Same four stages, but executed on
+Ray-on-K8s
+; Poseidon/Firmament places pods considering:(i) data locality (Kafka partition, object store proximity),(ii) accelerator fit (GPU/NPU),(iii) privacy/sovereignty (namespace/label constraints),(iv) network cost/latency.
+
+C) Global/Core
+
+	•	Long-running backfills, large joins, catalog curation: can use
+Airflow or Argo Workflows
+ to orchestrate
+Ray
+ jobs on K8s.	•	Airflow is
+only
+ in global/regional control loops—not local nodes.
+
+⸻
+
+
+3) Placement & Policy (concrete mechanics)
+
+
+3.1 Ray + Poseidon/Firmament
+
+	•
+Ray Actors/Tasks
+ carry a
+PlacementIntent
+:
+
+
+data_affinity: {topics, partitions, object_keys}resource_profile: {cpu, mem, gpu, npu}privacy: {residency=“local|fog|region|global”, sensitivity=“low|med|high”}qos: {p95_ms, p99_ms}
+
+
+	•
+Dispatcher
+ translates intents into:
+	•	Ray
+placement groups
+ (PACK/SPREAD/STRICT_PACK).	•	K8s
+node selectors/affinity/taints
+ (e.g.,
+node.locality=neighborhood-12
+,
+data.kafka.rack=us-east-1a
+).	•	Poseidon/Firmament
+cost vectors
+ (bandwidth, latency, preemption risk, power).
+
+Scoring
+ (sketch):
+
+\text{score} = w_L \cdot \text{locality} - w_N \cdot \text{net\_cost} + w_R \cdot \text{resource\_fit} + w_Q \cdot \text{QoS\_headroom} - w_P \cdot \text{policy\_violation}
+Hard constraints (residency/privacy)
+must
+ pass; otherwise reject.
+
+3.2 Queues & Backpressure
+
+	•
+Local
+: NATS/JetStream with per-subject limits and DLQs.	•
+Fog/Regional/Core
+: Kafka with schema-enforced topics.	•	Bridges:
+NATS↔Kafka
+ connectors pass
+TritRPC(B2)
+ frames unchanged; Avro+JSON-LD IDs ride in the envelope.
+
+⸻
+
+
+4) Avro + JSON-LD + TritRPC in this fabric
+
+	•
+Every message
+ (local to global) is an Avro datum with a
+JSON-LD @context
+; both hashed as
+SCHEMA-ID
+ and
+CONTEXT-ID
+ in the
+TritRPC envelope
+.	•
+Local promotion
+ uses the same IDs as global promotion—ensuring semantic continuity.	•
+Path A
+ (Avro Binary inside TritRPC) is default everywhere;
+Path B
+ (Avro-T3) is opt-in where ternary/Q3 links exist.	•
+AEAD/signatures
+ computed on
+canonical bytes (TritPack243)
+—transport invariant.
+
+⸻
+
+
+5) Agentic Beyond One Node (multi-node autonomy)
+
+
+Agent protocol (lightweight)
+
+
+	1.
+Observer
+ gossips load/latency/privacy/energy metrics.
+	2.
+Planner
+ proposes a distributed plan (Ray DAG), embedding placement intents per stage.
+	3.
+Governor
+ checks policy (residency, data sensitivity).
+	4.
+Dispatcher
+ commits to Ray/K8s where constraints & scores pass.
+	5.
+Observer
+ adapts (scale-out, migrate actors, spill to fog) when SLOs slip.
+
+Fault handling
+
+	•	If a local SHACL gate fails,
+Governor
+ triggers:
+	•	quarantine graph (local named graph, sealed),	•	emit a redacted
+diagnostic TritRPC
+ to fog (for human review),	•	retry only when policy allows.
+
+⸻
+
+
+6) Corrected “Promotion” Summaries (by tier)
+
+
+Local (device/node) — Ray-only
+
+	•	Ingest: NATS/JetStream → Avro validate → local WAL	•	Stage: AtomSpace via Ray Actor	•	Promote: Ray Workflow (Atom→RDF* + SHACL)	•	Publish: local SPARQL; optional uplink via TritRPC(B2)
+
+Fog/Regional — Ray-on-K8s + Poseidon
+
+	•	Ingest: Kafka	•	Stage/Promote: Ray actors/workflows; SHACL at cluster scale	•	Publish: SPARQL (regional); CK updates; mirror up
+
+Global/Core — Airflow/Argo orchestrates Ray
+
+	•	Cross-tenant backfills, curation, catalog/versioning; SHACL at corpus scale
+
+⸻
+
+
+7) Concrete specs that don’t change (to anchor the wire)
+
+	•
+Envelope
+:
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD][AEAD?]
+	•
+Canonical bytes
+:
+TritPack243
+ for all modes; AEAD over canonical bytes.	•
+Varints & signed ints
+:
+TLEB3
+,
+balanced-ternary
+ (endianness =
+MUST big-endian
+).	•
+Kafka/Local MQ
+: carry the
+same TritRPC bytes
+; schema+context resolved via Registry/cache.
+
+⸻
+
+
+8) Minimal CRDs / Polices (K8s level)
+
+	•
+TritWorkflow
+: declarative Ray DAG with placement intents + privacy/QoS.	•
+PlacementPolicy
+: default weights for Firmament scoring per namespace.	•
+DataSovereigntyPolicy
+: residency, export rules, redaction classes.	•
+SemanticContext
+: binds schema subjects to JSON-LD contexts; caches
+CONTEXT-ID
+.
+
+⸻
+
+
+9) Self-critique (and how to refine)
+
+	•
+Good
+: Removes Airflow from local loops; adds
+agent mesh
+ and
+Firmament-aware
+ placement; keeps Avro/JSON-LD/TritRPC invariants; unifies queues with NATS↔Kafka bridges.	•
+Gaps
+:
+
+	1.	Publish
+PlacementIntent→K8s/Ray
+ translation library + Poseidon weights.
+	2.	Provide
+Ray Workflow templates
+ for Stage/Promote/Publish with SHACL actors.
+	3.	Ship
+local triple-store
+ container + WAL/compaction policy.
+	4.	Add
+SLO-driven migration
+ (Observer-triggered actor rescheduling).
+	5.	Formalize
+agent protocol
+ (protobuf/Avro—use Avro!) and heartbeat/backoff rules.
+
+⸻
+
+
+10) Immediate upgrades you’ll notice
+
+	•	Local nodes make promotion decisions
+without
+ central schedulers.	•	Multi-node teams act
+agentically
+ (observe→plan→schedule→adapt) across nodes/clusters.	•	Semantics and security never drift:
+same Avro+JSON-LD IDs
+ and
+same TritRPC envelope
+ at every hop.If you want, I’ll deliver:
+
+	1.	a
+Ray Workflow
+ skeleton for Local Stage/Promote (with SHACL actor),
+	2.	a
+PlacementIntent→K8s/Ray
+ mapper (labels/taints + placement groups), and
+	3.	a
+NATS↔Kafka
+ bridge config that preserves TritRPC envelopes and validates
+SCHEMA-ID/CONTEXT-ID
+ at the edge.
+Awesome call. Let’s fold a
+local, docker-machine–style VM space
+ into the architecture so a single laptop/desktop has
+on-demand, policy-aware isolation
+ with
+resizable resources
+,
+taints/tolerations
+, and
+user-driven orchestration
+ — without breaking Avro+JSON-LD+TritRPC or the agentic scheduling story.
+Local “Machine Space” (LMS): design add-on
+
+
+1) What it is
+A lightweight
+local hypervisor VM
+ (e.g., QEMU/HyperKit/Apple Virtualization) that hosts a
+K3s
+ cluster with:
+	•
+Node classes
+:
+lms-control
+,
+lms-work
+,
+lms-secure
+, optionally
+lms-gpu
+.	•
+Runtime isolation
+:
+Kata Containers
+ or
+Firecracker
+ (microVMs) for high-trust workloads;
+gVisor
+ for hardened userland sandboxes.	•
+CNI
+: Cilium/Calico with NetworkPolicies and per-namespace egress limits.	•
+Storage
+: dynamic LVM-thin or qcow2 disks;
+resize
+ on demand.	•
+Ray local cluster
+: pre-wired to K3s; integrates with the global agent mesh.This VM is managed via a
+lms CLI
+ (docker-machine vibes): create, start, stop,
+resize CPU/RAM/disk
+, attach GPUs/NPUs, set taints/tolerations, and apply
+user profiles
+ that turn resources on/off.
+
+2) Why it matters
+
+	•
+Isolation
+: experiments, untrusted code, and PII-processing jobs run in microVMs, not on the host OS.	•
+Elasticity
+: turn cores/RAM/GPU on for a session; release when done.	•
+Policy
+: per-user
+profiles
+ enforce access, residency, and egress rules locally (no central admin needed).	•
+Continuity
+: same
+Avro+JSON-LD IDs
+ and
+TritRPC
+ envelope; local MQ (NATS/JetStream) mirrors Kafka.
+
+3) Core mechanics
+
+
+3.1 Lifecycle & resize
+
+	•
+Create
+:
+lms create --cpus 6 --memory 24g --disk 200g --name dev-a
+	•
+Resize
+ (hot-plug where supported; else drain→reboot):
+	•	CPU/RAM:
+lms resize dev-a --cpus 10 --memory 40g
+	•	Disk:
+lms disk expand dev-a --size 500g
+
+	•
+GPU/TPU passthrough
+ (capability-gated):
+lms attach-gpu dev-a --device mlx:0
+	•
+Profiles
+ flip on/off resource classes (see §3.3).
+
+3.2 K3s node topology (inside LMS)
+
+	•	Node
+lms-control
+ (taint:
+role=control:NoSchedule
+)	•	Node
+lms-work
+ (default workloads)	•	Node
+lms-secure
+ (taints:
+isolation=kata:NoSchedule
+,
+egress=deny:NoSchedule
+)	•	Optional Node
+lms-gpu
+ (taints:
+accel=gpu:NoSchedule
+)Ray workers map to these nodes via
+placement groups
+ and
+nodeSelectors
+.
+
+3.3 User orchestration: profiles & policies
+Two CRDs stored in the LMS control plane:
+
+UserResourceProfile
+
+
+apiVersion: lms.local/v1kind: UserResourceProfilemetadata: { name: michael-dev }spec:  cpu: { min: 4, max: 16, burst: 4 }  memory: { min: "8Gi", max: "64Gi", burst: "8Gi" }  disk:    pools:      - name: fast        class: nvme        quota: "200Gi"      - name: cold        class: ssd        quota: "2Ti"  accelerators:    gpu: { allowed: true, models: ["mps","rtx*"], max: 1 }  isolation:    runtimeDefault: gvisor    securePool: kata  network:    egress: { allowedCIDRs: ["10.0.0.0/8","*.corp"], denyAllElse: true }  defaults:    scheduleOn: ["lms-work"]
+
+
+AccessRestrictionPolicy
+ (OPA Gatekeeper constraints implied)
+
+
+apiVersion: lms.local/v1kind: AccessRestrictionPolicymetadata: { name: pii-guard }spec:  namespaces: ["pii-*"]  mustUseRuntime: "kata"  egress: "deny"  volumeClass: "encrypted-fast"  tlsRequired: true
+
+
+The
+lms profile apply
+ command toggles node taints, NetworkPolicies, ResourceQuotas, LimitRanges, and default RuntimeClasses accordingly.
+
+3.4 Taints/tolerations examples
+
+	•	Mark secure node:
+
+
+kubectl taint nodes lms-secure isolation=kata:NoSchedulekubectl taint nodes lms-secure egress=deny:NoSchedule
+
+
+	•	Workload tolerations:
+
+
+tolerations:  - key: isolation    operator: Equal    value: kata    effect: NoSchedule  - key: egress    operator: Equal    value: deny    effect: NoSchedulenodeSelector:  lms.node.class: secureruntimeClassName: kata
+
+
+	•	GPU node:
+
+
+kubectl taint nodes lms-gpu accel=gpu:NoSchedule
+
+
+Ray actor that needs GPU:
+
+
+nodeSelector: { lms.node.class: gpu }tolerations:  - key: accel    operator: Equal    value: gpu    effect: NoSchedule
+
+
+3.5 Runtime isolation tiers
+
+	•
+default
+: containerd + AppArmor/SELinux + seccomp + eBPF LSM.	•
+gVisor
+: syscall interception for moderate hardening.	•
+Kata/Firecracker
+: microVM boundary for PII/secret workloads.	•
+NetworkPolicy
+: Cilium/Calico enforce isolation & egress allow-lists.	•
+Storage classes
+:
+encrypted-fast
+ (dm-crypt + LVM thin),
+cold-archive
+.
+
+3.6 Local MQ + Registry
+
+	•
+NATS/JetStream
+ with per-subject quotas & DLQs.	•
+Schema Registry cache
+ in LMS;
+JSON-LD context cache
+ pinned to
+CONTEXT-ID
+.	•
+NATS↔Kafka bridge
+ preserves TritRPC(B2) bytes & Avro/JSON-LD IDs.
+
+4) Ray + Poseidon/Firmament integration (local ↔ global)
+
+	•
+Local
+: Ray inside LMS honors
+PlacementIntent
+ (node class, runtime, accelerators).	•
+Fog/Regional
+: when the
+Observer
+ detects SLO pressure or policy (e.g., GPU unavailable), it escalates plan fragments to a
+Ray-on-K8s
+ cluster scheduled by
+Poseidon/Firmament
+.	•
+Seamless spillover
+: work starts local; spills to fog/regional when constraints require, keeping
+TritRPC
+ envelopes unchanged.
+
+PlacementIntent → K8s/Ray mapping (LMS)
+
+
+placementIntent:  nodeClass: secure        # -> nodeSelector: lms.node.class=secure  runtime: kata            # -> runtimeClassName: kata  accel: gpu               # -> toleration accel=gpu + selector lms.node.class=gpu  privacy: high            # -> namespace=pii-*, AccessRestrictionPolicy=pii-guard  qos: { p95_ms: 50, p99_ms: 150 }
+
+
+5) TritRPC, Avro, JSON-LD — unchanged but empowered
+
+	•
+Same envelope
+:
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD][AEAD?]
+.	•
+Same canonicalization
+:
+TritPack243
+ for hashing/AEAD.	•
+Same payload paths
+: Path-A (Avro Binary) default; Path-B (Avro-T3) optional.	•
+Local enforcement
+: LMS attaches ResourceQuotas/LimitRanges so rogue jobs cannot bypass envelope policy (e.g., PII workloads forced onto
+lms-secure
+ with Kata + egress-deny).
+
+6) Minimal UX (so it feels like docker-machine)
+
+
+# Create & start a local machine spacelms create --name mk-dev --cpus 8 --memory 32g --disk 300g --profile michael-devlms start mk-dev# Toggle secure mode for PII taskslms profile apply pii-guardkubectl apply -f jobs/pii-dedup.yaml  # auto-routed to lms-secure via runtimeClass/taints# Add GPU for a session, then releaselms attach-gpu mk-dev --device mps0kubectl apply -f jobs/vision-train.yamllms detach-gpu mk-dev --device mps0# Expand disk as your local catalog growslms disk expand mk-dev --size 600g
+
+
+7) Security & governance hooks (local)
+
+	•
+OPA/Gatekeeper
+ policies enforce runtime, egress, and label requirements per namespace.	•
+Vault Agent
+ issues short-lived creds; CSI driver mounts sealed secrets.	•
+Audit
+: Cilium Hubble/eBPF flow logs; content-addressed WAL for replay; TritRPC AEAD/signatures for tamper-evidence.
+
+8) How this fits the agentic promotion model (corrected)
+
+Local (LMS)
+ replaces Airflow with
+Ray Workflows
+:
+	•	Ingest (NATS) → Validate (Avro) → Stage (AtomSpace Actor) → Promote (Atom→RDF* + SHACL) → Publish (local SPARQL / uplink via TritRPC).
+
+Global/Regional
+ may still use Airflow/Argo
+only
+ for large backfills/curation, dispatching to
+Ray-on-K8s
+ (Poseidon/Firmament).
+
+⸻
+
+
+9) Self-critique & refinements
+
+Strengths
+: clean isolation boundary; deterministic resource governance; quick, user-driven elasticity; zero change to Avro/JSON-LD/TritRPC; first-class Ray placement; consistent semantics edge→core.
+Gaps to tighten
+ (recommended next):
+
+	1.
+Reference lms CLI
+: VM backend adapters (QEMU/AppleVirt/Hyper-V), K3s bootstrap, Kata/gVisor toggles, hot-plug where supported.
+	2.
+Profile compiler
+: translate
+UserResourceProfile
+ → K8s Quotas, LimitRanges, RuntimeClasses, NetworkPolicies, taints/tolerations in one shot.
+	3.
+Secure defaults
+: ship with
+egress=deny
+ for
+pii-*
+ namespaces; only explicit allow-lists open.
+	4.
+Telemetry & SLO
+: built-in Observer exporting nodeClass/QoS metrics to OpenTelemetry; automatic spillover rules.
+	5.
+Test vectors
+ (unchanged): Path-A/Path-B TritRPC examples; AEAD; SCHEMA-ID/CONTEXT-ID resolution.
+
+⸻
+
+If you want, I can draft:
+	•	the
+lms CLI spec
+ (commands, flags, lifecycle),	•	the
+CRDs
+ (UserResourceProfile, AccessRestrictionPolicy) with Gatekeeper constraints, and	•	a
+starter Ray Workflow
+ (Stage→Promote→Publish) that auto-targets
+lms-secure
+ using runtimeClass + taints/tolerations.
+you’re right—the
+host workstation should not run Ray Workflows
+. Ray/Workflows belong
+inside the LMS K3s cluster
+ (or higher tiers), while the
+host OS
+ optimizes for minimal overhead, OS-native scheduling, and fast local IO. Below is a corrected, end-to-end layout that integrates a docker-/Lightning-container edge runtime, keeps inference local, and scales up along your ladder:
+node → local-cluster/mesh → fog → cloud → global mesh
+.
+
+⸻
+
+
+Corrected Execution Model (by tier)
+
+
+┌───────────────────────────────────────────────────────────────────────┐│  Global Mesh (multi-region)  → Cloud Region  →  Fog Cluster  →  LMS  ││  (policy, catalog, FL coord)     (big jobs)        (mid jobs)     (k3s) ││                                                              ↑          ││                                 Edge devices (Docker/Lightning)         ││                                                              ↑          ││                                Host Workstation (OS-native runner)      │└───────────────────────────────────────────────────────────────────────┘
+
+
+1) Host Workstation (Node) — OS-native runner only
+
+	•
+No Ray/Workflows here.
+	•
+Task runner:
+ a light Agent that executes steps via the OS:
+	•	macOS:
+launchd
+ jobs / POSIX processes	•	Linux:
+systemd
+ units / plain processes	•	Windows: Task Scheduler / services
+	•
+When to run on host:
+ micro-tasks, parsing, quick transforms, UI/IDE-adjacent work, metering collectors, and “thin” inferences that don’t justify container spin-up.	•
+Isolation options (opt-in):
+ run in a
+Docker
+ container (containerd/Moby) or
+Lightning
+ container if user profile demands sandboxing.	•
+Queue:
+ local NATS/JetStream (or simple FIFO) → promotes to LMS when thresholds hit.	•
+Policy:
+ user profile decides default (host vs container) and what triggers offload.
+
+2) Local Machine Space (LMS) — K3s cluster with Ray
+
+	•
+Ray Actors/Workflows live here
+, not on the host.	•
+Schedulers:
+ K8s + Poseidon/Firmament; taints/tolerations for
+secure
+,
+gpu
+, etc.	•
+Isolation:
+ gVisor/Kata/Firecracker as needed; per-namespace NetworkPolicy & quotas.	•
+Use cases:
+ multi-step pipelines, SHACL promotion, batch inferences, privacy-scoped jobs, GPU/accel needs, anything that benefits from container orchestration.
+
+3) Edge & Smart Devices — Docker or Lightning containers
+
+	•
+Default role:
+
+inference + metering
+, not training.	•
+Packaging:
+ OCI images or
+Lightning
+ containers (PyTorch Lightning/Lightning Fabric based) with a TritRPC sidecar.	•
+Isolation footprint:
+ containerd/Moby, optionally Firecracker (e.g., Kata) on capable gateways; on tiny devices, balenaEngine is acceptable.	•
+Networking:
+ local NATS or MQTT; uplink via TritRPC(B2) to fog/regional.
+
+4) Fog / Regional Clusters — K8s + Ray (Poseidon/Firmament)
+
+	•
+Role:
+ heavier batch inference, feature generation, small-to-medium training, and
+federated training coordination
+ when a cohort exists locally.	•
+Data affinity:
+ co-locate with Kafka/object store partitions.
+
+5) Cloud / Global Mesh
+
+	•
+Role:
+ large training, global backfills, catalog curation, cross-tenant SPARQL, FL aggregation across cohorts, compliance audits.	•
+Orchestration:
+ Argo/Airflow
+only here
+ (drives Ray-on-K8s jobs).
+
+⸻
+
+
+Placement & Offload Policy (smallest-sufficient tier)
+
+
+Ladder:
+ host → LMS → edge mesh (if host is gateway) → fog → cloud → global.
+Decision inputs
+
+	•
+S
+ize: CPU, RAM, GPU/NPU needed	•
+L
+atency SLO: p95/p99 targets	•
+D
+ata locality: where source/targets sit	•
+P
+rivacy/residency: local/fog/region/global	•
+I
+solation: none/gVisor/Kata	•
+C
+ost/energy budget	•
+A
+vailability: queue depth, backlog, duty cycle
+
+Heuristic (sketch)
+
+
+if violates(P) or needs(I=Kata) or needs(GPU) or S > host-quota:    send → LMSelif L requires < 10ms and host has S:    run on host (OS-native)elif edge device hosts the sensor and S fits:    run on edge (Docker/Lightning)else:    escalate → fog → cloud by locality & SLO
+
+
+Always choose the
+lowest
+ tier that satisfies {S,L,D,P,I,C,A}. Spill upward if SLO/backpressure fails.
+
+⸻
+
+
+Inference vs Training & Federated Learning
+
+	•
+Edge
+:
+inference + metering only
+; cache small feature stores; log predictions/latencies; perform
+online calibration
+ (e.g., thresholds) but not full SGD.	•
+LMS
+: batch inference, light fine-tuning (LoRA/PEFT), distillation, and
+local cohort
+ FL if enough nodes are present.	•
+Fog/Cloud
+: heavy training;
+FL aggregators
+. Use Flower/Ray AIR/NVFLARE (pick one) with TritRPC for message transport.	•
+Gate for FL start
+:
+cohort_size ≥ N
+ AND
+node_score ≥ θ
+ AND privacy allows; otherwise
+defer to fog
+.
+
+⸻
+
+
+Containerization patterns (Edge & LMS)
+
+
+A) Docker (generic OCI)
+
+	•
+Image
+: app + model + TritRPC sidecar (Avro+JSON-LD aware).	•
+Ingress
+: TritRPC over TCP/UDS; optional HTTP/gRPC gateway for legacy callers.	•
+Env
+: schema/context IDs provided as env or configmap.
+
+B) Lightning containers (ML-focused)
+
+	•
+LightningModule
+ packaged with model weights;
+Lightning runtime
+ handles device placement (CPU/MPS/CUDA) inside container.	•
+Control
+: TritRPC “serve” method maps to Lightning’s predict step.	•
+Metering
+: sidecar emits per-request metrics (latency, confidences) to NATS/Kafka.
+
+Security tiers
+
+	•	Default: containerd + seccomp + AppArmor.	•	Hardened: gVisor.	•	High-trust: Kata/Firecracker microVMs (on LMS/gateway).
+
+⸻
+
+
+Corrected Promotion (local without Airflow)
+
+
+Host (OS-native):
+
+
+	1.
+Ingest
+: read NATS subject → Avro validate (SchemaRegistry cache) → attach provenance → write local WAL
+	2.
+Stage
+: local AtomSpace process (not container if policy permits)
+	3.
+Promote
+: if small → run mapping + SHACL as
+host processes
+; if policy/size/privacy demands →
+submit to LMS Ray Workflow
+
+	4.
+Publish
+: local SPARQL (embedded store) or uplink via TritRPC(B2) to fog
+
+LMS (K3s with Ray):
+
+	•	Same 4 steps, but as
+Ray Workflows
+ placed by Poseidon/Firmament with taints/tolerations (
+secure
+,
+gpu
+, etc.)
+
+⸻
+
+
+TritRPC / Avro / JSON-LD — unchanged core
+
+	•
+Envelope
+:
+[MAGIC][VER][MODE][FLAGS][SCHEMA-ID][CONTEXT-ID][PAYLOAD][AEAD?]
+	•
+Canonical bytes
+:
+TritPack243
+ (sign once, route anywhere)	•
+Payload
+:
+Path-A
+ (Avro Binary) default;
+Path-B
+ (Avro-T3) optional/experimental	•
+Every tier
+ speaks the same contract; local and edge never drift from fog/cloud semantics.
+
+⸻
+
+
+Dev & Ops UX
+
+
+Host (developer ergonomics)
+
+
+# run locally (OS-native), auto-offload if policy triggersagent run --task stage_promote --policy default# explicitly offload to LMSagent offload --to lms --dag stage_promote# package & push edge container (Docker or Lightning)agent pack --target edge --lightning ./serving --tag mymodel:0.3agent deploy --device edge-12 --image mymodel:0.3
+
+
+LMS control
+
+
+lms create --cpus 8 --memory 32g --disk 300g --profile devlms taint add lms-secure isolation=kata:NoSchedulelms apply-profile michael-dev
+⸻
+
+
+Self-critique & refinements
+
+
+Strengths now
+
+	•	Clear separation:
+host = OS-native runner
+,
+LMS/above = Ray/K8s
+.	•	Edge containers (Docker/Lightning) cover smart devices; inference + metering by default, with clean offload rules.	•	Placement policy is explicit; smallest-sufficient tier first; semantics/security remain invariant (Avro+JSON-LD in TritRPC).
+
+What to tighten next
+
+
+	1.
+Policy compiler
+: translate placement constraints (S,L,D,P,I,C,A) into host/LMS/fog actions automatically.
+	2.
+Edge reference images
+: one
+Docker
+ and one
+Lightning
+ template with TritRPC sidecar + Avro/JSON-LD bootstrap.
+	3.
+Offload thresholds
+: ship sane defaults (e.g.,
+cpu>75% 5s
+,
+p95>2×SLO
+,
+mem>80%
+,
+GPU req=true
+) with hysteresis to avoid flapping.
+	4.
+Federated learning guardrails
+: cohort formation, privacy/residency proofs, secure aggregation, and TritRPC message schemas.
+	5.
+Test vectors & SerDes
+: finalize Path-A/Path-B examples, AEAD vectors, and publish Rust/Python libs.If you want, I’ll produce the
+policy compiler matrix
+ (inputs→actions), the
+edge Docker/Lightning templates
+ with a TritRPC sidecar, and the
+offload thresholds
+ as a default policy you can tune per profile.
+Absolutely—let’s enrich the
+governed Airflow path
+ with a complementary,
+volunteer/federated compute mesh
+ for sparse, local-first topologies. Think
+BOINC/Folding@home/SETI@home
+ vibes but modernized: Avro/JSON-LD contracts, TritRPC envelopes, container/WASM isolation, proof/verification, and optional on-ledger settlement (RLC-style) — all slotted into your node→local-mesh→fog→cloud→global ladder.
+
+⸻
+
+
+Dual-Orchestration Model
+
+
+A) Canonical, governed ETL (Airflow)
+
+	•
+Purpose:
+ Authoritative
+source→target
+ pipelines (data lineage, SLAs, data contracts).	•
+Traits:
+ Change-controlled DAGs; catalog-integrated (CK/Open Data Catalog); reproducible; audit-ready.	•
+Transport:
+ Kafka (Avro + JSON-LD) using
+TritRPC(B2)
+ as the envelope.
+
+B) Federated Compute Mesh (volunteer/agentic)
+
+	•
+Purpose:
+ Opportunistic capacity for users with
+small, federated trust networks
+ and
+sparse compute/storage/IO
+, where centralized cluster paths are overkill or unavailable.	•
+Traits:
+ Opt-in nodes, intermittent connectivity, heterogeneous devices, pluggable verification, credits/settlement (RLC-style) optional.	•
+Transport:
+ Same
+TritRPC
+ envelopes; same Avro schema + JSON-LD semantics; overlay network (QUIC/libp2p or NATS federation).These two planes interoperate:
+Airflow DAGs can publish work to the mesh
+ and later
+collect/reduce
+ results with governed checks.
+
+⸻
+
+
+Mesh Architecture (focused for sparse topologies)
+
+
+               (Governed plane)                         (Mesh plane)           ┌──────────────────────┐               ┌──────────────────────┐           │  Airflow DAG (core)  │               │  Mesh Coordinator    │           │  • Source→Target     │               │  • WU registry       │           │  • Catalog + policy  │               │  • Scheduler         │           └─────────┬────────────┘               │  • Verifier/Reducer  │                     │ TritRPC(B2)                └─────────┬────────────┘                     ▼                                           ▲             ┌───────────────┐                                  │             │ MeshOperator  │ publish/collect                  │ gossip/submit             └──────┬────────┘                                  │                    │                         ┌──────────────────┴──────────────────┐                    ▼                         │        Federated Trust Network       │        ┌───────────────────────┐             │ (Edge/Peers: Docker/Lightning/WASM) │        │  Work Unit (WU) pack  │────────────▶│   • Workers (containers/WASM)       │        │  • Avro datum(s)      │ TritRPC     │   • Verifiers (redundant/zk/TEE)    │        │  • JSON-LD context    │             │   • Storage shims (IPFS/HTTP/S3)    │        │  • Policy & SLO       │             └──────────────────────────────────────┘        └───────────────────────┘
+⸻
+
+
+Roles
+
+	•
+Coordinator (may run on your host or within LMS):
+WU registry, scheduling, result collection, verification, reduction, settlement. Can be a small service the Airflow
+MeshOperator
+ talks to.	•
+Workers (edge/peers):
+Run
+Docker
+/
+Lightning
+ containers or
+WASM
+ sandboxes; pull WUs, compute, return results + proofs/receipts.	•
+Verifiers:
+Redundant re-executors or cryptographic verifiers (zk/TEE/spot-check); provide attestations, thresholds, or SNARK/STARK proofs (optional).	•
+Storage shims:
+Content-addressed blobs via IPFS/S3/HTTP; small inputs inline in WU; large binaries fetched by hash.
+
+⸻
+
+
+Work Units (WU) – Spec Sketch
+
+
+WU header (TritRPC envelope):
+
+	•
+SCHEMA-ID
+: SHA3(Avro canonical form)	•
+CONTEXT-ID
+: SHA3(JSON-LD @context)	•
+POLICY
+: privacy/residency, isolation requirements, SLOs	•
+PROOF_MODE
+:
+redundant | spot_check | tee | zk
+	•
+SANDBOX
+:
+docker | lightning | wasm | kata
+ (+ resource hints)
+
+WU body (Avro):
+
+
+{  "work_unit_id": "urn:wu:…",  "task": "image.infer@v3",                    // logical task name  "inputs": [{ "uri":"ipfs://…", "sha256":"…" }], // or inline bytes  "params": { "top_k": 3, "threshold": 0.65 },  "constraints": {    "max_wall_ms": 60000,    "min_mem_mb": 1024,    "accel": ["mps","cuda","neon"]  },  "return": { "schema_id":"sha3:…", "context_id":"sha3:…" }}
+
+
+Results are returned as TritRPC frames with the declared
+return
+ Avro schema (plus
+verifier receipts
+).
+
+⸻
+
+
+Isolation & Runtime Choices (edge-friendly)
+
+	•
+Docker/OCI
+: general workloads; seccomp+AppArmor.	•
+Lightning containers
+: ML inference; ergonomic device placement (CPU/MPS/CUDA).	•
+WASM (wasmtime/wasm3)
+: portable, fast cold-start, deterministic by design (great for replicated verification).	•
+Kata/Firecracker
+: microVM boundary for PII/regulated tasks on capable nodes.
+
+Selection rule
+ (inside WU policy): prefer
+WASM
+ for deterministic, CPU-only subtasks;
+Lightning
+ for ML inference;
+Kata
+ when isolation or PII flags demand.
+
+⸻
+
+
+Scheduling in Sparse Meshes
+
+	•
+Opportunistic & delay-tolerant
+: store-and-forward; tasks carry TTL & priority; nodes can go offline and return.	•
+Placement hints
+: data affinity, approximate geoloc/latency classes, privacy residency (local/fog/region).	•
+Smallest-sufficient tier
+ first:host → local mesh → fog → cloud → global; escalate on SLO failure/backpressure.
+
+⸻
+
+
+Verification & Trust
+Choose per-WU
+PROOF_MODE
+:
+
+	1.
+Redundant quorum
+ (deterministic tasks): N≥3 replicas;
+majority hash
+ match → accept; tie-break with an extra run.
+	2.
+Spot-check
+ (stochastic tasks): embed
+canary
+ sub-tasks with known outputs; score worker accuracy; weight results.
+	3.
+TEE attestation
+: require SEV-SNP/TDX/SGX attestation quotes in receipts; Coordinator validates before rewarding.
+	4.
+ZK proofs
+ (advanced): worker returns
+result + proof
+; Coordinator verifies succinctly.
+	5.
+Optimistic + fraud proofs
+: accept result, allow a challenge window; challengers must submit counter-evidence; slashing applies on successful challenges.
+
+Receipts (Avro)
+ include: WU id, worker DID, runtime+version, input digests, output digests, timing, energy (optional),
+attestation/proof
+.
+
+⸻
+
+
+Credits, Settlement, and Reputation (RLC-style option)
+
+	•
+Accounting:
+ simple
+credits
+ by default (time × resources × QoS).	•
+On-ledger mode:
+ stake/bond, slashing, and settlements via a permissioned ledger (or append-only Merkle log with witnesses) to keep ops simple.	•
+Reputation:
+ moving average of successful verified WUs; decay over time; affects task allocation & payouts.	•
+Privacy:
+ do not leak dataset identity; account in aggregate unless proofs require per-WD detail.
+
+⸻
+
+
+Data Movement
+
+	•
+Small inputs
+: inline Avro bytes within the WU.	•
+Large inputs
+: content addressed (IPFS/S3/HTTP) by
+digest
+; side-channel bulk transfer allowed;
+digests
+ always checked before execution.	•
+Outputs
+: inline if small; else content-addressed artifacts with digests; results Avro references these URIs.	•
+All WU and result messages
+ travel as
+TritRPC(B2)
+ (Kafka/NATS/libp2p) or
+B3/Q3
+ when available;
+same envelope, same semantics
+.
+
+⸻
+
+
+Airflow ↔ Mesh Integration
+
+
+MeshOperator (Airflow)
+
+	•
+publish_wus(task_id, batch)
+ → chunks payloads; assigns PROOF_MODE; signs and emits TritRPC WUs.	•
+collect(task_id)
+ → gathers results, verifies per PROOF_MODE, reduces, emits canonical
+Target Avro
+.	•
+lineage hooks
+ → write WU DAG edges and verification receipts to the Catalog (CK).
+
+DAG pattern
+
+
+Extract → Normalize → (MeshOperator: Distribute) → (Mesh Reduce) → Validate → Load
+
+
+	•	Use
+governed
+ DAG only to define contracts and reductions; mesh handles elastic compute.
+
+⸻
+
+
+What’s good to run on the Mesh?
+
+	•
+Embarrassingly parallel
+: image/audio transcoding; feature extraction; map-style preprocess; parameter sweeps.	•
+Inference at the edge
+: small/medium models (Lightning containers).	•
+Analytics kernels
+: sketching (HyperLogLog, Count-Min), Bloom filters, hashing, sampling.	•
+Simulation shards
+: Monte Carlo, rendering tiles, search branches.Avoid (or require strong proofs/TEEs for): PII-heavy, low-entropy aggregation, or tasks needing sensitive keys.
+
+⸻
+
+
+Privacy & Compliance
+
+	•
+Policy in WU
+: residency (local/fog/region), isolation (Kata/TEE), no-egress flags.	•
+Tokenized secrets
+: pull once from a short-lived vault token; never write secrets to result.	•
+Field-level AEAD
+: seal sensitive fields in payloads/results; Coordinator can route sealed fragments only to attested nodes.	•
+Differential privacy
+ (optional): for aggregate statistics; applied at Reduce.
+
+⸻
+
+
+Minimal APIs (sketch)
+
+
+WU Publish (Coordinator)
+
+
+POST /api/v1/wuBody: TritRPC payload (Avro WU)Resp: { accepted: n, ids: [...] }
+
+
+WU Poll (Worker)
+
+
+GET /api/v1/wu?cap=gpu&runtime=lightning&residency=localResp: [WU...]
+
+
+Result Submit (Worker)
+
+
+POST /api/v1/resultBody: TritRPC payload (Avro result + receipt)
+
+
+Settlement (optional)
+
+
+POST /api/v1/settle { wu_id, receipts[], proof_bundle }
+⸻
+
+
+Governance & Catalog (CK)
+
+	•	Dataset/model
+cards
+ list whether mesh use is allowed, required proof modes, privacy class, allowable residencies.	•	Airflow enforces catalog rules at
+MeshOperator
+ boundary.	•	All WU/result/receipt digests + provenance recorded for audit/repro.
+
+⸻
+
+
+Self-critique & refinements
+
+
+Strengths
+
+	•	Keeps
+Airflow
+ as the governed source→target authority while enabling
+elastic, agentic
+ compute for sparse topologies.	•	Uses
+the same Avro+JSON-LD contracts
+ and
+TritRPC envelope
+, so semantics never drift.	•	Offers
+graduated trust
+: redundant hashes → spot-checks → TEEs → ZK.	•	Runs everywhere:
+Docker/Lightning
+ containers,
+WASM
+ for determinism,
+Kata
+/microVM for strong isolation.
+
+Gaps to tighten next
+
+
+	1.
+Reference WU schemas & result/receipt Avro
+ (test vectors with AEAD).
+	2.
+Coordinator reference
+ (NATS/libp2p overlay with QUIC, retry/TTL, backpressure).
+	3.
+Proof adapters
+: SGX/SEV attestation validator; pluggable zk-verifier interface.
+	4.
+Airflow MeshOperator
+ sample implementation (publish/collect/reduce).
+	5.
+Default policies
+: what’s allowed on mesh, default PROOF_MODE per task class, and residency matrix.
+	6.
+Edge images
+: Docker + Lightning base images with TritRPC sidecar & Avro/JSON-LD bootstrap.
+	7.
+Reputation/settlement
+: start with credits; add optional staking & slashing later.Want me to draft (a) the
+WU/Result/Receipt Avro
+ schemas with TritRPC envelopes, (b) a
+MeshOperator
+ for Airflow (pseudo-code), and (c) a
+WASM worker
+ reference that runs the same WU deterministically on ARM/x86?
+Got it. Here’s a
+tight, agent-first augmentation
+ that snaps into everything we’ve built (Avro + JSON-LD + TritRPC, LMS K3s with Ray, Airflow for governed ETL, and the volunteer/federated mesh). It makes each node an
+AI system in its own right
+: OpenCog-backed symbolic core, an on-node LLM/SMLL (small model) service, and a
+portfolio of OS-native agents
+ (user, knowledge, network/connections, terminal/shell, etc.)—all contract-driven and policy-governed.
+
+⸻
+
+
+Agent-First Node Architecture (OS-native)
+
+
+0) Design principles
+
+	•
+OS-first runner:
+ no Ray on the host; host runs agents as
+OS-native services
+ (launchd/systemd/Windows Service) for minimal overhead and best I/O.	•
+OpenCog + LLM co-reasoning:
+ AtomSpace is the symbolic substrate; LLM/SMLL serves tool-use, summarization, schema synthesis. Both are first-class and auditable.	•
+Contracts everywhere:
+ Avro schema + JSON-LD
+@context
+, wrapped in
+TritRPC
+ (B2/B3/Q3). Agents talk by
+contracts
+, not ad-hoc JSON.	•
+Local sovereignty:
+ user and system graphs live locally; promotion is explicit. Default is private pods + capability tokens.	•
+Smallest-sufficient tier:
+ host → LMS k3s → edge mesh → fog → cloud → global.
+
+⸻
+
+
+1) On-Node Components (host workstation)
+
+
+1.1 Agent Kernel (supervisor)
+
+	•	Runs as
+agentd
+ (launchd/systemd). Subsystems:
+	•
+Planner
+ (lightweight): decides
+where
+ to execute (host vs LMS vs mesh) per policy.	•
+ToolBus:
+ routes
+AgentMessages
+ (Avro/TritRPC) between agents/tools.	•
+Guardrails:
+ capability enforcement, PII gates, egress policies.	•
+Memory Fabric:
+
+	•
+User Graph
+ (private): preferences, projects, personal entities (AtomSpace workspace + vector store).	•
+System Graph
+: processes, sockets, mounts, services, packages, health (AtomSpace workspace).	•
+Vector Index
+: FAISS/Milvus-lite; RAG over user/system docs.
+	•
+Secret & Consent
+: Vault Agent/OS keychain + consent ledger (append-only).
+
+1.2 Built-in agents (host level)
+
+	•
+User Agent
+: profile inference, intent router, preference policy compiler.	•
+Knowledge Agent
+: RAG over User/System graphs; RDF*/AtomSpace promotion locally.	•
+Network/Connections Agent
+: interfaces with OS net APIs (pcap/nettop/lsof), builds a connections subgraph, alerts on anomalies.	•
+Terminal/Shell Agent
+: secure shell tool with least-privilege; emits command intents + effects to the System Graph.	•
+LLM Service
+: on-node LLM/SMLL server:
+	•	Tiered:
+SMLL
+ (e.g., 1–3B) always available; larger models only in LMS or fog.	•	Tool-use via
+AgentMessages
+ (not HTTP plugins); prompt templates live in the User Graph and are versioned.
+All agents
+speak Avro
+ over
+TritRPC(B2)
+ locally (UDS/TCP). JSON-LD contexts guarantee semantic stability.
+
+⸻
+
+
+2) Local Machine Space (LMS) k3s cluster (microVM isolation)
+
+	•	When the host needs isolation/scale/GPU/PII handling,
+Planner
+ offloads to LMS:
+	•
+Ray Actors/Workflows live here
+ (SHACL promotion, batch inference, secure jobs).	•	Node classes:
+lms-work
+,
+lms-secure
+ (Kata),
+lms-gpu
+.	•
+lms
+ CLI (docker-machine vibes): create/start/resize, taints/tolerations, attach GPU, apply
+UserResourceProfile
+ and
+AccessRestrictionPolicy
+.
+
+⸻
+
+
+3) Edge and Mesh (Docker/Lightning/WASM)
+
+	•
+Edge containers
+ (Docker or Lightning): inference + metering; TritRPC sidecar; WASM for deterministic kernels.	•
+Volunteer mesh
+ (BOINC-style): Work Units (WU) published from Airflow (governed) or from the
+MeshCoordinator
+; verification via quorum/spot/TEE/ZK; results reduced and promoted by governed DAGs.
+
+⸻
+
+
+4) Data planes & contracts
+
+
+4.1 Core Avro schemas (sketches)
+
+
+AgentEnvelope
+ (wrap all node-local exchanges)
+
+
+{  "type":"record","name":"AgentEnvelope","namespace":"agent.v1",  "fields":[    {"name":"id","type":"string"},    {"name":"ts","type":"long","logicalType":"timestamp-micros"},    {"name":"sender","type":"string"},    {"name":"receiver","type":"string"},    {"name":"kind","type":{"type":"enum","name":"AgentKind",      "symbols":["OBSERVATION","INTENT","ACTION","RESULT","ERROR"]}},    {"name":"schema_id","type":"string"},      // Avro shape pin    {"name":"context_id","type":"string"},    // JSON-LD pin    {"name":"payload","type":"bytes"}         // datum of the declared schema_id  ]}
+
+
+Observation
+ (from Network/Terminal/System)
+
+
+{  "type":"record","name":"Observation","namespace":"agent.v1",  "fields":[    {"name":"source","type":"string"},    {"name":"type","type":"string"},          // e.g., "net.conn","proc.spawn"    {"name":"attrs","type":{"type":"map","values":"string"}},    {"name":"severity","type":{"type":"enum","name":"Severity","symbols":["INFO","WARN","CRIT"]}}  ]}
+
+
+Action
+ (what Terminal/Network agent may execute)
+
+
+{  "type":"record","name":"Action","namespace":"agent.v1",  "fields":[    {"name":"capability","type":"string"},    // e.g., "shell.exec","net.block"    {"name":"args","type":{"type":"map","values":"string"}},    {"name":"policy","type":{"type":"map","values":"string"}} // e.g., timeout, cwd  ]}
+
+
+KnowledgeUpdate
+ (User/System graph deltas)
+
+
+{  "type":"record","name":"KnowledgeUpdate","namespace":"agent.v1",  "fields":[    {"name":"graph","type":{"type":"enum","name":"Graph","symbols":["USER","SYSTEM"]}},    {"name":"patch","type":"bytes"},          // RDF*/AtomSpace delta (binary or Turtle*)    {"name":"prov","type":{"type":"map","values":"string"}}  ]}
+
+
+LLMRequest / LLMResponse
+ (tool-use, structured)
+
+
+{  "type":"record","name":"LLMRequest","namespace":"agent.v1",  "fields":[    {"name":"model","type":"string"},    {"name":"prompt","type":"string"},    {"name":"tools","type":{"type":"array","items":"string"}}, // declared capabilities    {"name":"retrieval","type":{"type":"map","values":"string"}}  ]}
+
+{  "type":"record","name":"LLMResponse","namespace":"agent.v1",  "fields":[    {"name":"text","type":["null","string"],"default":null},    {"name":"tool_calls","type":{"type":"array","items":      {"type":"record","name":"ToolCall","fields":[        {"name":"capability","type":"string"},        {"name":"args","type":{"type":"map","values":"string"}}      ]}}},    {"name":"confidence","type":["null","float"],"default":null}  ]}
+
+
+All carried in
+TritRPC
+ with
+SCHEMA-ID
+ +
+CONTEXT-ID
+.
+Path-A
+ (Avro Binary) by default;
+Path-B
+ ternary-native optional.
+
+4.2 JSON-LD contexts
+
+	•
+agent.jsonld
+ defines terms:
+Observation
+,
+Action
+,
+Graph
+,
+Capability
+,
+Provenance
+—so graph deltas are semantically portable and promotion to RDF*/OWL is deterministic.
+
+⸻
+
+
+5) Execution & placement logic (host-first)
+
+Inputs:
+ size (S), latency SLO (L), data locality (D), privacy/residency (P), isolation (I), cost/energy (C), availability (A).
+Decision:
+
+	•	Host (OS-native) if
+S
+ small,
+L
+ tight,
+I
+ none/low, and policy allows.	•	LMS if needs Kata/GPU/PII or
+S
+ beyond host quota or
+L
+ not met on host.	•	Edge container if sensor-adjacent; WASM for deterministic kernels.	•	Mesh/fog/cloud escalations per SLO and backlog with same contracts.
+
+⸻
+
+
+6) Agent behaviors (concrete)
+
+
+6.1 Network/Connections Agent
+
+	•
+Observe:
+ sockets, DNS, QUIC, TLS, process ownership; emit
+Observation
+ events.	•
+Detect:
+ policy-bound patterns (beaconing, exfil windows); tag
+SYSTEM graph
+ with risk edges.	•
+Act:
+ propose
+Action
+ (“block domain”, “throttle process”) to
+Governor
+ for approval.
+
+6.2 Terminal/Shell Agent
+
+	•
+Guarded exec:
+ only approved capabilities/args; TTY/PTY with redactors; emit Observation + Result.	•
+Replayability:
+ store command + normalized outputs (hashes) to
+User graph
+ under project nodes.
+
+6.3 Knowledge Agent
+
+	•
+RAG
+: merges vector candidates (User/System docs) with AtomSpace queries; builds
+Working Set
+ before LLM call.	•
+Promotion:
+ local Atom→RDF* mapping +
+SHACL
+; stay local by default; explicit uplink via TritRPC.
+
+6.4 LLM Service
+
+	•
+SMLL on host
+: quantized small models;
+bigger only in LMS/fog
+.	•
+Tool-use
+: constrained to declared Avro capabilities; tool results update graphs; traces are persisted (reproducible).
+
+⸻
+
+
+7) Airflow (governed ETL) ↔ Agent Mesh (elastic)
+
+	•	Canonical
+source→target
+ DAGs live in Airflow; a
+MeshOperator
+ can
+publish WUs
+ to the federated mesh for elastic compute, with receipts/reductions back into governed loads.	•	Agents consume/produce the same
+TritRPC
+ frames, so crossings are seamless.
+
+⸻
+
+
+8) Security & policy
+
+	•
+Capabilities
+: every Action checks capability tokens (who, what, where, TTL, scope).	•
+Egress
+: Cilium/Calico NetworkPolicy (host/LMS); local deny-by-default for PII namespaces.	•
+Secrets
+: short-lived; never serialized in clear; fields sealed with AEAD in
+AgentEnvelope
+ payloads as needed.	•
+Audit
+: AgentEnvelope streams are content-addressed; signed canonical bytes (TritPack243) yield tamper-evident logs.
+
+⸻
+
+
+9) Developer & user UX
+
+Host
+
+
+# start agent kernelsudo agentd start# send an intent to shell agent, OS-nativeagentctl send --to shell --schema Action --file ./ls_home.avro# offload a promotion job to LMSagentctl offload --to lms --workflow promote_local_graph# ask the LLM with tools restricted to knowledge+shellagentctl ask "summarize recent auth failures and suggest fixes" --tools knowledge,shell
+
+
+LMS
+
+
+lms create --name mk-dev --cpus 8 --memory 32g --disk 300g --profile michael-devlms apply-profile pii-guard
+
+
+Edge
+
+
+agentctl pack --target edge --lightning ./models/edge_infer --tag myedge:0.1agentctl deploy --device edge-12 --image myedge:0.1
+⸻
+
+
+10) Example end-to-end flows
+
+
+	1.
+User asks:
+ “Why is my CPU spiking when Chrome is idle?”
+	•	Network Agent emits
+Observation
+ spikes; System Graph links PID↔sockets; Knowledge Agent composes a Working Set; LLM explains + proposes Actions (throttle, block domain). Governor approves; Terminal Agent executes throttling. Promotion stays local unless user opts to publish.
+
+	2.
+Local doc RAG:
+ User Agent ingests notes; Knowledge Agent updates
+User Graph
+; LLM drafts a plan; Terminal Agent scaffolds files; everything runs host-native. If model too big → offload to LMS automatically.
+	3.
+Volunteer job:
+ Airflow DAG publishes WUs for feature extraction; peers run Docker/WASM; receipts come back; governed DAG reduces + loads to target store. Same schemas; TritRPC everywhere.
+
+⸻
+
+
+11) What to ship next (concrete, code-ready)
+
+	•
+Avro schemas
+ (finalize):
+AgentEnvelope
+,
+Observation
+,
+Action
+,
+KnowledgeUpdate
+,
+LLMRequest/Response
+,
+Receipt
+.	•
+JSON-LD contexts
+ for agents/graphs/capabilities (stable IRIs).	•
+TritRPC SerDes
+ (Rust/Python): TritPack243, AEAD, envelope helpers.	•
+agentd
+ +
+agentctl
+: host runner & CLI; UDS transport; policy compiler.	•
+LLM service
+: SMLL on host, LMS profile for larger models; tool-use via AgentMessages.	•
+LMS CRDs
+:
+UserResourceProfile
+,
+AccessRestrictionPolicy
+; Kata/gVisor presets.	•
+MeshCoordinator
+: minimal NATS/libp2p, quorum verifier, Airflow
+MeshOperator
+.	•
+Test vectors
+: end-to-end—host action, LMS offload, mesh round-trip, AEAD integrity.
+
+⸻
+
+
+12) Self-critique & refinements
+
+Strengths
+
+	•	Clean separation of concerns: host = OS-native agent system; LMS/fog/cloud = orchestration and heavy lifting.	•	Every exchange is
+contractual
+ (Avro+JSON-LD) and
+transport-invariant
+ (TritRPC).	•	Co-reasoning is explicit and auditable (AtomSpace ↔ LLM); tool calls are first-class Avro actions.	•	Scales horizontally with volunteer mesh without abandoning governance.
+
+Gaps / refine
+
+
+	1.
+Formalize tool capability taxonomy
+ (cap names, arg schemas, side-effects); ship a registry.
+	2.
+Consistent tracing
+: W3C Trace Context for AgentEnvelope to correlate LLM/tool/graph hops.
+	3.
+Determinism modes
+: WASM-first for verifiable steps; annotate LLM non-determinism and cache/seed.
+	4.
+Prompt governance
+: store prompts/templates in
+User Graph
+ with versions, hashes, and opt-in redaction rules.
+	5.
+Auto-placement tuning
+: learn thresholds from SLO deltas and energy telemetry (Observer feeds a bandit to improve host vs LMS decisions).
+	6.
+Accessibility & recovery
+: safe-mode (no external egress), “explain my last action” endpoints, and one-shot rollback for graph mutations.
+
+⸻
+
+If you want, I’ll deliver
+(1) the finalized Avro schemas + JSON-LD contexts
+,
+(2) agentd/agentctl spec with OS service units
+, and
+(3) a minimal SMLL service with tool-use
+ that can run on your workstation today and offload to LMS transparently when policies trigger.Absolutely—let’s harden the UX stack with a
+Local Digital‑Twin UI
+ (LDT‑UI) that
+never executes remote website code
+ and instead renders
+locally verified scripts, styles, and components
+ under your policies. We’ll also add a
+K3s‑in‑cloud twin
+ that mirrors the local K3s (LMS) cluster to act as the user’s
+execution bastion & trusted C2
+ for the personal mesh.Below is a complete design that slots into our agent‑first, Avro+JSON‑LD+TritRPC architecture and the node→local‑mesh→fog→cloud→global ladder.
+
+⸻
+
+
+0) Objectives & threat model
+
+Your objectives
+
+	•
+No remote JS execution.
+ All interaction logic comes from
+locally verified
+ scripts/libraries.	•
+Policy‑controlled CSS.
+ User chooses the stylesheet/skin;
+no Shadow DOM spoofing
+ or injected styles.	•
+Reusable, offline libraries.
+ Eliminate repeated I/O for jQuery/React/etc.;
+cache once, verify forever
+.	•
+Deterministic, auditable UI.
+ Same Avro+JSON‑LD semantics and TritRPC envelope; signatures survive transport.	•
+K3s twin in cloud.
+ Mirrors LMS; serves as
+execution bastion & C2
+ for user and federated mesh.
+
+Key threats
+
+	•	Minified/obfuscated third‑party bundles; supply‑chain injection; drive‑by JS; Shadow DOM masking; CSS‑based UI deception; tampering between source and render.
+
+⸻
+
+
+1) Local Digital‑Twin UI (LDT‑UI): high‑level
+
+Replace the browser’s remote execution
+ with a
+local rendering runtime
+ that:
+
+	1.
+Fetches only data
+ (HTML/JSON/GraphQL) through a policy gateway/proxy.
+	2.
+Maps remote content → local UI components
+ via a
+signed UI Manifest
+.
+	3.
+Renders
+ with
+local, verified scripts
+ and
+user‑owned CSS skins
+ inside
+sandboxed realms
+.
+	4.
+Never evals remote code
+;
+never loads remote CSS/JS/fonts
+.
+	5.	Exposes only
+capabilities
+ (network, file, clipboard, etc.) via Avro‑declared tools; all calls go through
+TritRPC
+ with AEAD, policy, logging.
+
+⸻
+
+
+2) LDT‑UI architecture (components)
+
+	•
+Policy Gateway (PGW)
+ – single egress for “web content”. Enforces:
+	•	Domain allowlist/denylist, rate limits, header scrubbing, no mixed content, no redirects to untrusted schemes.	•	Accepts: HTML, JSON, images;
+rejects
+: JS, CSS, fonts (served locally only).
+	•
+Content Normalizer (CN)
+ – parses fetched HTML/JSON, strips scripts/styles, extracts
+semantic signals
+ (schema.org, OpenGraph, microdata), and produces a
+Content AST
+.	•
+UI Manifest Resolver (UIMR)
+ – picks a
+signed UI Manifest
+ to map content → components. Manifests are local, versioned, signed, and content‑addressed.	•
+Local Component Library (LCL)
+ – reusable,
+verified
+ UI widgets (tables, forms, galleries, editors), plus
+data mappers
+. Shipped unminified, with SBOM+attestations.	•
+CSS Skin Manager (CSM)
+ – loads
+user‑chosen CSS tokens/skins
+; applies them consistently;
+forbids
+ remote/injected CSS.	•
+Sandboxed Script Realms (SSR)
+ – executes local scripts in
+SES/QuickJS/Hermes
+ realms;
+capabilities injected explicitly
+;
+no global ambient authority
+.	•
+Render Host (RH)
+ – presents UI (Tauri/Wry/WebView/CEF).
+Navigation
+ never leaves RH; all links become
+intents
+ resolved by agents/tools.	•
+Audit & Provenance
+ – every render pipeline emits
+AgentEnvelope
+ observations; hashes of manifests, components, and skins recorded.
+
+⸻
+
+
+3) End‑to‑end rendering pipeline
+
+
+	1.
+Request
+: user navigates to
+https://example.com/product/123
+.
+	2.
+PGW fetches
+ the document
+as data
+ (no JS, no CSS), strips scripts/tags; CN builds
+Content AST
+ (nodes annotated with JSON‑LD if present).
+	3.
+UIMR selects
+ a
+Signed UI Manifest
+ (SUM) for
+example.com
+ (or a generic vertical manifest: “product detail”).
+	4.
+LCL components
+ are bound to AST nodes per SUM rules;
+no code from the site
+ is executed.
+	5.
+CSM applies
+ the user skin (CSS design tokens + policy); blocks any style from remote content.
+	6.
+SSR
+ runs only
+local verified scripts
+ (component logic, input validation, formatters) with
+capability shims
+ for network/storage
+through agents
+.
+	7.
+RH renders
+; any “link/click” becomes an
+Agent intent
+; any API call goes via TritRPC to the
+Network/Connections Agent
+ with allowlists and provenance.
+
+Result:
+ visually rich, fully interactive UI
+without trusting remote JS/CSS
+, under your policies, and with
+semantic fidelity
+ (JSON‑LD preserved).
+
+⸻
+
+
+4) Signed UI Manifest (SUM)
+A
+package that tells LDT‑UI how to render
+ a given site/domain/vertical using local components & styles.
+Manifest contents
+
+	•
+Target
+: domain patterns, path patterns, or content class (e.g., “blog”, “product”, “doc”).	•
+Selectors/Bindings
+: map Content AST nodes to LCL components (e.g.,
+.price → <PriceTag/>
+).	•
+Data transforms
+: simple expressions or WASM filters (deterministic only).	•
+Actions
+: form handling, pagination, search—each mapped to
+Avro Actions
+ (capabilities).	•
+Skin
+: token set references, layout hints; never imports remote CSS.	•
+Security
+: required capabilities, API endpoints allowlist, privacy flags.
+
+Distribution & trust
+
+	•	Built via
+reproducible toolchain
+ (Nix/Bazel),
+unminified
+, with
+SBOM
+ and
+SLSA/in‑toto attestations
+.	•	Signed (ed25519/p256); stored content‑addressed.	•	Updatable via GitOps;
+never hot‑patched by websites
+.
+
+⸻
+
+
+5) Local Component Library (LCL) & sandboxing
+
+	•
+Tech
+: Web Components rendered in RH, but
+Shadow DOM closed is forbidden
+. LDT‑UI
+translates closed shadow to open
+ or
+disallows
+ components requiring it.	•
+Sandbox
+:
+SES realms
+ (or QuickJS) per component family;
+capabilities injected
+ (e.g., fetch via PGW only; filesystem off; clipboard read‑only unless user approves).	•
+No eval/dynamic import
+; no reflection across realms; no shared global objects.	•
+WASM option
+: deterministic compute kernels as WASM; great for verification and cross‑arch stability.
+
+⸻
+
+
+6) CSS governance & anti‑spoofing
+
+	•
+User‑owned skin
+: design tokens (colors, spacing, fonts), baseline reset;
+no remote fonts
+ by default (FOIT/fingerprinting ban).	•
+CSS sanitizer
+: only a
+policy subset
+ of properties/selectors; disallow
+filter
+, tricky blend modes,
+position:fixed
+ overlays unless allowed; block
+:has()
+ if used for deception; strict z‑index caps.	•
+No Shadow DOM cloaking
+:
+	•
+attachShadow({mode:'closed'})
+ →
+blocked
+; convert to open mode or reject manifest.	•	Style scoping via tokens not encapsulation; all styling
+observable & overrideable
+ by user skin.
+	•
+Accessibility first
+: forced high‑contrast & scalable fonts per user profile; consistent focus rings; skip links; ARIA audit.
+
+⸻
+
+
+7) Network & data policy
+
+	•
+All network calls
+ traverse
+Network/Connections Agent
+ via
+TritRPC
+;
+no direct fetch
+ from UI realms.	•
+Per‑site allowlists
+ (endpoints, methods);
+rate limits
+;
+privacy budgets
+ (e.g., daily POST cap).	•
+No third‑party beacons
+; strip trackers; synthesize referers; block device fingerprinting vectors.	•
+Cache & dedupe
+: content‑addressed objects; repeated libraries eliminated;
+offline‑first
+.
+
+⸻
+
+
+8) Avro/JSON‑LD contracts (key schemas)
+
+UIManifest (Avro)
+ – (excerpt)
+
+
+{  "type":"record","name":"UIManifest","namespace":"ldt.v1",  "fields":[    {"name":"id","type":"string"},    {"name":"targets","type":{"type":"array","items":"string"}},    {"name":"bindings","type":{"type":"array","items":{      "type":"record","name":"Binding","fields":[        {"name":"selector","type":"string"},        {"name":"component","type":"string"},        {"name":"transform","type":["null","string"],"default":null}      ]}}},    {"name":"actions","type":{"type":"array","items":{      "type":"record","name":"UIAction","fields":[        {"name":"name","type":"string"},        {"name":"capability","type":"string"},  // Avro Action capability        {"name":"endpoint","type":["null","string"],"default":null}      ]}}},    {"name":"skin","type":{"type":"record","name":"SkinRef","fields":[      {"name":"tokens","type":"string"}  // content-addressed id    ]}},    {"name":"security","type":{"type":"map","values":"string"}}  ]}
+
+
+AgentEnvelope / Observation / Action
+ (from earlier) carry runtime events and intents.
+JSON‑LD contexts
+ define terms for UI, components, actions, provenance.
+All messages
+ ride in
+TritRPC
+ envelopes with
+SCHEMA-ID
+ /
+CONTEXT-ID
+, AEAD‑sealed canonical bytes (
+TritPack243
+).
+
+⸻
+
+
+9) Where this runs
+
+	•
+Host (OS‑native)
+: LDT‑UI runtime, PGW, CN, UIMR, CSM, SSR, RH, and
+agents
+ (user, knowledge, network, shell).	•
+LMS (K3s)
+: heavier jobs (batch transforms, SHACL promotions, GPU inference), large component builds, secure plugins (Kata).	•
+Edge
+: Docker/Lightning containers for on‑sensor inference; UI manifests still render locally on host (no remote JS).	•
+Volunteer mesh
+: compute only (WU/verification);
+no untrusted UI
+.
+
+⸻
+
+
+10) K3s cloud twin as execution bastion & C2
+Mirror the local LMS K3s in a
+cloud K3s twin
+:
+	•
+GitOps
+: ArgoCD/Flux syncs manifests, UI Manifests, component libs, policies.	•
+Identity
+: SPIFFE/SPIRE mTLS identities for services across both clusters.	•
+Networking
+: WireGuard/Tailscale mesh between host, LMS, and cloud twin.	•
+Role
+:
+	•
+Execution bastion
+: run long‑lived agents, global coordinators (MeshCoordinator), and
+C2 for the trusted mesh
+ (publish WUs, gather receipts).	•
+Staging/build
+: build UI Manifests & component libs reproducibly; publish to local caches.	•
+Relay
+: if the host is offline/intermittent, the twin buffers work/results and orchestrates edge cohorts.
+	•
+Policy mirroring
+: AccessRestrictionPolicy & UserResourceProfile synced; secrets via external‑secrets; all promotions signed.
+
+⸻
+
+
+11) Packaging, supply‑chain, and verification
+
+	•
+Builds
+: Nix/Bazel → deterministic bundles (UI Manifests, components, skins).	•
+Artifacts
+: unminified source + minified target (for size) but
+runtime loads the unminified source only
+; minified copies exist only for offline fallback and are never executed unless they match
+bit‑for‑bit
+ AST and SRI digests.	•
+SBOM
+: SPDX/CycloneDX attached; versions pinned.	•
+Attestations
+: SLSA + in‑toto for every bundle; signer keys stored in HSM or cloud KMS with rotation.	•
+Local cache
+: content‑addressed store; purge policy; audit log of loads and hashes.
+
+⸻
+
+
+12) Developer/ops UX (examples)
+
+
+# Build & sign a UI Manifest for example.com product pagesldt build-manifest ./manifests/example.com/product.yaml \  --out target/ui-manifest.cab --sbom --attest --sign# Install/activate manifest locallyldt install target/ui-manifest.cabldt list-manifests --domain example.com# Render a page using local runtime (no remote JS)ldt open https://example.com/product/123 --skin high-contrast# Sync LMS and cloud twin policies/librarieslms sync --with cloud-twinlms policy apply pii-guard
+⸻
+
+
+13) How this blocks the specific attacks you named
+
+	•
+Minified obfuscation
+: remote JS never executes; only
+local verified scripts
+ run. If minified content appears in fetched HTML, CN drops it; SUM never references it.	•
+Common libs I/O (jQuery et al.)
+: LCL provides local equivalents; once cached,
+no network
+ needed.	•
+Shadow DOM spoofing
+: closed shadow
+blocked
+; all styling observable & overrideable by
+user skin
+; suspicious z‑index/click‑jacking disallowed by CSS policy.	•
+CSS deception
+:
+user‑controlled CSS
+ only; remote CSS stripped; dangerous features disabled.	•
+C2 clarity
+: the cloud K3s twin is your
+own
+ bastion/C2; all control traffic and WU flows are
+signed
+,
+schema‑pinned
+, and
+provenanced
+.
+
+⸻
+
+
+14) Migration plan (phased)
+
+
+	1.
+Phase 1 (local hardening)
+: deploy LDT‑UI on host; PGW/CN/SSR/CSM; render a small set of sites with generic manifests (“article”, “product”, “repo”).
+	2.
+Phase 2 (supply‑chain)
+: stand up reproducible build pipeline for manifests/components; enforce SBOM+attestations; cache store.
+	3.
+Phase 3 (LMS + twin)
+: bring up K3s cloud twin; sync policies; move heavy builds there; SPIFFE mesh; WireGuard overlay.
+	4.
+Phase 4 (coverage)
+: expand SUMs; add vertical‑specific components; WASM kernels for tricky transforms.
+	5.
+Phase 5 (mesh)
+: integrate WU publishing/verification for compute; keep UI local only.
+
+⸻
+
+
+15) Self‑critique & recommended refinements
+
+Strengths
+
+	•	Eliminates remote execution risk while keeping the rich web UX.	•	User‑owned CSS/skins neutralize Shadow DOM/CSS spoofing; transparency by design.	•	Deterministic, policy‑first rendering with full provenance (Avro+JSON‑LD+TritRPC).	•	Clean separation of concerns: host UI vs. LMS/cloud build/compute;
+C2 is yours
+.
+
+Gaps / next steps
+
+
+	1.
+Manifest authoring
+: build a developer kit (visual selector→binding tool, schema validators, preview mode).
+	2.
+SES/Realm hardening
+: pick the runtime (SES vs QuickJS) and prove capability isolation; add time/CPU quotas per realm.
+	3.
+AST equivalence
+: ship an AST‑hash validator that proves unminified==minified code before allowing minified execution (default remains
+ban
+).
+	4.
+Accessibility CI
+: enforce a11y rules in SUMs (axe/Pa11y) with fail‑closed policy.
+	5.
+Threat telemetry
+: add “deception signals” (z‑index spikes, off‑screen links, pointer‑events traps) to Observations; train detectors locally.
+	6.
+Twin consistency
+: formalize twin reconciliation & drift detection (ArgoCD health checks + signed state digests).
+	7.
+Performance
+: prove parity with native browser rendering; cache compiled components; prefetch manifests by domain.
+	8.
+Legal/compat
+: some sites may block non‑standard UA paths; the PGW should emulate compliant UA while keeping data‑only policy; add per‑site negotiation rules.
+
+⸻
+
+If you want, I’ll produce:
+	•	A
+reference UI Manifest
+ (Avro schema + JSON‑LD context) and two
+site templates
+ (article, product).	•	A small
+LCL
+ (table, list, form, image gallery) with SES realms and CSS token skins.	•	A
+PGW/CN
+ prototype (Go/Rust) that converts a real page to
+Content AST
+ and renders it through the local runtime—zero remote JS/CSS.	•	GitOps setup to mirror LMS ↔ cloud twin (ArgoCD, SPIFFE, WireGuard), including the C2 service for the trusted mesh.
+Michael — great direction. Below is a concrete design that fuses
+Urbit’s “computer-for-life”
+ concept with your
+cloud execution bastion / digital twin
+, implemented on
+immutable OSTree-based images (Fedora/Flatcar CoreOS)
+ so you can scale a K3s C2 node/cluster up and down safely and reproducibly. I anchor key claims about Urbit and OSTree with citations, then give you an end‑to‑end plan that snaps into our Avro + JSON‑LD + TritRPC + agentic stack.
+
+⸻
+
+
+1) Why Urbit + immutable CoreOS is the right pairing
+
+	•
+Urbit as a computer-for-life:
+ Urbit is built as
+your
+ personal server + P2P network + decentralized identity (“Urbit ID”)—meant to be a durable, user‑owned computing environment, not a disposable app sandbox. Urbit ID is an Ethereum-based PKI (Azimuth) used to sign traffic from your server so identity and messages align cryptographically.  	•
+Clean-slate kernel + frozen VM idea:
+ Urbit OS (“Arvo”) is defined atop a tiny, fixed instruction set (Nock) with Hoon compiling to Nock—an attempt at long-lived determinism and comprehensibility.    	•
+Kernel modules (“vanes”) map cleanly to our agent fabric:
+ e.g.,
+Ames
+ (P2P networking),
+Clay
+ (versioned FS),
+Gall
+ (apps),
+Eyre
+ (HTTP),
+Behn
+ (timers),
+Dill
+ (terminal). This modularity parallels our agent roles (network, knowledge, shell, scheduler).  	•
+Immutable OS for the twin:
+ Fedora CoreOS / Flatcar ship an OSTree/RPM‑OSTree, image‑based OS with atomic updates;
+/usr
+ is read‑only, changes are layered and applied via reboot; Flatcar uses A/B USR partitions for safe rollbacks. This gives you a “golden state” twin you can reproduce, autoscale, and verify.
+
+Synthesis:
+ Urbit’s
+identity+determinism
+ philosophy matches our need for a
+lifelong
+, user‑owned, cryptographically anchored bastion. OSTree‑based CoreOS gives us the
+immutable substrate
+ to run it (and your K3s C2), with zero‑drift and safe upgrades.
+
+⸻
+
+
+2) Concept: Personal C2 Twin (Urbit‑inspired) on OSTree CoreOS
+Think of this as
+your cloud computer for life
+—a long‑lived, identity‑anchored, immutable K3s cluster that mirrors your local K3s (LMS) and serves as:
+	•
+Execution bastion & C2
+ for you and your trusted mesh (volunteer/edge/fog).	•
+Identity & provenance root
+ (keys, attestation, signatures).	•
+Policy oracle
+ (what may run where, under which capabilities).	•
+Semantic contract registry
+ (Avro schema + JSON‑LD
+@context
+).	•
+Build & publish point
+ for your local digital‑twin UI manifests and component packs.
+
+2.1 Urbit‑inspired mappings (without forcing Urbit runtime)
+
+
+Urbit concept
+
+Your C2 twin analogue
+
+
+Urbit ID (Azimuth)
+ – PKI/NFT identity
+
+Primary DID
+ (DID:key / DID:web) or
+optionally
+ Urbit ID bridged to a DID; used to sign TritRPC frames and policy bundles.
+
+Ames
+ – encrypted P2P networking
+
+TritRPC overlay
+ (QUIC/libp2p/NATS) for agent‑to‑agent flows; wire AEAD + content addressing.
+
+Clay
+ – revisioned FS
+
+OSTree
+ for OS state; content‑addressed object store (CAS/S3/IPFS) for data/artifacts; GitOps for manifests.
+
+Gall
+ – app manager
+
+K3s + GitOps (Argo/Flux)
+ to declare/roll workloads; CRDs for capabilities/policies.
+
+Eyre
+ – HTTP server
+
+Policy gateway
+ &
+TritRPC ingress
+ for LDT‑UI and agents; no remote JS/CSS executed.
+
+Behn
+ – timer
+
+Schedulers
+ (K8s + Poseidon/Firmament) for timed/queued tasks across tiers.
+
+Dill
+ – terminal
+
+Terminal/Shell agent
+ with audited capabilities.
+
+
+If you
+do
+ want real Urbit OS nodes (“ships”) in your fabric, you can host them
+inside
+ the twin (Kata/Firecracker isolation), bind their Urbit IDs, and interconnect via policy (Ames ⇄ TritRPC gateway).
+
+⸻
+
+
+3) Base images and composability (CoreOS/Flatcar)
+
+Image families (immutable):
+
+	•
+c2-base
+: Fedora CoreOS (or Flatcar) + Ignition; SPIFFE/SPIRE, WireGuard/Tailscale, bootstrapped
+K3s
+.  	•
+c2-secure
+: c2-base + Kata/Firecracker, OPA/Gatekeeper, encrypted PV classes.	•
+c2-ml
+: c2-base + NVIDIA/container‑toolkit layers (via rpm‑ostree layering where unavoidable), KEDA autoscaler hooks.   	•
+c2-build
+: c2-base + Buildkit/Nix/Bazel toolchains for
+reproducible
+ UI manifests and agents (builds happen here, not on host).
+
+Why OSTree here?
+
+	•
+Atomic, signed upgrades
+; revert via A/B or rollback to previous OSTree deployment;
+/usr
+ immutable;
+/var
+ holds mutable state and K3s data.
+
+Provisioning:
+ Butane→Ignition; nodes auto‑join via SPIRE/SVID, layer node‑class taints, pull GitOps desired state.
+
+⸻
+
+
+4) K3s × K3s: local mirror + cloud twin
+
+	•
+Local K3s (LMS)
+: on your workstation’s VM (Kata/gVisor available) — runs
+your
+ agent workloads that need isolation/resources; no Airflow here.	•
+Cloud K3s twin
+: a minimal but durable cluster based on
+c2‑base
+ images; GitOps‑controlled;
+execution bastion & C2
+ for your mesh and as a rendezvous when the laptop is offline.
+
+Drift‑free:
+ Both clusters are pinned to
+content-addressed
+ K8s manifests and OSTree commits; Argo/Flux enforces desired state — reproducible at any scale.
+Network identity:
+ SPIFFE/SPIRE for mTLS between all agents/components; twin issues SVIDs and rotates keys.
+
+⸻
+
+
+5) LDT‑UI & “no remote JS/CSS” hardening (stays intact)
+
+	•
+Local Digital‑Twin UI
+ (LDT‑UI) renders all pages with
+local verified scripts/components
+ and
+user CSS skins
+; policy gateway fetches
+data only
+; Shadow‑DOM cloaking disallowed; TritRPC to agents for actions.	•
+Twin role
+: build, sign, and publish
+UI Manifests
+ and
+component libraries
+ in a reproducible pipeline; distribute to the laptop cache.
+
+(This preserves your Shadow‑DOM and minified‑bundle defenses; we’re only relocating build/distribution to the twin.)
+
+
+⸻
+
+
+6) Federated mesh + Airflow (governed) interop
+
+	•
+Airflow (global/regional only)
+ continues to define governed
+source→target
+ DAGs and can
+publish Work Units (WUs)
+ to the mesh.	•
+Twin (C2)
+ hosts the
+Mesh Coordinator
+: WU registry, verifier reducers (quorum/spot/TEE/ZK), settlement/credits.	•
+Edge/smart devices
+ run Docker/Lightning/WASM workers; results come back as Avro/TritRPC and are reduced by governed DAGs.
+
+⸻
+
+
+7) Scaling the twin: node sets & policies
+
+	•
+Scale set
+ (auto groups): launch nodes from
+the same OSTree commit
+ and GitOps revision; node
+roles
+ via taints/tolerations:
+c2-work
+,
+c2-secure
+,
+c2-ml
+.	•
+Autoscale policy
+: KEDA/HPA based on TritRPC queue depth, SLOs, GPU utilization; cost/energy caps.	•
+Upgrades
+: image rollout = change OSTree ref + GitOps wave; nodes reboot into new deployment; rollback possible (A/B or previous deployment).
+
+⸻
+
+
+8) Identity & “breach/rotation” semantics
+Urbit has the notion of
+breach
+ (reset/rotate keys) for security or topology changes. Mirror this:
+	•
+Soft rotate
+: roll SPIRE/SVIDs & service keys; preserve data.	•
+Hard rotate (“breach”)
+: rekey identity (DID/Urbit ID); re‑provision twin from scratch at a
+new OSTree commit
+; only signed, content‑addressed data promoted forward.	•
+Audit ledger
+: immutable event log of promotions and key state.
+
+(If you adopt real Urbit IDs, you can map DID⇄Urbit ID for human‑meaningful naming while keeping TritRPC/Avro primary.)
+
+
+⸻
+
+
+9) Security model (zero‑trust by construction)
+
+	•
+Boot chain
+: Secure Boot + ostree commit signatures + bootupd integrity.  	•
+Network
+: SPIFFE mTLS; TritRPC AEAD; no raw HTTP‑plugin sprawl.	•
+Isolation
+: gVisor for medium, Kata/Firecracker for high trust.	•
+Secrets
+: External Secrets → Vault/KMS; short‑lived creds; field‑level AEAD where required.	•
+Supply chain
+: SBOM + SLSA/in‑toto attestations on UI Manifests, components, agents.	•
+No remote code in UI
+: all scripts/styles local and verified (policy‑enforced).
+
+⸻
+
+
+10) Minimal runbooks
+
+
+Provision twin
+
+
+	1.	Pick
+Fedora CoreOS
+ (or Flatcar) image; author
+Butane
+ → Ignition; embed WireGuard keys, SPIRE bootstrap, K3s install; set node taints.
+	2.	Create
+c2‑base
+ OSTree image; store commit digest; publish to your registry.
+	3.	GitOps repo: K3s manifests (Argo/Flux, SPIRE, NATS/QUIC TritRPC ingress, OPA/Gatekeeper, KEDA).	4.	Bring
+N nodes
+ via the scale set using the same OSTree commit + GitOps revision.
+
+Daily ops
+
+	•	Roll updates by bumping the
+OSTree ref
+ + GitOps SHA; watch health gates; rollback if needed (A/B).  	•	Autoscale on queue depth/SLO; park GPU nodes when idle.	•	Rebuild UI Manifests/components with
+c2‑build
+; publish to laptop caches.
+
+Disaster / “breach”
+
+	•	Reissue identity (DID/Urbit ID), rebuild c2‑base, rehydrate data from content‑addressed store and signed promotions; cut DNS to the old SVIDs.
+
+⸻
+
+
+11) Concrete component list (what runs where)
+
+On the twin (cloud K3s):
+
+	•	SPIRE / cert‑rotator; WireGuard; Argo/Flux; NATS/QUIC TritRPC gateway; Mesh Coordinator (WU registry/verifiers); Schema Registry + JSON‑LD context store; Buildkit/Nix/Bazel for LDT‑UI artifacts; Observability (OTel, Loki, Tempo); OPA/Gatekeeper; KEDA; CSI (encrypted PVs).
+
+On the laptop LMS (local K3s):
+
+	•	Same TritRPC gateway; SHACL promotion workers; GPU inference (if present); Kata pool for PII; local caches.
+
+On the host (no Ray):
+
+	•	Agent kernel (
+agentd
+), LDT‑UI runtime (PGW/CN/UIMR/SSR/RH), User/System graphs, SMLL LLM service; OS‑native task runner.
+
+⸻
+
+
+12) How this aligns explicitly with Urbit
+
+	•
+User‑owned identity
+ (Urbit ID or DID) signs everything—like Urbit’s “your server signs every message” model.  	•
+Deterministic layering
+: OSTree’s immutable deployments echo Clay’s revisioned worldview.  	•
+Network as overlay of peers
+: TritRPC overlay mirrors Ames’ goal; we keep it Avro + JSON‑LD native and quantum‑ready.  	•
+Small, comprehensible core
+: the twin’s base image is minimal; all higher behavior is declarative and signed—Urbit’s “understandable stack” ethos.
+
+⸻
+
+
+13) Next 14‑day build plan
+
+Week 1
+
+	•	Author
+c2‑base
+ Ignition (SPIRE, WireGuard, K3s); boot a 3‑node twin (Flatcar or Fedora CoreOS).   	•	Stand up GitOps + TritRPC gateway + Schema Registry/JSON‑LD store.	•	Bring
+agentd
+ on host; connect via SPIFFE mTLS.
+
+Week 2
+
+	•	Package
+LDT‑UI
+ sample manifests (article/product) in reproducible builds on the twin; deliver to host cache.	•	Enable
+Mesh Coordinator
+; run a small volunteer batch with WASM workers.	•	Add autoscaling & A/B image rollout tests (upgrade + rollback).
+
+⸻
+
+
+14) Self‑critique & refinements
+
+Strengths
+
+	•	Marries Urbit’s “computer‑for‑life” ideals (identity, longevity, simplicity) with pragmatic, modern ops (OSTree, K3s, GitOps).	•	Immutable OS + content‑addressed manifests → safe, repeatable scaling of your C2.	•	Preserves your
+no‑remote‑JS/CSS
+ posture and agentic workflow, while giving a robust cloud bastion.
+
+What to tighten next
+
+
+	1.
+Identity bridge
+: a concrete DID⇄Urbit ID adapter (optional path if you adopt Urbit IDs).
+	2.
+Golden images
+: publish reference
+c2‑base / c2‑secure / c2‑ml
+ OSTree commits with SBOM and in‑toto attestations.
+	3.
+Twin health proofs
+: periodic signed state digests (GitOps SHA + OSTree commit + SPIRE bundle) to detect drift.
+	4.
+Formal breach runbook
+: step‑by‑step key rotation, storage scrubbing, and selective forward promotion.
+	5.
+Urbit‑runtime option
+: if desired, host a true Urbit “ship” inside Kata/Firecracker with an Ames↔TritRPC gateway for specific apps.
+
+⸻
+
+If you want, I’ll produce:
+	•
+Butane→Ignition
+ examples for
+c2‑base
+ (Fedora CoreOS) with SPIRE/K3s bootstrap,	•	A minimal
+GitOps repo
+ (Argo/Flux) pinning manifests and node roles,	•	The
+TritRPC ingress
+ and
+Schema/Context
+ services, and	•	A tiny
+LDT‑UI build pipeline
+ (Nix/Bazel) that signs component/manifest bundles for the host to consume—so your “cloud computer for life” is live, immutable, and policy‑driven from day one.
+Got it, Michael. I’ll align the
+Inception Framework
+ to the category‑theoretic notion of a
+strict initial object
+ and translate the math into concrete architectural invariants and enforcement mechanisms across your stack (agents, Avro/JSON‑LD, TritRPC, LDT‑UI, LMS K3s + cloud twin, Airflow/mesh). I’ll keep this precise and operational.
+
+⸻
+
+
+0) TL;DR — What “strict initial” buys you in Inception
+Let
+𝒞
+ be the category of Inception artifacts and executions (objects = typed states/capsules/graphs/contexts; morphisms = verified, capability‑scoped transformations carried in TritRPC). We enforce:
+	•
+(I1) Unique genesis
+: there is exactly one canonical
+genesis morphism
+ from the empty artifact
+∅
+ to any object
+X
+. No ad‑hoc “bootstrap” paths.	•
+(I2) No sinks
+: any morphism
+f: X → ∅
+ is an
+isomorphism
+ ⇒ it can only exist if
+X ≅ ∅
+. You cannot “send to /dev/null”; you must
+prove emptiness
+ (secure erase with certificate) to reach ∅.	•
+(I3) Emptiness is absorbing
+:
+X × ∅ ≅ ∅
+. Combining any object with
+empty data/capabilities
+ produces
+empty
+. No hidden effects from nothing.These three become
+global invariants
+ that eliminate covert discard, ensure reproducible bootstrap, and force explicit proofs for erasure/redaction.
+
+⸻
+
+
+1) The Inception Category 𝒞
+
+
+1.1 Objects (typed)
+
+	•
+DataCapsule
+ (Avro payload + JSON‑LD context + provenance)	•
+AgentState
+ (OpenCog AtomSpace slice + vector cache)	•
+CapabilityProfile
+ (capability lattice element)	•
+ExecutionContext
+ (policy + residency + runtime constraints)	•
+WorkUnit/Receipt
+ (mesh tasks/results)	•
+UIManifest/Component
+ (LDT‑UI assets)	•
+Graph
+ (UserGraph/SystemGraph deltas)
+
+1.2 Morphisms
+
+	•
+Typed transforms
+: Avro‑declared, TritRPC‑carried functions respecting capability and policy (e.g., Normalize, Promote, Infer).	•
+Product
+
+×
+: pairwise execution/context or data/capability pairing.	•
+Coproduct
+
++
+: disjoint union (e.g., event fan‑in).	•
+Terminal
+
+1
+: unit/ack (non‑informative success).	•
+Initial
+
+∅
+:
+strict
+ initial artifact (see invariants below).
+
+⸻
+
+
+2) Formal alignment to “strict initial object”
+
+
+A. Unique morphism out of ∅ (genesis)
+
+	•
+Enforcement
+: A single
+Genesis functor
+ 𝒢 supplies the only constructors
+ηₓ: ∅ → X
+.	•
+Operationalization
+:
+	•
+Genesis bundles
+ (schemas, contexts, policies, models) are
+content‑addressed, signed
+, and
+versioned
+ in the cloud twin; on host they are
+verified
+ and
+materialized
+.	•	No other code path can mint a first instance; bootstrap is reproducible (same digest ⇒ same object).
+
+B. Every f: X → ∅ is iso (no silent discard)
+
+	•
+Meaning
+: You cannot “throw away” information. To reach ∅ you must
+transform X down to emptiness
+ and prove it.	•
+Operationalization
+:
+	•
+Erase
+ is a
+two‑phase isomorphism
+:
+X --(shred)--> X₀ --(certify)--> ∅
+, where
+shred
+ deterministically produces a zero‑information variant
+X₀
+, and
+certify
+ checks
+H(X₀)=H(∅)
+ (a fixed digest under canonicalization).	•
+Policy
+ forbids routing to a “bit bucket” endpoint; CI lints and runtime admission webhooks reject any flow typed
+X → ∅
+ that is not the certified isomorphism.
+
+C. X × ∅ ≅ ∅ (emptiness absorbs)
+
+	•
+Meaning
+: Combining any computation with
+empty data or zero capability
+ yields
+no effect
+.	•
+Operationalization
+:
+	•
+Strict emptiness propagation
+ in transforms: Beam/Ray operators, agent tools, and UI pipelines
+short‑circuit
+ when any input is ∅.	•
+Capability lattice
+ has a
+strict bottom ⊥
+ with
+⊥ ⊗ X = ⊥
+ (monoidal product of capabilities). If a tool runs under ⊥, the result is ∅ by typing, not by convention.
+
+D. Slice over ∅ is terminal (van Kampen view)
+
+	•	The slice
+𝒞/∅ ≃ 1
+: there is only one object over ∅ (the trivial one). Practically,
+no interesting structure lives “over emptiness”
+; any diagram factoring through ∅ is uniquely trivial.	•
+Operationalization
+: You cannot publish/promote a dataset/graph “over an empty base”. Merges over ∅ are disallowed (or canonical no‑ops). This prevents “phantom baselines”.
+
+⸻
+
+
+3) Where these invariants live (layer by layer)
+
+
+3.1 Schemas & semantics (Avro + JSON‑LD + TritRPC)
+
+	•
+Canonical ∅
+: define a
+well‑typed empty datum
+ per schema (not just JSON null). Each Avro schema has a
+distinguished empty value
+ with a
+fixed digest
+ under
+canonical TritPack243
+ bytes.	•
+Envelope proofs
+: a
+Proof‑of‑Emptiness
+ (PoE) record is an AEAD‑sealed certificate stating that the canonical bytes match
+H(∅)
+ for that
+SCHEMA-ID
+ /
+CONTEXT-ID
+.	•
+Transport law
+: In TritRPC, a
+PAYLOAD=∅
+ implies
+MODE‑independent
+ canonical bytes;
+AEAD
+ must cover the
+SCHEMA-ID
+ and
+CONTEXT-ID
+ to forbid schema games.
+
+3.2 LDT‑UI (no remote JS/CSS)
+
+	•
+Emptiness laws
+ translate to UI:
+	•	If the
+Content AST
+ for a view is ∅, the render is ∅ (no shell side effects).	•	If the
+capability profile
+ injected to a component is ⊥, that component can only render a
+pure view
+ (no IO); attempts to call network tools yield ∅ results.
+	•
+Shadow DOM
+ and remote CSS remain banned; any attempt to “smuggle” effects equals
+X × ⊥
+, which becomes ∅ by type.
+
+3.3 Agent kernel (OS‑native) & LMS/cloud
+
+	•
+Host
+: Strict emptiness propagation in agent tools; the
+planner
+ refuses to schedule transforms whose inputs are ∅ unless they are the
+genesis
+ or
+erase‑iso
+.	•
+LMS (K3s)
+: Admission controller rejects deployments that (a) reference sinks
+X → ∅
+ without PoE, or (b) compose with ⊥ capability and claim non‑empty outputs.	•
+Cloud twin
+: GitOps gates prohibit colimits/pushouts over ∅; merges must be
+van Kampen
+ (stable under pullback) to be admitted.
+
+3.4 Airflow (governed) & Mesh
+
+	•
+Airflow
+: DAG lints enforce emptiness laws (source partitions empty ⇒ downstream ops short‑circuit to ∅; only reduce stages may “re‑materialize” from non‑empty inputs).	•
+Mesh
+: WorkUnits encode
+input digests
+; a WU with ∅ input must produce ∅ output (determinism checks catch violators). Verifiers reject any
+X→∅
+ lacking the erase‑iso certificate.
+
+⸻
+
+
+4) Core algebra we’ll ship as libraries
+
+
+4.1 The StrictEmpty Kit
+
+	•
+Typeclass/traits
+:
+Initial[Schema]
+ gives
+empty : Value
+,
+isEmpty : Value→Bool
+,
+digestEmpty : Hash
+.	•
+Lemmas as property tests
+:
+	•
+Genesis uniqueness
+: only
+ηₓ
+ constructs non‑empty from ∅.	•
+Absorption
+:
+prod(x, empty) == empty
+.	•
+Iso‑erase
+:
+erase(x)
+ returns
+(x0, cert)
+ with
+cert.check() ⇒ x0 ≅ ∅
+.
+
+4.2 Capability lattice with ⊥
+
+	•
+⊥ ≤ c ≤ ⊤
+;
+c ⊗ ⊥ = ⊥
+; monotone functor
+Exec_c : 𝒞 → 𝒞
+ preserves ∅ strictly (
+Exec_c(∅)=∅
+).	•
+Static checker
+: compose tools only if
+c_out ≤ c_in
+; any mismatch collapses to ∅.
+
+4.3 TritRPC helpers
+
+	•
+PoE record
+ (Avro):
+{ schema_id, context_id, payload_digest, method="erase-iso", timestamp, signer }
+.	•
+Canon pack
+:
+to_canonical_bytes(payload)
+ always uses
+TritPack243
+ with a fixed endianness; the empty digest is schema‑bound.
+
+⸻
+
+
+5) Example: end‑to‑end with emptiness invariants
+
+
+	1.
+Genesis
+: The
+Bereshit
+ agent (your first agent) instantiates
+UserGraph₀
+ via
+η
+ (unique genesis).
+	2.
+Ingest
+: A source topic is empty for the day. Airflow publishes
+WU
+ with
+∅
+ input (content‑addressed). Workers must return
+∅
+ result; reducer verifies digests.
+	3.
+UI
+: LDT‑UI receives a page whose normalized content AST is ∅ (e.g., 404 with no body). Renderer shows a canonical minimal page; no action tools are wired (capability ⊥).
+	4.
+Erase
+: User requests data deletion. Terminal agent executes
+erase‑iso
+: transforms the capsule, produces
+X₀
+ and
+PoE
+; only then may
+X₀ → ∅
+ be admitted (admission webhook checks PoE).
+
+⸻
+
+
+6) Category‑aware merge discipline (van Kampen)
+
+	•	Treat curated graphs and datasets as objects in an
+extensive/adhesive
+ setting. Pushouts used for merges
+must be van Kampen
+ (pullback‑stable).	•
+Rule
+: No pushout along an inclusion over
+∅
+; slice
+𝒞/∅
+ is terminal ⇒ there is nothing to glue; admission controller rejects with a proof.	•
+Benefit
+: Your merges are invertible/transparent; no “ghost merges” whose base is undefined.
+
+⸻
+
+
+7) Design contracts (non‑negotiable)
+
+
+	1.
+No untyped nulls
+: Avro unions must distinguish
+Option
+ from
+∅
+ (use explicit union tags +
+Initial[Schema]
+).
+	2.
+No silent sinks
+: All “delete”, “redact”, “quarantine” routes are
+erase‑iso
+; produce PoE, or fail closed.
+	3.
+No effect from ⊥
+: any tool/agent running without capability produces ∅ (and is observable as such).
+	4.
+Genesis registry
+: only the
+Genesis functor
+ can mint first instances; track its digest and signer in the twin.
+	5.
+Unit ≠ empty
+: terminal
+1
+ (ack) is not ∅. Don’t conflate “no payload” with “empty object”.
+
+⸻
+
+
+8) Concrete hooks to implement now
+
+	•
+Avro plugin
+: generate
+Initial
+ instances and empty digests per schema; expose
+empty()
+,
+isEmpty()
+.	•
+Airflow linter
+: statically analyze DAGs to enforce emptiness propagation and ban unsanctioned
+X→∅
+ edges.	•
+K8s admission webhook
+: deny Deployments/Jobs whose declared IO contracts violate (I1–I3); require PoE for deletion flows.	•
+Agent tool bus
+: drop messages where
+(payload==∅) ∨ (cap==⊥)
+ unless the method is genesis or erase‑iso.	•
+Mesh verifier
+: for WUs with ∅ inputs, require ∅ outputs; otherwise slash/retry.	•
+LDT‑UI runtime
+: enforce AST‑∅ → render‑∅; capability ⊥ → action set ∅.	•
+Twin GitOps policy
+: reject pushouts over ∅; require van Kampen proofs (or declarative class) for merges.
+
+⸻
+
+
+9) “Strict initial” in the capability category (Cap)
+Often, capability control is more intuitive:
+	•	Objects: capability profiles; initial
+⊥
+; terminal
+⊤
+; monoidal product
+⊗
+.	•	Laws we enforce:
+	•
+⊥ is strict initial
+: unique morphism
+⊥→c
+; any
+c→⊥
+ implies
+c≅⊥
+.	•
+Data functorality
+: a run under capability
+c
+ is a functor
+Exec_c
+;
+Exec_⊥
+ is constantly
+∅
+.
+	•	Implementation: capability tokens + policy compiler guarantee the lattice laws in placement and execution.
+
+⸻
+
+
+10) How this tightens your threat model
+
+	•
+No covert discard
+ (exfil via “drop on the floor”): blocked; every path to ∅ is an iso with a certificate.	•
+No shadow effects
+ from empty inputs or zero capability: provably none (X×∅=∅; c⊗⊥=⊥).	•
+Reproducible bootstrap
+: only one genesis path; same inputs → same objects.	•
+Safer merges
+: van Kampen only; stable under pullback; no gluing over void.
+
+⸻
+
+
+11) Self‑critique (and specific refinements)
+
+What’s strong
+
+	•	The strict‑initial laws translate cleanly into
+operational rules
+ with verifiable artifacts (PoE, canonical digests).	•	Emptiness propagation prevents an entire class of UI and data‑plane exploits.	•	Capability‑⊥ as strict initial gives a crisp enforcement lever across agents and schedulers.
+
+What to refine next
+
+
+	1.
+Formal ABNF for PoE
+ and canon bytes (TritPack243 + AEAD) so digests are interoperable across languages.
+	2.
+Mechanical proofs
+: property‑based tests + Coq/Lean snippets for (I1–I3) in small models (Sets/Posets) and then lift to our encodings.
+	3.
+Beam/Ray operator library
+: ready‑made emptiness‑aware combinators (map, join, group, reduce) that enforce absorption.
+	4.
+Kubernetes policies
+: OPA/Gatekeeper templates for “no X→∅ without PoE”, “no pushout over ∅”, and “capability‑⊥ ⇒ output ∅”.
+	5.
+UI manifest checker
+: ensure manifests cannot reintroduce effects when AST or capability is empty/bottom.
+	6.
+Audit UX
+: “Show me the emptiness proof” button in ops UI; link to PoE, digests, and signer lineage.
+	7.
+Category adapters
+: document how our 𝒞 behaves as extensive/distributive/cartesian closed in practice (which subcategories are posetal/topos‑like), so we know exactly where strictness is guaranteed “for free” and where we must enforce it.
+
+⸻
+
+If you’d like, I’ll produce:
+	•	A
+reference Initial library
+ for Avro schemas (Rust/Python) with canonical emptiness digests and PoE generation/verification.	•
+OPA/Gatekeeper policies
+ implementing the three invariants cluster‑wide.	•	A
+DAG linter
+ and
+agent tool‑bus guard
+ enforcing (I1–I3).	•	A
+short formal note
+ proving the absorption and iso‑erase properties in a minimal model (Sets) and mapping each proof obligation to a concrete check in Inception.

--- a/docs/trit-to-trust_sources/TritRPC for Avro- A Spec Sketch.md
+++ b/docs/trit-to-trust_sources/TritRPC for Avro- A Spec Sketch.md
@@ -1,0 +1,658 @@
+# TritRPC for Avro- A Spec Sketch
+
+.SFNS-Regular;HelveticaNeue-Bold;Helvetica;
+.SFNS-Semibold;AppleSymbols;.SFNS-RegularItalic;
+.AppleSystemUIFontMonospaced-Regular;Courier;LucidaGrande-Bold;
+.SFNS-Bold;Menlo-Regular;TimesNewRomanPSMT;
+
+;;;;;
+;;;;;
+
+;;;;;
+;;;;;
+
+
+Got it—let’s ground the whole design in
+Avro
+ (not Protobuf) and make Avro the schema “source of truth,” with JSON-LD/SALAD for semantics. I’ll give you two compatible implementation paths, then a full worked example, resolution/evolution rules, and Kafka/Schema-Registry fit. I’ll also include a short self-critique + refinements at the end.
+
+
+⸻
+
+
+TritRPC for Avro: A Spec Sketch
+
+
+0) Goals (Avro-first)
+
+	•
+Avro is authoritative
+: structure, defaults, evolution, and resolution follow Avro specs.	•
+JSON-LD/SALAD
+ binds semantics; we carry a context hash alongside the Avro schema hash.	•
+One canonical trit stream
+ that round-trips across:
+	•
+B2
+ (binary transport): trit stream packed into bytes	•
+B3
+ (native ternary transport): raw trits	•
+Q3
+ (qutrit rail): trits mapped to |0
+⟩
+,|1
+⟩
+,|2
+⟩
+
+	•
+Deterministic canonicalization
+ for hashing/signing, independent of transport.	•
+Kafka-compatible
+: value is bytes (B2), keyed by Avro Schema ID (+ JSON-LD Context ID).
+
+
+⸻
+
+
+1) Two Avro-Compatible Encodings (choose one or support both)
+
+
+Path A — Avro Binary-in-TritRPC (ABT)
+Keep Avro’s
+existing binary encoding
+ for the payload, unchanged. TritRPC provides the envelope, IDs, AEAD, and byte/trit bridging.
+	•
+Pros
+: 100% Avro-compatible; use stock Avro libraries; minimal risk.	•
+Cons
+: You don’t get ternary-native arithmetic internally (it’s still Avro’s zigzag varints, byte order, etc.).
+
+How it works
+
+	•	Envelope header has MAGIC/VER/MODE/FLAGS + IDs (below).	•
+PAYLOAD
+ is the
+Avro Binary Encoding (ABE)
+ of the datum, verbatim bytes.	•	For
+B2
+ mode, we can either:
+	•	store the Avro bytes as-is, or	•	(optionally) wrap them inside the canonical TritPack243 block so all modes share identical canonicalization rules.
+	•	For
+B3/Q3
+ modes, we
+must
+ pack: ABE bytes → trits using
+TritPack243
+ (so the raw channel carries trits/qutrits).
+In Path A, Avro’s binary is king; TritRPC is a thin, secure, transport-agnostic envelope.
+
+
+⸻
+
+
+Path B — Avro-T3 (native ternary encoding with Avro semantics)
+Define a
+ternary-native encoding
+ that respects Avro’s
+semantics
+ and
+resolution rules
+ but swaps in ternary-friendly primitives (balanced ternary integers, a base-9 varint, etc.). Useful if you want a truly trit-native payload.
+	•
+Pros
+: Native ternary integers, clean mapping to qutrit rails, less impedance.	•
+Cons
+: You must implement a new codec (encoder/decoder), though schema/resolve logic still comes from Avro.
+
+How it works
+
+	•	Keep Avro types and resolution rules intact (records, arrays, maps, unions, etc.).	•	Replace primitive encodings with ternary equivalents:
+	•
+int
+,
+long
+:
+balanced-ternary
+ varints (
+varint-bt
+)	•
+bytes
+,
+string
+: length as ternary varint; payload bytes as-is; strings as UTF-8 bytes (to avoid inventing “trit-UTF”)	•
+boolean
+: single
+trit
+:
+0
+=false,
+2
+=true (reserve
+1
+ for future/NA)	•
+float
+,
+double
+: length-delimited IEEE bit patterns as bytes (so values are bit-exact), or optional ternary fixed-point logical type	•
+fixed
+: exact length, opaque bytes	•
+enum
+: index as ternary varint	•
+array
+/
+map
+: block counts as ternary varints; match Avro’s block framing	•
+union
+: member index as ternary varint; then the member value
+In Path B, you get ternary-native payloads while remaining fully
+Avro-semantics-compatible
+. A resolver can still do reader/writer schema evolution exactly the Avro way.
+
+
+⸻
+
+
+2) TritRPC Envelope (Avro-bound)
+Logical (trit-level) frame:
+
+
+[ MAGIC ][ VER ][ MODE ][ FLAGS ][ SCHEMA-ID ][ CONTEXT-ID ][ PAYLOAD ][ (AEAD TAG?) ]
+
+
+	•
+MAGIC:
+ 9 trits unique to TritRPC.	•
+VER:
+ 2 trits (start at 1).	•
+MODE:
+ 1 trit →
+0=B2
+,
+1=B3
+,
+2=Q3
+.	•
+FLAGS:
+ 3 trits (use as binary bits: AEAD, compression, reserved).	•
+SCHEMA-ID:
+ 81 trits = multicodec’d
+SHA3-256(Avro canonical form)
+.	•
+CONTEXT-ID:
+ 81 trits = multicodec’d
+SHA3-256(JSON-LD @context canonicalization)
+.	•
+PAYLOAD:
+
+	•	Path A: the
+Avro Binary Encoding
+ (ABE) datum (bytes)	•	Path B:
+Avro-T3 encoding
+ (trits), then packed for B2 mode
+	•
+AEAD:
+ optional, as a trailing length-delimited field (authenticate everything before it).
+
+Canonical Byte Packing (shared by both paths) — TritPack243
+
+	•	Pack
+5 trits
+→
+ 1 byte
+ (value 0..242).	•	Tail groups (1..4 trits) → emit
+marker 243..246
+ +
+1 data byte
+.	•	Bytes
+247..255
+ are invalid in canonical form.	•	Hash/sign
+the canonical TritPack243 bytes
+ for transport-invariant integrity.
+
+
+⸻
+
+
+3) Avro Type Mapping (Path B: Avro-T3 codec)
+Below, “TLEB3” is a
+base-3 varint
+ using small trit groups with a continuation trit (conceptually like varint, ternary edition).
+
+
+Avro Type
+
+Avro-T3 Encoding (ternary)
+
+
+null
+
+no bytes/trits emitted.
+
+boolean
+
+1 trit (0=false, 2=true; 1 reserved).
+
+int
+ (32b)
+
+varint-bt
+ (balanced-ternary varint).
+
+long
+ (64b)
+
+varint-bt
+.
+
+bytes
+
+len
+ as TLEB3, then that many
+bytes
+ (opaque).
+
+string
+
+len
+ as TLEB3, then UTF-8
+bytes
+.
+
+float
+
+length-delimited 4-byte IEEE 754 (opaque bytes).
+
+double
+
+length-delimited 8-byte IEEE 754 (opaque bytes).
+
+fixed(N)
+
+exactly N
+bytes
+.
+
+enum
+
+symbol index as TLEB3.
+
+array[T]
+
+Avro’s block framing:
+block_count
+ (TLEB3), then items (T3-encoded); repeat until zero block. Negative count for size-prefixed blocks can be modeled with a ternary sign (or keep Avro’s rule verbatim).
+
+map[V]
+
+block_count
+ (TLEB3), then pairs:
+len(key)
+ + key bytes, then value V; repeat; zero block terminator.
+
+union[U₀…U
+ₖ
+]
+
+member_index
+ (TLEB3), followed by value encoded as that member’s type.
+
+
+Logical types (recommended)
+
+	•
+{"type":"long","logicalType":"balancedTernary"}
+ →
+force
+ varint-bt (both paths can accept; in Path A it’s advisory).	•
+{"type":"bytes","logicalType":"trits"}
+ → payload interpreted as
+trit stream
+ (still serialized as bytes in Avro, but
+meaning
+ is trits; pack/unpack via TritPack243 when crossing modes).	•	Keep Avro’s standard logicals (decimal, date, time, timestamp, uuid) as-is (bytes/ints); define ternary alternates only if you truly need them.
+
+Unions & defaults
+
+	•	All Avro union and default behaviors remain
+unchanged
+. The codec only alters primitive encodings, not schema resolution semantics.
+
+
+⸻
+
+
+4) JSON-LD / SALAD Semantics
+
+	•	Carry a
+CONTEXT-ID
+ (SHA3-256 of canonicalized
+@context
+).	•	Optional: include a
+contextURI
+ field (length-delimited) in a control/handshake frame for resolvers.	•	Stores/indexers can resolve both
+structure
+ (Avro schema) and
+meaning
+ (JSON-LD) for knowledge graphs and semantic joins.
+
+
+⸻
+
+
+5) Kafka & Schema Registry
+
+	•
+Key:
+ typically
+{subject, schemaVersion}
+ or a stable hash.	•
+Value:
+
+B2 bytes
+ = canonical TritPack243 of the entire TritRPC envelope (header + payload [+ AEAD tag]).	•
+Schema Registry subject:
+ the Avro writer’s schema; we also pin
+SCHEMA-ID
+ in the envelope so consumers can verify they resolved the exact schema used to encode.	•
+Context pinning:
+ store
+CONTEXT-ID
+ as a header or inside the envelope to keep semantics explicit.
+
+Why put the whole envelope in Kafka value?
+
+	•	AEAD, mode, flags, and IDs ride with the message; consumers can do strict verification, not rely on out-of-band contracts.
+
+
+⸻
+
+
+6) Worked Example (both Path A and Path B)
+
+
+Avro schema
+
+
+{  "type": "record",  "name": "AddRequest",  "namespace": "calc.v1",  "fields": [    {"name":"a","type":{"type":"long","logicalType":"balancedTernary"}},    {"name":"b","type":{"type":"long","logicalType":"balancedTernary"}}  ]}
+
+
+We send:
+AddRequest{ a=12, b=5 }
+.
+
+6.1 Path A — Avro Binary in TritRPC
+
+
+Payload (ABE bytes):
+
+	•	Avro
+long
+ uses zigzag + varint.
+	•
+12
+ (zigzag) →
+24
+ → varint bytes:
+0x18
+	•
+5
+ (zigzag) →
+10
+ → varint bytes:
+0x0A
+
+	•	ABE payload =
+18 0A
+ (hex).
+
+TritRPC envelope (conceptual)
+
+
+MAGIC,VER,MODE=B2,FLAGSSCHEMA-ID  (SHA3 of Avro canonical form)CONTEXT-ID (SHA3 of JSON-LD @context)PAYLOAD = [0x18, 0x0A]     # Avro binary bytes(AEAD tag if enabled)
+
+
+If
+MODE=B2
+, we can pass
+18 0A
+ raw. If we want strict canonicalization everywhere, we instead
+TritPack243
+ the trit form of the envelope into bytes (recommended), then hash/sign those bytes.
+
+6.2 Path B — Avro-T3 (ternary-native payload)
+
+
+Balanced-ternary (big-endian digits)
+
+	•
+12
+ → base-3
+110
+ → balanced digits
+(+,+,0)
+ →
+transport trits
+
+[2,2,1]
+ (map −1→0, 0→1, +1→2)	•
+5
+  → base-3
+12
+  → balanced digits
+(+,-,-)
+ →
+transport trits
+
+[2,0,0]
+
+
+Encode each long as varint-bt:
+Let
+len=3
+ digits each. A simple TLEB3 for
+len=3
+ might be: one digit group with continuation=Z and value=3. Then emit the 3 trits in chosen endianness (spec: big-endian).
+Field order
+ follows Avro field order (no field tags in Avro):
+
+
+[a (len=3), a digits: 2 2 1] [b (len=3), b digits: 2 0 0]
+
+
+Now wrap with TritRPC header and (if MODE=B2) pack the whole trit stream via
+TritPack243
+ into bytes for Kafka.
+
+Note:
+ Path B preserves all Avro semantics; only the primitive codec differs.
+
+
+⸻
+
+
+7) AEAD, Hashing, Compression
+
+	•	Compute AEAD (e.g., XChaCha20-Poly1305) over the
+canonical TritPack243 bytes of the entire envelope
+, excluding the trailing AEAD tag field.	•	Include header fields (MODE, FLAGS, SCHEMA-ID, CONTEXT-ID) in the associated data so transport upgrades/downgrades can’t be replayed/misinterpreted.	•	Compress
+PAYLOAD
+ (Zstd/LZ4)
+before
+ AEAD if
+FLAGS.compression=1
+. For B3/Q3 links, compress the
+byte form
+ (i.e., after packing).
+
+
+⸻
+
+
+8) Avro Resolution & Evolution (Reader/Writer)
+All Avro resolution rules apply identically:
+	•
+Default values
+: reader defaults used when writer lacks a field.	•
+Aliases
+: respected as usual.	•
+Union resolution
+: reader resolves the writer’s chosen member by name/index as Avro specifies.	•
+Compatibility
+: your registry checks (backward/forward/full) are unchanged.
+
+Path A
+: Writer/reader use stock Avro libraries; envelope just carries the IDs & mode.
+Path B
+: Writer/reader use the
+Avro-T3 codec
+ (drop-in replacement layer). Schema resolution still uses Avro’s logic.
+
+
+⸻
+
+
+9) Control/Handshake Frames
+Define a tiny Avro record (in a control subject) for negotiation:
+
+
+{  "type":"record",  "name":"Hello",  "namespace":"tritrpc.control.v1",  "fields":[    {"name":"modes","type":{"type":"array","items":"int"}},   // 0=B2, 1=B3, 2=Q3    {"name":"aead_suites","type":{"type":"array","items":"string"}},    {"name":"contextURI","type":["null","string"],"default":null}  ]}
+
+
+Server replies with a selected mode/suite. Thereafter, data frames use that MODE.
+
+
+⸻
+
+
+10) Diagnostics: Pseudo Wire Dumps
+
+
+Envelope (logical view)
+
+
+MAGIC(9t) | VER(2t) | MODE(1t) | FLAGS(3t)| SCHEMA-ID(81t) | CONTEXT-ID(81t)| PAYLOAD(...)| [ AEAD-TAG (len-delimited) ]
+
+
+Path A — Avro bytes inside payload
+
+
+PAYLOAD = ABE bytes        # example: 0x18 0x0A
+
+
+Path B — Avro-T3 payload for AddRequest
+
+
+# a (12): len=3
+→
+ [Z:continue=stop | value=3]# digits: [2,2,1]# b (5):  len=3
+→
+ [Z       ...        ]# digits: [2,0,0]PAYLOAD = [ TLEB3(3) | 2 2 1 | TLEB3(3) | 2 0 0 ]
+
+
+If
+MODE=B2
+, pack the entire envelope with
+TritPack243
+ to obtain canonical bytes.
+
+
+⸻
+
+
+11) Interop Menu (what to actually ship first)
+
+	•
+Default
+ to
+Path A (ABT)
+ for zero friction:
+	•	Use existing Avro serializers.	•	Wrap in TritRPC envelope with SCHEMA-ID + CONTEXT-ID + AEAD.	•	For cross-mode, apply TritPack243 canon bytes.
+	•
+Optionally
+ add
+Path B (Avro-T3)
+ behind a feature flag:
+	•	Same Avro schemas and resolution.	•	New codec that swaps in ternary-friendly primitives.	•	Provides a clean bridge to future B3/Q3 links.
+
+
+⸻
+
+
+12) Quick Checklist (engineering)
+
+	•	Compute
+SCHEMA-ID
+ = SHA3-256(Avro canonical form).	•	Compute
+CONTEXT-ID
+ = SHA3-256(canonicalized JSON-LD
+@context
+).	•	Implement
+TritPack243
+ (trit↔byte).	•	Implement
+AEAD
+ over canonical TritPack243 bytes.	•
+Path A
+: drop in Avro Binary payload.	•
+Path B (optional)
+: Avro-T3 codec primitives (varint-bt, TLEB3, boolean-trit).	•	Kafka serializers/deserializers:
+	•	value = canonical bytes (full envelope)	•	headers include MODE/FLAGS for quick filtering (optional)
+	•	Test vectors: same messages encoded with Path A and Path B must produce
+different payloads
+ but identical
+envelope behaviors
+ (IDs, AEAD success, evolution, etc.).
+
+
+⸻
+
+
+13) Self-Critique & Recommended Refinements
+
+
+Strong points now:
+
+	•	Avro is truly first-class: schema, evolution, and registry integration are preserved.	•	Two clear paths: ultra-safe (Path A) and ternary-native (Path B).	•	Deterministic canonicalization via TritPack243 + AEAD story is clean and transport-agnostic.	•	JSON-LD/SALAD semantics are pinned explicitly (CONTEXT-ID).
+
+What to tighten next (I recommend doing all of these):
+
+
+	1.
+Publish test vectors
+ for both paths (nulls, unions, arrays/maps, decimals, timestamps). Include: raw trits, packed bytes, SHA3 digests, AEAD tags.
+	2.
+Lock digit endianness
+ for balanced ternary (spec currently says
+big-endian
+ for human readability; make it a MUST).
+	3.
+Decimal logical type
+: define ternary fixed-point representation (Path B) or mandate Avro’s existing bytes encoding only (Path A).
+	4.
+Union index varint size
+: cap digits for small unions to guarantee worst-case sizes (e.g., ≤ 9 members → 1 digit).
+	5.
+Streaming RPC
+ over Avro: define chunked frames with rolling AEAD and explicit flush semantics (mirroring Avro object container block ideas).
+	6.
+Registry augmentation
+: store
+CONTEXT-ID
+ and MODE support in schema metadata so readers can verify expectations before decode.
+	7.
+B3/Q3 ECC profile
+: specify a default RS(GF(3^m)) or ternary stabilizer at the link layer, and a small outer CRC in the envelope for fast failure.
+
+
+⸻
+
+
+If you want, I can follow up with (a) a
+Rust
+ reference for TritPack243 + envelope, (b)
+Kafka SerDes
+ for Path A, and (c)
+Avro-T3
+ codec scaffolding for Path B, plus a
+test-vector pack
+ that exercises unions, arrays/maps, and logical types.

--- a/docs/trit-to-trust_sources/ternary tritprc document and spec.md
+++ b/docs/trit-to-trust_sources/ternary tritprc document and spec.md
@@ -1,0 +1,770 @@
+# ternary tritprc document and spec
+
+.SFNS-Semibold;.SFNS-Regular;HelveticaNeue-Bold;
+.SFNS-RegularItalic;.AppleSystemUIFontMonospaced-Regular;TimesNewRomanPSMT;
+Helvetica;Courier;
+;;;;;
+;;;
+;;;;;
+;;;
+
+
+Why Binary Streams Prevail (and a Hypothetical Ternary “TritRPC”)
+
+In modern computing and RPC frameworks, binary (base-2) data streams are universal.
+ This is no accident: it reflects deep practical realities of hardware and engineering. Below we break down why binary won out, examine analogous multi-level tricks in current tech, sketch a hypothetical base-3 “TritRPC” for illustration, and highlight the theoretical allure of ternary logic.
+The Overwhelming Practical Hurdle: Why Binary Won
+Ultimately,
+hardware
+ dictates why everything is binary. Modern digital electronics are built on
+transistors
+ using CMOS logic, which behave like near-perfect on/off switches. They naturally support two stable states (on = 1, off = 0), and it’s
+much easier to make components with two stable states than three
+ :
+	•
+Simplicity and Reliability:
+ A CMOS transistor in logic circuits is either
+ON
+ (conducting, representing ‘1’) or
+OFF
+ (non-conducting, ‘0’). These two states are
+stable, low-power, and noise-resistant
+. Using binary “bits” kept early computer hardware simple and reliable . By contrast, a stable third state (e.g. a precise half-on voltage) is an engineering nightmare. Any analog intermediate level would be
+highly sensitive
+ to noise, temperature, and voltage drift, undermining reliability.	•
+The “Forbidden Zone”:
+ In CMOS logic, the transition region between fully on and off is unstable and power-hungry. A transistor that is half-on will draw significant current (both the pull-up and pull-down networks partly conduct), wasting energy as heat. Designing circuits to idle in a mid-level state would be
+inefficient and difficult to control
+. Essentially, there’s no convenient third “rail” for logic that doesn’t incur huge costs in power and circuit complexity.These hardware factors created an overwhelming inertia in favor of binary. The entire ecosystem – CPU gates, memory cells, and even communication protocols – was built on robust two-state logic. Overcoming this with ternary would require a
+revolutionary
+ new device offering an order-of-magnitude (10×) benefit to justify breaking from the binary standard. So far, ternary devices haven’t shown such a payoff, and binary remains the Goldilocks solution.
+
+Closest Analogues in Modern Tech: Multi-Level Signaling
+Interestingly, some
+physical signaling techniques
+ use more than two voltage levels per symbol – but crucially, they still interface with binary computers. For example, high-speed Ethernet links and Wi-Fi use
+multi-level modulation
+ to boost data rates. A scheme like
+PAM-4
+ (Pulse Amplitude Modulation with 4 levels) encodes
+2 bits per symbol
+ by using four distinct voltage levels :
+	•
+How it works:
+ Each voltage level represents a 2-bit pattern: for instance, in PAM-4 we might map Level_0 =
+00
+, Level_1 =
+01
+, Level_2 =
+10
+, Level_3 =
+11
+. This doubles the data throughput
+per clock
+ because one symbol carries 2 bits (instead of 1 in binary NRZ encoding). Likewise, modern Wi-Fi uses QAM constellations (e.g. 16-QAM, 64-QAM) where combinations of amplitude and phase encode multiple bits per carrier wave.	•
+But still binary at heart:
+ These multi-level signals are purely a
+physical layer optimization
+. The receiver (e.g. your network card) immediately decodes each multi-level symbol back into a standard binary bit stream before passing it up to any software or RPC layer. The computer’s logic still only understands 1s and 0s. In other words, the wire might momentarily carry more than two voltage states, but
+the information ultimately becomes bits
+. The same is true in storage: NAND flash memory with
+TLC
+ (Triple-Level Cell) stores 3 bits in one cell by distinguishing 8 charge levels , and QLC (Quad-Level Cell) uses 16 levels for 4 bits. These analog tricks increase density, but internally error-correcting controllers ensure the output is still a stream of binary data.In summary, no mainstream
+computing system
+ uses ternary logic throughout. Where we do see multi-level encodings, they serve as efficiency hacks at the analog transmission/storage layer, not as ternary computation. The hardware always converts the data back to binary because the logic circuits themselves remain binary.
+
+Sketch of a Hypothetical “TritRPC” Framework
+For the sake of argument,
+imagine
+ we had a true ternary computer that processes trits (-1, 0, +1). What might a serialization/RPC format look like in base-3? It turns out it could closely mirror something like Protocol Buffers, just with a different number system. Let’s use
+balanced ternary
+ digits – say
+N
+ for -1,
+Z
+ for 0, and
+P
+ for +1 – because balanced ternary elegantly handles negatives without a separate sign bit . We’ll outline two key components of a made-up
+“TritRPC”
+:
+
+	1.
+Basic Encoding – Varintᵀ (Variable-length Trits):
+ In binary ProtoBuf, integers are encoded as
+varints
+ where each byte uses 7 bits for value and 1 bit as a “continue” flag. In our ternary version, we can use a similar scheme with trits. For example, use the most significant trit of each tryte (a group of ternary digits) as a continuation flag: say
+P
+ or
+N
+ in that position means “more trits follow”, and
+Z
+ means “stop here”.
+	•
+Encoding the number 5:
+ In balanced ternary, 5 is represented as
+PNN
+ (because $5 = 1 \cdot 3^2 + (-1) \cdot 3^1 + (-1) \cdot 3^0 = 9 - 3 - 1$). This fits in one tryte, so we mark it as the final chunk with a leading
+Z
+.
+Wire format:
+
+Z P N N
+ (a four-trit sequence).	•
+Encoding the number 13:
+ In balanced ternary, 13 is
+PPP
+ ($13 = 1\cdot9 + 1\cdot3 + 1\cdot1$). We again only need one group, so the wire representation is
+Z P P P
+.(In practice, just like binary varints, larger numbers would span multiple groups of trits with
+P/N
+ flags indicating continuation.)
+
+	2.
+Message Structure – Tagged Fields:
+ The message would be a series of fields with headers, analogous to ProtoBuf’s field tags. Each field tag would combine the field number and type (but now encoded in base-3). For instance, consider a message:
+
+
+message User {    string name = 1;    int32  points = 2;}
+
+
+Suppose we want to encode
+User{name="Al", points=5}
+ in TritRPC:
+	•
+Field 1 (name):
+ Field number 1, type=string. In a ProtoBuf-like scheme, we might assign a type code (say
+PZ
+ for “string”). The field tag in base-3 could be the field number (1, which is
+1
+ in ternary) combined with type code, yielding something like
+PZZ
+ (this is a hypothetical encoding for illustration). Next comes the length of the string. “Al” is 2 characters, so we encode 2 as
+Z P N
+ (ternary 2 = $2_{10} = 2_{3}$, represented here as
+PN
+ with a
+Z
+ terminator). Then the UTF-8 bytes of “Al” would be represented in ternary form (each byte would be converted to a couple of trytes).
+On the wire
+, the field would look like:
+[Tag: PZZ] [Length: Z P N] [Payload: (ternary data for "A" and "l")]
+.	•
+Field 2 (points):
+ Field number 2, type=varint. In our scheme, maybe the type code for a varint is
+ZZ
+. The field tag for field 2 would then be something like
+PNZZ
+. The value 5 is encoded as the varintᵀ
+Z P N N
+ (from above).
+On the wire:
+
+[Tag: PNZZ] [Value: Z P N N]
+.The overall message stream is just these field segments concatenated. Notably, the
+structure
+ (field tags, lengths, values) is conceptually the same as binary ProtoBuf – we’ve just swapped out bits for trits. This exercise shows that if ternary computers existed, our RPC/serialization frameworks would look remarkably similar to today’s, only the numeric base underneath changes.
+
+The Theoretical Kicker: Why Base 3 at All?
+If binary is so dominant, why even ponder ternary? Information theory provides an intriguing answer:
+base-e (~2.718) is the mathematically optimal radix
+ for encoding numbers in terms of efficiency, and 3 is the nearest integer to
+e
+. In fact, a ternary digit (trit) carries about
+log₂3 ≈ 1.585 bits
+ of information . In theory, that means a ternary system could be slightly more information-dense than a binary one. A 64-trit number, for example, can represent a larger range than a 64-bit number (it’s equivalent to ~101.4 bits) .Historically, this led to some experimentation with ternary computers. Notably, the Soviet
+Setun
+ computer (1958) used balanced ternary logic. It was reported to have some advantages like lower power usage and cheaper circuits. However, those benefits were not big enough to overcome the sheer momentum of binary technology (and Setun was eventually left behind by binary machines). The complexity of building reliable ternary hardware outweighed the marginal gains in efficiency .
+In conclusion,
+ binary won because it hit the sweet spot between simplicity and functionality. Our entire digital world – from logic gates to RPC protocols – is built on that robust foundation of 1s and 0s. While ternary computing is elegant in theory and may see niche use (or a revival if new tech makes it viable), any “trinary RPC” would require a fundamentally different hardware paradigm. Until then, binary streams remain the practical choice for virtually all engineering purposes.————————————————————————————————————————————End-to-end sketch for a
+TritRPC
+ that cleanly bridges binary (classical), trinary (native ternary), and qutrit (quantum) channels, while staying compatible with Avro/JSON-LD/SALAD semantics and Kafka-style messaging.
+I’m giving you: a wire format, packing rules, schema linkage, service/method naming, example messages, and channel negotiation. Then I self-critique and list refinements.
+
+⸻
+
+
+TritRPC v0.1 — minimal spec
+
+
+0) Design goals (what this solves)
+
+	•
+Dual world consistency:
+ One canonical trit stream that packs deterministically into bytes (for today’s hardware) and maps 1-to-1 to qutrit symbols (for quantum or future ternary links).	•
+Schema/semantics first:
+ Avro is the schema authority; JSON-LD
+@context
+ supplies semantic meaning. We bind both into the envelope so knowledge systems retain identity + meaning.	•
+Transport agnostic:
+ Same message can traverse Kafka (bytes), local IPC/MQ, direct ternary PHY, or qutrit rails — without re-schematizing.	•
+Deterministic signing/hashing:
+ Canonicalization is independent of transport mode.
+
+⸻
+
+
+1) Envelope & preamble
+
+Frame layout (logical trits)
+
+
+[ MAGIC ][ VER ][ MODE ][ FLAGS ][ SCHEMA-ID ][ CONTEXT-ID ][ PAYLOAD ]
+
+
+	•
+MAGIC:
+ 9 trits: literal base-3 digits for “TritRPC”. (Byte mode uses its packed bytes; see §3.)	•
+VER:
+ 2 trits (0..8 → major 0..8). Start with 1.	•
+MODE:
+ 1 trit:
+	•	0 =
+B2
+ (binary transport): payload is the canonical trit stream, packed via TritPack243 to bytes.	•	1 =
+B3
+ (raw trit transport): payload carried as trits (native ternary link).	•	2 =
+Q3
+ (qutrit transport): trits mapped to |0〉, |1〉, |2〉 computational basis.
+	•
+FLAGS:
+ 3 trits bitfield (still ternary digits, interpreted as bits 0/1 only for now):
+	•	f0: AEAD present (0/1)	•	f1: compression present (0/1)	•	f2: reserved
+	•
+SCHEMA-ID:
+ 81 trits (≈128 bits of entropy): multicodec of
+SHA3-256(Avro-schema-canonical-form)
+, represented as trits (see §3 for packing).	•
+CONTEXT-ID:
+ 81 trits: multicodec of
+SHA3-256(JSON-LD @context canonical)
+.	•
+PAYLOAD:
+ TritRPC message body (fields), AEAD tag (if f0=1) is appended as length-delimited field at the end (so the canonical trit stream that’s authenticated includes everything before the tag).
+Why two IDs?
+Avro
+ ensures structural validation;
+JSON-LD
+ locks semantic meaning (SALAD/JSON-LD alignment), which you emphasized for knowledge systems.
+
+⸻
+
+
+2) Message body / wire types
+
+
+2.1 Field tag
+We generalize protobuf’s idea to base-9:
+
+
+tag = field_number * 9 + wire_type   (encoded as base-9 varint; see §2.2)
+
+
+	•
+wire_type
+ ∈ [0..8] (base-9 friendly). Start with:
+	•	0 =
+varint-u
+ (unsigned, base-9 varint)	•	1 =
+varint-b
+ (signed
+balanced ternary
+ integer)	•	2 =
+len
+ (length-delimited: bytes, strings, embedded msgs, Avro blocks)	•	3 =
+fixed-27
+  (exactly 27 trits; handy for small fixed IDs)	•	4 =
+fixed-54
+	•	5..8 = reserved (floats/decimals/logical types future)
+
+2.2 Varint over trits (“TLEB3”)
+A compact continuation scheme using
+tritlets
+ (3 trits each):
+	•	Layout per
+tritlet
+:
+[C][P1][P0]
+
+	•
+C
+ (continuation): 2=more tritlets follow; 0=end (1 reserved).	•
+(P1,P0)
+ encodes a base-3 digit in
+[0..8]
+ as
+v = P1*3 + P0
+.	•	Digits are
+little-endian base-9
+.	•	Example: decimal 10 → base-9 digits
+11
+ → two tritlets.This gives a clean, native base-9 varint that aligns with our field tags and meshes with ternary logic.
+
+2.3 Signed ints (balanced ternary)
+
+	•	Represent integers in
+balanced ternary
+ (digits ∈ {−1,0,+1}).	•	Wire maps digit values with
+offset +1
+ to unbalanced trits
+{0,1,2}
+ for transport:
+	•
+−1→0
+,
+0→1
+,
++1→2
+.
+	•	Then emit as
+length-delimited digit stream
+ using TLEB3 for
+length
+ followed by raw trits (or pack to base-9 digits as a varint if you prefer). The
+wire_type=1
+ distinguishes this from unsigned varints.
+Why balanced ternary? It makes signed magnitude natural (no ZigZag), matches ternary arithmetic, and is friendlier to qutrit rails.
+
+2.4 Length-delimited
+
+	•
+len
+ = TLEB3 (base-9 varint)	•
+payload
+ = that many
+bytes
+ (for strings/opaque blobs)
+or
+
+trits
+ (for embedded TritRPC messages). The
+field’s Avro logical type
+ determines which one it is, see §4.
+
+⸻
+
+
+3) Canonical byte packing (B2 mode)
+We need one exact way to turn any trit stream into bytes and back,
+without ambiguity
+.
+
+3.1 TritPack243
+
+	•
+Rule:
+ Pack
+5 trits
+ (base-3 number in [0..242]) into
+1 byte
+ (
+0..242
+).	•
+Terminator for partials:
+ If the final group has
+k ∈ {1..4}
+ trits, emit:
+	•	One
+marker byte
+
+243 + (k−1)
+ (i.e., 243..246),	•	Then
+one data byte
+ carrying the base-3 value of those k trits (0..(3^k−1)).
+	•
+No padding
+, no other markers. Bytes
+247..255
+ are invalid in canonical form.
+
+Why this?
+ Deterministic, compact, invertible; and it lets us hash/sign the
+same bytes
+ regardless of transport.
+Hashing/signing:
+ compute AEAD and/or SHA3-256 on the
+TritPack243 bytes
+ (the canonical representation).
+
+⸻
+
+
+4) Schema integration (Avro + JSON-LD)
+
+	•
+Authority:
+ Avro remains the on-disk/registry schema; SALAD/JSON-LD define semantics.	•
+Binding:
+
+	•
+SCHEMA-ID
+ := SHA3-256(Avro canonical form).	•
+CONTEXT-ID
+ := SHA3-256(JSON-LD context canonicalized).
+	•
+Logical types (examples):
+
+	•
+{"type":"bytes","logicalType":"trits"}
+ → field content is a
+trit
+ sequence (embedded TritRPC or balanced trits).	•
+{"type":"bytes","logicalType":"tryte256"}
+ → fixed 256 trits (packs to 52 bytes via TritPack243 + tail marker).	•
+{"type":"long","logicalType":"balancedTernary"}
+ → encode with wire_type=1.	•	Use Avro unions as usual; the wire type is a transport detail.
+
+Kafka bridge:
+ The
+Kafka value
+ is the TritPack243 byte array of the entire TritRPC frame.
+	•
+Schema Registry
+ key can include
+SCHEMA-ID
+ and
+CONTEXT-ID
+ so readers can resolve both structure and semantics.	•
+Local IPC/MQ
+ mirrors Kafka topic naming; the envelope ensures consistent meaning across transports.
+
+⸻
+
+
+5) Service & method naming
+
+Service descriptor
+ (meta, not on every frame):
+	•
+service_name
+: length-delimited UTF-8	•
+method_name
+: length-delimited UTF-8	•
+request_schema_id
+,
+response_schema_id
+: 81-trit identifiers (as in header)
+
+On the wire
+, each
+request/response
+ includes a
+Method-ID
+ field:
+	•	Field
+1
+ (wire_type=len): method name (or a stable numeric ID via varint)	•	The
+payload
+ after that field is the Avro-conformant message encoded with TritRPC wire rules.
+
+⸻
+
+
+6) Example: Calc.Add(a:int, b:int) -> sum:int
+
+
+6.1 Avro schema (request)
+
+
+{  "type": "record",  "name": "AddRequest",  "namespace": "calc.v1",  "fields": [    {"name":"a","type":{"type":"long","logicalType":"balancedTernary"}},    {"name":"b","type":{"type":"long","logicalType":"balancedTernary"}}  ]}
+
+
+Response
+ has one field
+sum
+ with the same logical type.
+
+6.2 Field tags
+
+	•
+a
+: field_number=1, wire_type=1 (varint-b) →
+tag = 1*9 + 1 = 10
+ (base-9
+11
+)	•
+b
+: field_number=2, wire_type=1 →
+tag = 19
+ (base-9
+21
+)	•
+sum
+: field_number=1, wire_type=1 in the response
+
+6.3 Balanced ternary values
+
+	•
+a = 12
+
+	•	base-3:
+110
+ → balanced digits:
++ + 0
+ (from 3²..3⁰)	•	transport digits (offset+1):
+2 2 1
+ (trits)
+	•
+b = 5
+
+	•	base-3:
+12
+ → balanced:
++ − −
+ (weights 9,3,1 → 9−3−1=5)	•	transport:
+2 0 0
+
+
+Encoding for each balanced integer (wire_type=1):
+
+	•	Length (
+count of trits
+) via
+TLEB3
+ (here 3 trits → a single tritlet with C=0 and digit=3)	•	Then those trits in
+little-endian
+ (least-significant digit first) or big-endian — pick one;
+spec says big-endian
+ for human readability.
+In practice we’d provide the exact TLEB3 digit breakdown + TritPack243 example bytes as test vectors in a reference doc.
+
+⸻
+
+
+7) Security & integrity
+
+	•
+AEAD:
+ Apply AEAD (e.g., XChaCha20-Poly1305) to the
+canonical TritPack243 bytes
+ of the entire frame excluding the AEAD tag field itself. Include
+SCHEMA-ID
+,
+CONTEXT-ID
+,
+MODE
+, and
+FLAGS
+ so transport upgrades cannot be replayed/misinterpreted.	•
+Signatures:
+ For non-repudiation, sign the
+same canonical byte string
+ (deterministic).	•
+Compression:
+ If
+FLAGS.compression=1
+, compress the
+PAYLOAD
+ (not the preamble)
+before
+ AEAD. LZ4/Zstd on bytes; on B3/Q3 links, you still compress the byte form (pack → compress → AEAD).
+
+⸻
+
+
+8) Quantum (Q3) bridge
+
+	•
+Symbol map:
+ trit
+0,1,2
+ ↔ qutrit
+|0〉,|1〉,|2〉
+.	•
+Framing:
+ Keep the same logical frame: MAGIC..CONTEXT-ID..PAYLOAD, just transmitted as qutrit sequences.	•
+Error-correction:
+ Use a ternary stabilizer code or Reed–Solomon over GF(3^m) at the link layer. TritRPC is agnostic; link layer returns a reliable trit stream.	•
+Interop:
+ Gateways do pure relays:
+Q3 ⇄ B3 ⇄ B2
+ using the canonical TritPack243 for B2 edges. No semantic loss, no re-schematization.
+
+⸻
+
+
+9) Knowledge systems & storage
+
+	•
+Semantics preserved:
+ Since
+CONTEXT-ID
+ binds a JSON-LD
+@context
+, any store (graph DB, doc store, columnar lake) can reconstruct meaning, not just shape.	•
+Avro blocks:
+ For high-volume ingestion (e.g., Kafka), you can embed
+Avro Object Container
+ blocks as
+len-delimited
+ fields. TritRPC doesn’t fight Avro; it standardizes the outer transport and signing with ternary-friendly internals.	•
+Indexing:
+ Index on
+(SCHEMA-ID, CONTEXT-ID, service, method)
+; optionally index the first N balanced-ternary numeric fields in their
+balanced form
+ to support ternary-native analytics.
+
+⸻
+
+
+Operational details you can ship
+
+
+A) Handshake / capability negotiation
+
+	•	Client sends a small
+HELLO
+ frame with supported
+MODE
+s (e.g.,
+{B2,B3,Q3}
+) and AEAD suites.	•	Server chooses
+MODE
+ and suite; echoes choice. Both sides then fix the parameters.
+
+B) Error model
+
+	•	Use a reserved
+service_name="tritrpc.control"
+ with methods
+Error
+,
+Ping
+,
+Close
+.	•	Standard error fields:
+code
+ (varint-u),
+message
+ (len), optional
+details
+ (embedded TritRPC).
+
+C) Topic strategy (Kafka + local IPC)
+
+	•
+Topic key:
+
+service.method
+ (e.g.,
+calc.v1.Add
+); partition by method or chosen key.	•
+Value:
+ entire TritRPC frame in
+B2
+ bytes (TritPack243).	•
+Local IPC:
+ mirror topic and frame shape; use Unix domain sockets, NATS, or ZeroMQ. The envelope keeps meaning identical across layers.
+
+⸻
+
+
+Minimal worked bytes (shape, not full numeric dump)
+For
+Calc.Add(12,5)
+ request (B2 mode):
+
+
+MAGIC+VER+MODE+FLAGS          → bytes via TritPack243SCHEMA-ID (81 trits)          → packs to 18 full bytes + 1 tail marker + 1 tail byteCONTEXT-ID (81 trits)         → sameField tag for a (tag=10)      → TLEB3 → byteslen(trits of a)=3             → TLEB3 → bytesdigits(a)= [ +, +, 0 ]        → [2,2,1] trits → packedField tag for b (tag=19)      → TLEB3 → byteslen(trits of b)=3             → TLEB3 → bytesdigits(b)= [ +, −, − ]        → [2,0,0] trits → packed(optional AEAD tag)           → len-delimited field at end
+
+
+A test-vector doc would list the exact byte hex. The rules above make that deterministic.
+
+⸻
+
+
+Why this cleanly bridges binary ↔ trinary ↔ qutrit
+
+	•
+Single canonical trit stream
+ everywhere.	•
+B2
+ is just the canonical trit stream
+TritPack243
+-compressed into bytes; signatures and AEAD are over that canonical byte form — so B2/B3/Q3 are provably equivalent.	•
+Balanced ternary
+ for signed numbers fits ternary hardware and maps naturally to qutrits; on binary boxes we merely pack/unpack deterministically.	•
+Avro + JSON-LD
+ binding keeps structure and meaning stable so your semantic/knowledge layers remain intact across transports.
+
+⸻
+
+
+Self-critique & recommended refinements
+
+
+What’s strong:
+
+	•	Canonicalization (TritPack243 + TLEB3) is simple and deterministic.	•	Balanced ternary for signed ints removes ZigZag oddities and aligns with trinary/qutrit logic.	•	Avro/JSON-LD binding respects your SALAD/Avro/JSON-LD stack and Kafka mirroring.
+
+What to tighten next (I recommend doing all of these):
+
+
+	1.
+Publish precise test vectors
+
+	•	For at least 10 messages (ints, strings, nested records, arrays, maps).	•	Include: raw trits, packed bytes, AEAD inputs/outputs, SHA3 digests.
+
+	2.
+Finalize endianness
+ for balanced-ternary digit order (spec currently says big-endian for human readability; lock it and add MUST/SHOULD language).
+	3.
+Float/decimal/logical types
+
+	•	Define wire_type mappings for IEEE-754 via length-delimited bytes (preserve exact bit layout) and an optional
+ternary fixed-point
+ format for native ternary hardware.
+
+	4.
+Error-correction profile for Q3
+
+	•	Choose a default ternary stabilizer or RS(3^m) profile; specify frame CRC before AEAD for fast drop on corrupted frames.
+
+	5.
+Avro union discrimination
+
+	•	Add a small ternary
+union tag
+ convention (base-9 varint index first, then the chosen branch field).
+
+	6.
+Schema & context catalogs
+
+	•	Define a multibase string for
+SCHEMA-ID
+/
+CONTEXT-ID
+ (e.g.,
+mbase:trit:
+) for human tooling, plus a registry discovery routine.
+
+	7.
+Backpressure & streaming RPC
+
+	•	Add chunked length-delimited segments with rolling AEAD (like HTTP/2 DATA frames) for large payloads.
+
+	8.
+Reference SerDes
+
+	•	Implement
+tritpack243
+,
+tleB3
+, balanced-ternary conversions, and Avro bindings in Rust/Go/Python; expose Kafka serializers/deserializers.
+
+	9.
+Spec formalization
+
+	•	Write an I-D style document: ABNF-like for trit streams, state machines for MODE transitions, and full security considerations.If you want, I’ll draft the
+test vectors
+ and a
+Rust reference
+ SerDes next, plus a minimal
+Kafka serializer
+ and an
+Avro logicalType plugin
+ for
+balancedTernary
+ and
+trits
+.


### PR DESCRIPTION
### Motivation

- Rescue and surface the original `trit-to-trust` source materials by converting RTF source files into readable UTF-8 Markdown. 
- Preserve the original RTF sources alongside converted Markdown so nothing is removed or lost. 
- Ensure the repository's documentation is viewable in standard editors and suitable for inclusion in the docs folder and downstream consumers. 

### Description

- Added UTF-8 `*.md` conversions for the RTF documents under `docs/trit-to-trust_sources/`, including `From Trits to Trust`, `Hypothetical Ternary TritRPC`, `TritRPC for Avro- A Spec Sketch`, and `ternary tritprc document and spec`. 
- Implemented and iterated a Python RTF→text conversion routine that handles RTF control words, hex escapes, surrogate pairs, and writes canonicalized UTF-8 Markdown outputs. 
- Kept the original `.rtf` files in place and wrote the converted Markdown files next to them, avoiding deletions and aggregating docs from the previous turn. 
- Ensured canonicalization choices (TritPack/TLEB3 content is documented) are preserved in the new Markdown artifacts and the envelope/serialization spec content was included in the docs. 

### Testing

- Ran a UTF-8 sanity check (`python` script) over `README.md`, `spec/README-full-spec.md`, and `docs/*.md` to confirm existing docs decode as UTF-8, which succeeded. 
- Executed the RTF→Markdown conversion script that wrote the five `docs/trit-to-trust_sources/*.md` files, and iterated fixes to handle surrogate pairs and encoding errors, which produced UTF-8 outputs successfully. 
- Verified the converted Markdown for replacement-replacement characters and re-ran the converter until no `\uFFFD` replacement artifacts remained, which succeeded. 
- No CI unit tests were run as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e995087883238cb1e0b645b52137)