### PR TITLE
Add branch/PR integration runbook and audit tooling; update CI, Makefile, and fixture verifier for XChaCha20-Poly1305

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-      - name: Rust dependency fetch
-        run: cargo fetch --manifest-path rust/tritrpc_v1/Cargo.toml
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Go module download
-        run: cd go/tritrpcv1 && go mod download
       - name: Install Python deps
         run: python -m pip install --upgrade pip pynacl cryptography
       - name: Verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
+      - name: Rust dependency fetch
+        run: cargo fetch --manifest-path rust/tritrpc_v1/Cargo.toml
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Go module download
+        run: cd go/tritrpcv1 && go mod download
       - name: Install Python deps
-        run: python -m pip install --upgrade pip cryptography
+        run: python -m pip install --upgrade pip pynacl cryptography
       - name: Verify
         run: make verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures
+.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures integration-audit
 
 verify: fmt rust-test go-test fixtures
 
@@ -14,7 +14,11 @@ rust-test:
 	cd rust/tritrpc_v1 && cargo test
 
 go-test:
-	cd go/tritrpcv1 && go test
+	cd go/tritrpcv1 && go test -mod=mod ./...
 
 fixtures:
 	python tools/verify_fixtures_strict.py
+
+
+integration-audit:
+	./tools/audit_branch_pr_integration.sh main HEAD

--- a/docs/vnext/integration/README.md
+++ b/docs/vnext/integration/README.md
@@ -8,6 +8,7 @@ This directory captures the reintegration of the two intentionally separated Tri
 ## Start here
 
 - `unified_spec_integration_crosswalk.md` — exact merge map, source precedence, and placement guidance.
+- `branch_pr_merge_runbook.md` — safe merge workflow for integrating branch/PR content into `main` without dropping work.
 - `../../spec/drafts/tritrpc_unified_v4_master_spec.md` — working unified master draft.
 - `../../spec/drafts/annex_b_path_h_qutrit_hybrid_profile.md` — hybrid/qutrit annex promoted from the parallel workstream.
 - `../../reference/experimental/tritrpc_requirements_impl_v4/path_h/` — reference encoder, fixtures, demo sequence, and parity harnesses.

--- a/docs/vnext/integration/branch_pr_merge_runbook.md
+++ b/docs/vnext/integration/branch_pr_merge_runbook.md
@@ -1,0 +1,74 @@
+# Branch + PR Integration Runbook (to land in `main` safely)
+
+This runbook is the operational counterpart to the unified spec crosswalk. Use it when you are about to fold multi-day branch and PR work into `main`.
+
+## Goal
+
+Integrate all accepted work into `main` while minimizing risk of dropped commits, accidental regressions, or merge drift.
+
+## 0) Preconditions
+
+- You are on a clean working tree.
+- `main` and the source branch (usually `work`) both exist locally.
+- You can run the audit script from repo root.
+
+## 1) Verify source/target history relationship first
+
+```bash
+./tools/audit_branch_pr_integration.sh main work
+```
+
+Interpretation:
+
+- **SAFE FAST-FORWARD**: use `--ff-only` merge.
+- **ALREADY INTEGRATED**: no merge needed.
+- **DIVERGED**: inspect and resolve manually before merge.
+
+## 2) Review PR lineage visibility
+
+The audit prints all merge commits visible in source history (including `Merge pull request #...` entries). Confirm expected PRs appear before landing.
+
+## 3) Run verification checks before merge
+
+```bash
+make verify
+```
+
+If dependency/network limits block language tests, at minimum keep a record of what failed and why before proceeding.
+
+## 4) Perform merge
+
+Fast-forward path (preferred when audit says safe):
+
+```bash
+git checkout main
+git merge --ff-only work
+```
+
+Diverged path:
+
+```bash
+git checkout main
+git merge --no-ff work
+```
+
+Then resolve conflicts and re-run checks.
+
+## 5) Post-merge confirmation
+
+```bash
+./tools/audit_branch_pr_integration.sh main main
+```
+
+This should show `ALREADY INTEGRATED` (or zero missing commits).
+
+## 6) Recovery anchors (recommended)
+
+Before merge, create a safety tag on both refs:
+
+```bash
+git tag pre-main-merge-main-$(date +%Y%m%d) main
+git tag pre-main-merge-work-$(date +%Y%m%d) work
+```
+
+This gives a deterministic rollback point if you need to unwind quickly.

--- a/go/tritrpcv1/fixtures_test.go
+++ b/go/tritrpcv1/fixtures_test.go
@@ -6,12 +6,21 @@ import (
 	"encoding/hex"
 	"golang.org/x/crypto/chacha20poly1305"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func readPairs(path string) [][2][]byte {
-	f, _ := os.Open(path)
+func fixturePath(name string) string {
+	return filepath.Join("..", "..", "fixtures", name)
+}
+
+func readPairs(t *testing.T, path string) [][2][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixtures file %s: %v", path, err)
+	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	out := make([][2][]byte, 0)
@@ -28,8 +37,12 @@ func readPairs(path string) [][2][]byte {
 	return out
 }
 
-func readNonces(path string) map[string][]byte {
-	f, _ := os.Open(path)
+func readNonces(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open nonce file %s: %v", path, err)
+	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	out := map[string][]byte{}
@@ -70,16 +83,16 @@ func aeadBit(flags []byte) bool {
 
 func TestFixturesAEADAndPayloads(t *testing.T) {
 	sets := [][2]string{
-		{"fixtures/vectors_hex.txt", "fixtures/vectors_hex.txt.nonces"},
-		{"fixtures/vectors_hex_stream_avrochunk.txt", "fixtures/vectors_hex_stream_avrochunk.txt.nonces"},
-		{"fixtures/vectors_hex_unary_rich.txt", "fixtures/vectors_hex_unary_rich.txt.nonces"},
-		{"fixtures/vectors_hex_stream_avronested.txt", "fixtures/vectors_hex_stream_avronested.txt.nonces"},
-		{"fixtures/vectors_hex_pathB.txt", "fixtures/vectors_hex_pathB.txt.nonces"},
+		{"vectors_hex.txt", "vectors_hex.txt.nonces"},
+		{"vectors_hex_stream_avrochunk.txt", "vectors_hex_stream_avrochunk.txt.nonces"},
+		{"vectors_hex_unary_rich.txt", "vectors_hex_unary_rich.txt.nonces"},
+		{"vectors_hex_stream_avronested.txt", "vectors_hex_stream_avronested.txt.nonces"},
+		{"vectors_hex_pathB.txt", "vectors_hex_pathB.txt.nonces"},
 	}
 	key := [32]byte{}
 	for _, s := range sets {
-		pairs := readPairs(s[0])
-		nonces := readNonces(s[1])
+		pairs := readPairs(t, fixturePath(s[0]))
+		nonces := readNonces(t, fixturePath(s[1]))
 		for _, p := range pairs {
 			name := string(p[0])
 			frame := p[1]

--- a/go/tritrpcv1/go.sum
+++ b/go/tritrpcv1/go.sum
@@ -1,1 +1,2 @@
+golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
 golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=

--- a/rust/tritrpc_v1/Cargo.toml
+++ b/rust/tritrpc_v1/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "TritRPC v1 reference (Rust): TritPack243, TLEB3, Envelope + AEAD (XChaCha20-Poly1305)."
 
 [dependencies]
-chacha20poly1305 = { version = "0.10", features = ["xchacha20poly1305"] }
+chacha20poly1305 = "0.10"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/tritrpc_v1/tests/fixtures.rs
+++ b/rust/tritrpc_v1/tests/fixtures.rs
@@ -5,6 +5,10 @@ use std::fs;
 use subtle::ConstantTimeEq;
 use tritrpc_v1::{avrodec, avroenc, envelope, tleb3, tritpack243};
 
+fn fixture_path(name: &str) -> String {
+    format!("{}/../../fixtures/{}", env!("CARGO_MANIFEST_DIR"), name)
+}
+
 fn read_pairs(path: &str) -> Vec<(String, Vec<u8>)> {
     let txt = fs::read_to_string(path).expect("read fixtures");
     txt.lines()
@@ -54,31 +58,25 @@ fn aead_bit(flags_bytes: &[u8]) -> bool {
 #[test]
 fn verify_all_frames_and_payloads() {
     let sets = vec![
+        ("vectors_hex.txt", "vectors_hex.txt.nonces"),
         (
-            "fixtures/vectors_hex.txt",
-            "fixtures/vectors_hex.txt.nonces",
+            "vectors_hex_stream_avrochunk.txt",
+            "vectors_hex_stream_avrochunk.txt.nonces",
         ),
         (
-            "fixtures/vectors_hex_stream_avrochunk.txt",
-            "fixtures/vectors_hex_stream_avrochunk.txt.nonces",
+            "vectors_hex_unary_rich.txt",
+            "vectors_hex_unary_rich.txt.nonces",
         ),
         (
-            "fixtures/vectors_hex_unary_rich.txt",
-            "fixtures/vectors_hex_unary_rich.txt.nonces",
+            "vectors_hex_stream_avronested.txt",
+            "vectors_hex_stream_avronested.txt.nonces",
         ),
-        (
-            "fixtures/vectors_hex_stream_avronested.txt",
-            "fixtures/vectors_hex_stream_avronested.txt.nonces",
-        ),
-        (
-            "fixtures/vectors_hex_pathB.txt",
-            "fixtures/vectors_hex_pathB.txt.nonces",
-        ),
+        ("vectors_hex_pathB.txt", "vectors_hex_pathB.txt.nonces"),
     ];
     let key = [0u8; 32];
     for (fx, nx) in sets {
-        let pairs = read_pairs(fx);
-        let nonces = read_nonces(nx);
+        let pairs = read_pairs(&fixture_path(fx));
+        let nonces = read_nonces(&fixture_path(nx));
         for (name, frame) in pairs {
             let fields = split_fields(&frame);
             assert!(fields.len() >= 9, "{}", name);

--- a/tools/audit_branch_pr_integration.sh
+++ b/tools/audit_branch_pr_integration.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_BRANCH="${1:-main}"
+SOURCE_REF="${2:-HEAD}"
+
+if ! git rev-parse --verify "$SOURCE_REF" >/dev/null 2>&1; then
+  echo "ERROR: source ref '$SOURCE_REF' does not exist."
+  exit 2
+fi
+
+if ! git rev-parse --verify "$TARGET_BRANCH" >/dev/null 2>&1; then
+  echo "ERROR: target branch '$TARGET_BRANCH' does not exist locally."
+  echo "Hint: create it (e.g., git branch $TARGET_BRANCH <base>) or fetch it from origin."
+  exit 2
+fi
+
+SOURCE_SHA="$(git rev-parse --short "$SOURCE_REF")"
+TARGET_SHA="$(git rev-parse --short "$TARGET_BRANCH")"
+
+echo "=== TriTRPC Branch/PR Integration Audit ==="
+echo "Target branch : $TARGET_BRANCH ($TARGET_SHA)"
+echo "Source ref    : $SOURCE_REF ($SOURCE_SHA)"
+echo
+
+echo "--- Merge commits in source history (newest first) ---"
+git log --merges --pretty=format:'%h %s' "$SOURCE_REF"
+echo
+
+MISSING_COMMITS="$(git rev-list --count "$TARGET_BRANCH..$SOURCE_REF")"
+echo "--- Commits in $SOURCE_REF but not yet in $TARGET_BRANCH ---"
+echo "$MISSING_COMMITS"
+
+if [ "$MISSING_COMMITS" -gt 0 ]; then
+  git log --oneline "$TARGET_BRANCH..$SOURCE_REF"
+else
+  echo "None. Target already contains source history."
+fi
+
+echo
+COMMON_BASE="$(git merge-base "$TARGET_BRANCH" "$SOURCE_REF")"
+COMMON_BASE_SHORT="$(git rev-parse --short "$COMMON_BASE")"
+echo "Merge base: $COMMON_BASE_SHORT"
+
+if git merge-base --is-ancestor "$TARGET_BRANCH" "$SOURCE_REF"; then
+  echo "Status: SAFE FAST-FORWARD (target is ancestor of source)."
+  echo "Suggested merge command: git checkout $TARGET_BRANCH && git merge --ff-only $SOURCE_REF"
+  exit 0
+fi
+
+if git merge-base --is-ancestor "$SOURCE_REF" "$TARGET_BRANCH"; then
+  echo "Status: ALREADY INTEGRATED (source is ancestor of target)."
+  exit 0
+fi
+
+echo "Status: DIVERGED (manual conflict review required)."
+echo "Suggested inspection:"
+echo "  git log --left-right --cherry-pick --oneline $TARGET_BRANCH...$SOURCE_REF"
+echo "  git diff --stat $TARGET_BRANCH...$SOURCE_REF"
+exit 1

--- a/tools/verify_fixtures_strict.py
+++ b/tools/verify_fixtures_strict.py
@@ -4,12 +4,35 @@
 import sys
 from pathlib import Path
 from typing import Tuple
+_XCHACHA_PROVIDER = None
+
 try:
-    from cryptography.hazmat.primitives.ciphers.aead import XChaCha20Poly1305
-except Exception as e:
-    print("ERROR: cryptography package with XChaCha20-Poly1305 is required for this hook.", file=sys.stderr)
-    print("Try:  pip install cryptography", file=sys.stderr)
-    sys.exit(2)
+    try:
+        from nacl.bindings.crypto_aead import crypto_aead_xchacha20poly1305_ietf_encrypt
+    except Exception:
+        from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_encrypt
+
+    _XCHACHA_PROVIDER = "pynacl"
+
+    def xchacha20poly1305_tag(key: bytes, nonce: bytes, aad: bytes) -> bytes:
+        sealed = crypto_aead_xchacha20poly1305_ietf_encrypt(b"", aad, nonce, key)
+        return sealed[-16:]
+
+except Exception:
+    try:
+        from cryptography.hazmat.primitives.ciphers.aead import XChaCha20Poly1305
+
+        _XCHACHA_PROVIDER = "cryptography"
+
+        def xchacha20poly1305_tag(key: bytes, nonce: bytes, aad: bytes) -> bytes:
+            return XChaCha20Poly1305(key).encrypt(nonce, b"", aad)[-16:]
+
+    except Exception:
+        print("ERROR: XChaCha20-Poly1305 support is required for this hook.", file=sys.stderr)
+        print("Install one of:", file=sys.stderr)
+        print("  pip install pynacl", file=sys.stderr)
+        print("  pip install cryptography", file=sys.stderr)
+        sys.exit(2)
 
 ROOT = Path(__file__).resolve().parents[1]
 FX = ROOT / "fixtures"
@@ -94,7 +117,7 @@ def verify_file(fx_name: str, nx_name: str) -> None:
         if name not in nonce:
             print(f"[FAIL] Nonce missing for {fx_name}:{name}", file=sys.stderr)
             sys.exit(3)
-        calc = XChaCha20Poly1305(KEY).encrypt(nonce[name], b"", aad)[-16:]
+        calc = xchacha20poly1305_tag(KEY, nonce[name], aad)
         if calc != tag:
             print(f"[FAIL] AEAD tag mismatch: {fx_name}:{name}", file=sys.stderr)
             sys.exit(4)
@@ -109,7 +132,7 @@ def main():
         ("vectors_hex_pathB_stream.txt","vectors_hex_pathB_stream.txt.nonces"),
     ]
     for f,n in sets: verify_file(f,n)
-    print("[OK] All fixture AEAD tags verified under XChaCha20-Poly1305.")
+    print(f"[OK] All fixture AEAD tags verified under XChaCha20-Poly1305 ({_XCHACHA_PROVIDER}).")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation

- Provide a safe, auditable workflow for merging multi-day branches/PRs into `main` and reduce risk of dropped commits or merge drift.
- Ensure CI and local verification can fetch language dependencies reliably and verify fixtures that use XChaCha20-Poly1305 across Python providers.

### Description

- Add `tools/audit_branch_pr_integration.sh` to audit branch/PR relationship, show merge commits, list missing commits, and recommend merge actions.
- Add `docs/vnext/integration/branch_pr_merge_runbook.md` and reference it from the integration `README.md` as the operational runbook for safe merges.
- Update GitHub Actions CI (`.github/workflows/ci.yml`) to prefetch Rust dependencies (`cargo fetch`), download Go modules (`go mod download`), and install `pynacl` plus `cryptography` in Python step before running `make verify`.
- Update `Makefile` to add `integration-audit` target, include it in `.PHONY`, and change Go test invocation to `go test -mod=mod ./...`.
- Enhance `tools/verify_fixtures_strict.py` to support XChaCha20-Poly1305 via either `pynacl` or `cryptography`, auto-detect the provider, and print which provider was used on success.
- Update `rust/tritrpc_v1/Cargo.toml` to modify the `chacha20poly1305` dependency spec and add Go checksum entry in `go/tritrpcv1/go.sum`.

### Testing

- No automated tests were executed as part of this change in the PR itself; CI was updated to run verification on push/PR which will execute `make verify`.
- `make verify` (as invoked by CI) runs `rust-fmt`/`go-fmt`, `cargo test`, `go test -mod=mod ./...`, and `python tools/verify_fixtures_strict.py` when CI runs the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b6f5450c83238c152c559dc35fff)