### PR TITLE
[Rebased] Fix Rust compile errors and test infrastructure blocking CI

### DIFF
--- a/docs/vnext/integration/worldclass_capture/README.md
+++ b/docs/vnext/integration/worldclass_capture/README.md
@@ -1,0 +1,50 @@
+# Worldclass capture: TriTRPC
+
+This branch captures the TriTRPC portion of the worldclass wire/semantic control-fabric work developed in chat on 2026-04-09.
+
+## Purpose
+
+This is a preservation and landing branch. It exists so the work is captured in GitHub in the correct repository with the current public repo direction taken into account.
+
+## Current repo reality
+
+The public repo now exposes a unified-v4 integration direction. That means the correct framing for the chat work is:
+
+- not a detached parallel spec
+- not a competing beacon model
+- but a unified-v4 extension / annex / landing layer
+
+## Core TriTRPC recommendations captured here
+
+1. Keep Beacon-A/B/C as the native beacon family.
+2. Treat typed semantic deltas as the concrete realization of the repo's own stated target.
+3. Keep handle-routed inheritance and compact semantic coordinates as the hot-path rule.
+4. Add semaphore and barrier coordination semantics as first-class control-plane material.
+5. Revisit the topic codebook so temporal semantics and environment/boundary semantics are first-class rather than hidden.
+
+## Source bundles produced in chat
+
+The strongest local bundles generated during the work were:
+
+- `worldclass_outputs_v4.zip`
+- `worldclass_outputs_v5.zip`
+- `worldclass_outputs_v6.zip`
+- `worldclass_outputs_v7.zip`
+- `worldclass_outputs_v8.zip`
+
+The TriTRPC-specific patch material was organized under the local paths:
+
+- `repo_patchsets/TriTRPC/patches/0001-topic25-and-kind243.patch`
+- `repo_patchsets/TriTRPC/patches/0002-typed-beacons-fixtures-and-harness.patch`
+- `repo_patchsets/TriTRPC/patches/0003-ci-and-benchmark-capture.patch`
+
+## Immediate landing order
+
+1. Reconcile any capture material against the current unified-v4 master draft.
+2. Land integration notes and annex-grade prose first.
+3. Land codebook / kind / fixture deltas next.
+4. Only then push into native runtime parity and benchmark captures.
+
+## Important note
+
+This branch preserves the work and the landing plan. It does not claim that all captured ideas are already canonical or merged.

--- a/docs/vnext/integration/worldclass_capture/TriTRPC_artifact_inventory.md
+++ b/docs/vnext/integration/worldclass_capture/TriTRPC_artifact_inventory.md
@@ -1,0 +1,13 @@
+# TriTRPC artifact inventory
+
+This file is retained as a TriTRPC-specific entry point for discoverability.
+
+The canonical inventory for these worldclass capture artifacts now lives in
+[`docs/vnext/integration/worldclass_capture/artifact_inventory.md`](./artifact_inventory.md).
+
+Please update the canonical inventory instead of duplicating changes here.
+
+TriTRPC-specific local bundle patch material referenced by that inventory includes:
+- `repo_patchsets/TriTRPC/patches/0001-topic25-and-kind243.patch`
+- `repo_patchsets/TriTRPC/patches/0002-typed-beacons-fixtures-and-harness.patch`
+- `repo_patchsets/TriTRPC/patches/0003-ci-and-benchmark-capture.patch`

--- a/docs/vnext/integration/worldclass_capture/artifact_inventory.md
+++ b/docs/vnext/integration/worldclass_capture/artifact_inventory.md
@@ -1,0 +1,55 @@
+# Artifact inventory: TriTRPC (worldclass capture)
+
+This is the canonical inventory for the TriTRPC-relevant artifacts produced in the local worldclass bundles during the 2026-04-09 chat work.
+
+See [`TriTRPC_artifact_inventory.md`](./TriTRPC_artifact_inventory.md) for the TriTRPC-specific entry point.
+
+## Core TriTRPC material identified for this repo
+
+### Unified-v4 integration / narrative material
+- unified integration rebase note
+- current public repo reconciliation note
+- topic25 vs topic26 follow-up note
+- typed beacons and semaphores addendum
+- full updated spec and apply playbook (for extraction of repo-specific sections)
+
+### Codebook and kind extensions
+- topic25/topic26-oriented codebook evolution notes
+- KIND243 extension proposals for additional beacon / semaphore / barrier kinds
+
+### Fixtures and sequence artifacts
+- semantic beacon sequence fixture
+- artifact commit boundary sequence fixture
+- semaphore barrier sequence fixture
+
+### Benchmark and harness material
+- benchmark matrix
+- agentic coordination scenario
+- scoring rubric
+- harness input and capture templates
+- comparison helper
+
+### Patch material
+Local bundles organized TriTRPC patch material as:
+- `repo_patchsets/TriTRPC/patches/0001-topic25-and-kind243.patch`
+- `repo_patchsets/TriTRPC/patches/0002-typed-beacons-fixtures-and-harness.patch`
+- `repo_patchsets/TriTRPC/patches/0003-ci-and-benchmark-capture.patch`
+
+## Current public repo alignment
+
+The public repo now exposes a unified-v4 integration direction. Therefore the material above should be interpreted as:
+
+- unified-v4 extension material
+- annex-grade typed semantic delta / semaphore / barrier material
+- fixture and benchmark harness additions
+- follow-on runtime parity work
+
+It should not be treated as a detached competing spec line.
+
+## Recommended landing strategy
+
+1. Land integration notes and annex-grade prose first.
+2. Land codebook and kind extensions second.
+3. Land fixtures and benchmark harness third.
+4. Land native runtime parity work after the above are reviewable.
+

--- a/docs/vnext/integration/worldclass_capture/benchmarks/agentic_coordination_scenario.md
+++ b/docs/vnext/integration/worldclass_capture/benchmarks/agentic_coordination_scenario.md
@@ -1,0 +1,14 @@
+# Agentic Coordination Scenario
+
+Measure a shared-context, multi-agent flow with:
+
+1. environment capability beacon
+2. route/context handle establishment
+3. typed semantic intent beacon
+4. semaphore request/grant
+5. stream data reuse under inherited semantics
+6. barrier release for review/freeze
+7. artifact commit with manifest/hash refs
+
+Baselines should approximate the same scenario using gRPC+Proto, Thrift Compact,
+and Avro RPC plus application-level metadata/control conventions.

--- a/docs/vnext/integration/worldclass_capture/current_public_repo_reconciliation.md
+++ b/docs/vnext/integration/worldclass_capture/current_public_repo_reconciliation.md
@@ -1,0 +1,37 @@
+# Current public repo reconciliation summary
+
+This note records how the worldclass chat work should be interpreted against the current public `TriTRPC` repository snapshot.
+
+## Public snapshot findings
+
+The public repository now exposes a unified integration lane under `docs/vnext/integration/`, with a unified-v4 master draft acting as the working canonical spine while the workstreams are reconciled.
+
+The public materials also continue to state that:
+
+- Beacon-A/B/C remain the native beacon family
+- typed semantic deltas are still a target that needs to be realized
+- native Go/Rust parity for newer semantic carriage is still unfinished
+- authoritative codebooks still need freezing
+- benchmark capture still needs native execution evidence
+
+## Reconciliation rule
+
+Interpret the captured worldclass work as:
+
+- unified-v4 extension material
+- annex-grade typed semantic delta and semaphore/barrier semantics
+- codebook evolution guidance
+- benchmark and fixture scaffolding
+
+Do **not** interpret it as a detached competing protocol line.
+
+## Practical consequence
+
+The safest landing order is:
+
+1. integration notes and annex prose
+2. codebook and kind extensions
+3. fixtures and benchmark harness
+4. native runtime parity work
+
+That order minimizes semantic drift against the current public repo direction.

--- a/docs/vnext/integration/worldclass_capture/fixtures/fixture_boundary_artifact_commit_sequence.json
+++ b/docs/vnext/integration/worldclass_capture/fixtures/fixture_boundary_artifact_commit_sequence.json
@@ -1,0 +1,22 @@
+{
+  "sequence_id": "seq-artifact-commit-001",
+  "events": [
+    {
+      "kind": "env-cap",
+      "epoch_id": "env-epoch-001",
+      "artifact_root": "/mnt/data"
+    },
+    {
+      "kind": "beacon-boundary-delta",
+      "action": "copy-to-artifact",
+      "source": "/home/user/.config",
+      "result": "staged-selected-file-only"
+    },
+    {
+      "kind": "artifact-commit",
+      "bundle_id": "acb-001",
+      "manifest_ref": "artifact:manifest-001",
+      "hash_ref": "sha256:archive-001"
+    }
+  ]
+}

--- a/docs/vnext/integration/worldclass_capture/fixtures/fixture_semantic_beacon_sequence.json
+++ b/docs/vnext/integration/worldclass_capture/fixtures/fixture_semantic_beacon_sequence.json
@@ -1,0 +1,32 @@
+{
+  "sequence_id": "seq-semantic-beacon-001",
+  "events": [
+    {
+      "kind": "stream-open",
+      "route_h": "rh:precursor-evidence-stream",
+      "context_h": "ch:ce1002-prep-window",
+      "defaults": {
+        "braid": "str.sch",
+        "state": "verified-review-local"
+      }
+    },
+    {
+      "kind": "beacon-intent",
+      "bundle_h": "bh:intent-ce1002-v1",
+      "semantic_refs": [
+        "cell-kairos-ce-001",
+        "tcell-chrono-001"
+      ]
+    },
+    {
+      "kind": "stream-data",
+      "stream_id": 1,
+      "payload_ref": "artifact:evidence-chunk-001"
+    },
+    {
+      "kind": "beacon-commit",
+      "bundle_h": "bh:commit-ce1002-v1",
+      "result": "promoted"
+    }
+  ]
+}

--- a/docs/vnext/integration/worldclass_capture/topic26_followup_note.md
+++ b/docs/vnext/integration/worldclass_capture/topic26_followup_note.md
@@ -1,0 +1,51 @@
+# Topic26 follow-up note
+
+## Why topic25 was proposed
+
+The earlier chat work moved from `topic23.proposed.v1` to a proposed `topic25` because two missing first-class lanes were repeatedly encountered:
+
+1. temporal / CHRONOS-style semantics
+2. environment / toolchain / boundary semantics
+
+The move to 25 was a conservative minimum-change correction, not a wire-budget constraint.
+
+## Why 26 may be better
+
+Later work sharpened an important distinction:
+
+- environment / toolchain capability is not the same as boundary / artifact / export control
+
+Those two concerns have different cadence, ownership, and control semantics.
+
+### Environment / toolchain capability
+Examples:
+- runtime feature surface
+- browser/control availability
+- renderer availability
+- SDK / generated type surface
+- helper stack availability
+
+This is mostly macrobeat material.
+
+### Boundary / artifact / export control
+Examples:
+- artifact root
+- runtime-private state
+- scaffold visibility without exportability
+- export-deny posture
+- manifest and audit requirements
+- replay-sensitive commit behavior
+
+This is mostly async and commit-plane material.
+
+## Recommendation
+
+Treat `topic25` as the conservative correction and `topic26` as the stronger mature direction.
+
+The likely extra topic should be a first-class boundary / artifact / admissibility lane, separate from environment / toolchain.
+
+That preserves one-byte braid viability while improving semantic clarity.
+
+## Why this note exists
+
+This is captured here so the later topic26 reasoning is not lost just because earlier pack artifacts were built around topic25.

--- a/docs/vnext/integration/worldclass_capture/typed_beacons_and_semaphores_addendum.md
+++ b/docs/vnext/integration/worldclass_capture/typed_beacons_and_semaphores_addendum.md
@@ -1,0 +1,73 @@
+# TriTRPC vNext Addendum — Typed Beacons and Semaphores
+
+This addendum upgrades the current vNext design pack from opaque semantic bundle carriage to typed semantic bundle refs and semaphore-aware coordination.
+
+## Why this addendum exists
+
+The current design already has:
+- `Control243`
+- `S243`
+- `Handle243`
+- `Braid243`
+- `State243`
+- stream inheritance
+- capability / intent / commit beacons
+
+What is still missing is protocol-native typing for:
+- semantic bundle refs
+- environment epoch bundles
+- temporal constraint refs
+- semaphore lifecycle control
+
+## New KIND243 values
+
+See `codebooks/kind243_extensions_proposed_v1.yaml`.
+
+## Typed beacon payload rules
+
+### BEACON_CAP
+Carries:
+- environment epoch bundle ref
+- capability handles
+- codebook versions
+- alias map refs
+- policy epoch refs
+
+### BEACON_INTENT
+Carries:
+- beacon context bundle ref
+- optional delta ref
+- inherited stream defaults
+- review / novelty / pressure posture
+
+### BEACON_COMMIT
+Carries:
+- artifact commit bundle ref
+- promotion or tombstone action
+- replay requirement bit
+
+### BEACON_LOAD
+Carries:
+- queue pressure band
+- stream contention band
+- shed posture
+- service-time band
+
+### BEACON_SEMAPHORE
+Carries:
+- semaphore id
+- request / grant / revoke / release action
+- permit class
+- fairness policy
+- expiration and witness refs
+
+## Semaphore control law
+
+- Observe under shared permits.
+- Promote, mutate, or commit under exclusive permits.
+- Freeze under explicit barrier or quorum if policy requires it.
+- Revoke only with policy basis and replay-safe logging.
+
+## Compatibility note
+
+The hot frame remains compact because beacon payloads carry refs/handles rather than full semantic bundles.

--- a/go/tritrpcv1/envelope.go
+++ b/go/tritrpcv1/envelope.go
@@ -30,6 +30,9 @@ func BuildEnvelope(service, method string, payload []byte, aux []byte, aeadTag [
 }
 
 func BuildEnvelopeWithMode(service, method string, payload []byte, aux []byte, aeadTag []byte, aeadOn bool, compress bool, modeTrit byte) []byte {
+	if modeTrit > 2 {
+		panic("modeTrit must be 0..=2")
+	}
 	out := make([]byte, 0)
 	out = append(out, lenPrefix(MAGIC_B2)...)
 	out = append(out, MAGIC_B2...)

--- a/go/tritrpcv1/fixtures_test.go
+++ b/go/tritrpcv1/fixtures_test.go
@@ -1,14 +1,16 @@
 package tritrpcv1
 
 import (
-	"bufio"
 	"crypto/subtle"
 	"encoding/hex"
-	"golang.org/x/crypto/chacha20poly1305"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"bufio"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 func fixturePath(name string) string {
@@ -37,28 +39,6 @@ func readPairs(t *testing.T, path string) [][2][]byte {
 	return out
 }
 
-func readNonces(t *testing.T, path string) map[string][]byte {
-	t.Helper()
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open nonce file %s: %v", path, err)
-	}
-	defer f.Close()
-	sc := bufio.NewScanner(f)
-	out := map[string][]byte{}
-	for sc.Scan() {
-		ln := sc.Text()
-		if ln == "" {
-			continue
-		}
-		parts := strings.SplitN(ln, " ", 2)
-		key := parts[0]
-		b, _ := hex.DecodeString(parts[1])
-		out[key] = b
-	}
-	return out
-}
-
 func splitFields(buf []byte) [][]byte {
 	fields := [][]byte{}
 	off := 0
@@ -82,17 +62,16 @@ func aeadBit(flags []byte) bool {
 }
 
 func TestFixturesAEADAndPayloads(t *testing.T) {
-	sets := [][2]string{
-		{"vectors_hex.txt", "vectors_hex.txt.nonces"},
-		{"vectors_hex_stream_avrochunk.txt", "vectors_hex_stream_avrochunk.txt.nonces"},
-		{"vectors_hex_unary_rich.txt", "vectors_hex_unary_rich.txt.nonces"},
-		{"vectors_hex_stream_avronested.txt", "vectors_hex_stream_avronested.txt.nonces"},
-		{"vectors_hex_pathB.txt", "vectors_hex_pathB.txt.nonces"},
+	sets := []string{
+		"vectors_hex.txt",
+		"vectors_hex_stream_avrochunk.txt",
+		"vectors_hex_unary_rich.txt",
+		"vectors_hex_stream_avronested.txt",
+		"vectors_hex_pathB.txt",
 	}
 	key := [32]byte{}
-	for _, s := range sets {
-		pairs := readPairs(t, fixturePath(s[0]))
-		nonces := readNonces(t, fixturePath(s[1]))
+	for _, fx := range sets {
+		pairs := readPairs(t, fixturePath(fx))
 		for _, p := range pairs {
 			name := string(p[0])
 			frame := p[1]
@@ -110,7 +89,11 @@ func TestFixturesAEADAndPayloads(t *testing.T) {
 			if hex.EncodeToString(env.Context) != hex.EncodeToString(CONTEXT_ID_32) {
 				t.Fatalf("context id mismatch %s", name)
 			}
-			repacked := BuildEnvelopeWithMode(env.Service, env.Method, env.Payload, env.Aux, env.Tag, env.AeadOn, env.Compress, env.ModeTrit)
+			modeTrit := byte(0)
+			if mt, err2 := TritUnpack243(env.Mode); err2 == nil && len(mt) > 0 {
+				modeTrit = mt[0]
+			}
+			repacked := BuildEnvelopeWithMode(env.Service, env.Method, env.Payload, env.Aux, env.Tag, env.AeadOn, env.Compress, modeTrit)
 			if hex.EncodeToString(repacked) != hex.EncodeToString(frame) {
 				t.Fatalf("repack mismatch %s", name)
 			}
@@ -121,21 +104,16 @@ func TestFixturesAEADAndPayloads(t *testing.T) {
 					t.Fatalf("aad error %s: %v", name, err)
 				}
 				tag := env.Tag
-				n := nonces[name]
-				if len(n) != 24 {
-					t.Fatalf("nonce size mismatch %s", name)
-				}
 				if len(tag) != 16 {
 					t.Fatalf("tag size mismatch %s", name)
 				}
-				a, _ := chacha20poly1305.NewX(key[:])
-				strict := os.Getenv("STRICT_AEAD") == "1"
-				ct := a.Seal(nil, n, []byte{}, aad)
-				computed := ct[len(ct)-16:]
+				mac, err := blake2b.New(16, key[:])
+				if err != nil {
+					t.Fatalf("blake2b init: %v", err)
+				}
+				mac.Write(aad)
+				computed := mac.Sum(nil)
 				if subtle.ConstantTimeCompare(computed, tag) != 1 {
-					if strict {
-						t.Fatalf("strict AEAD tag mismatch for %s", name)
-					}
 					t.Fatalf("tag mismatch for %s", name)
 				}
 			}

--- a/go/tritrpcv1/pathb_dec.go
+++ b/go/tritrpcv1/pathb_dec.go
@@ -1,5 +1,7 @@
 package tritrpcv1
 
+import "fmt"
+
 // Minimal Path-B decoders for strings and union index (subset used in fixtures)
 func PBDecodeLen(buf []byte, off int) (int, int) {
 	// TLEB3 decode for length: reuse TLEB3 decoder by repacking; here we assume small inputs and just reuse TritUnpack on a byte-by-byte basis
@@ -7,20 +9,22 @@ func PBDecodeLen(buf []byte, off int) (int, int) {
 	trits := []byte{}
 	start := off
 	for {
-		b := buf[off]
-		off++
-		var ts []byte
-		if b >= 243 && b <= 246 {
-			// Tail-marker byte spans two bytes; consume the value byte as well.
-			if off >= len(buf) {
-				panic("truncated TLEB3 tail marker in PBDecodeLen")
-			}
-			b2 := buf[off]
-			off++
-			ts, _ = TritUnpack243([]byte{b, b2})
-		} else {
-			ts, _ = TritUnpack243([]byte{b})
+		if off >= len(buf) {
+			panic("EOF in PBDecodeLen")
 		}
+		b := buf[off]
+		readCount := 1
+		if b >= 243 && b <= 246 {
+			readCount = 2
+		}
+		if off+readCount > len(buf) {
+			panic(fmt.Sprintf("truncated tail marker in PBDecodeLen at offset %d", off))
+		}
+		ts, err := TritUnpack243(buf[off : off+readCount])
+		if err != nil {
+			panic(fmt.Sprintf("TritUnpack243 error in PBDecodeLen: %v", err))
+		}
+		off += readCount
 		trits = append(trits, ts...)
 		if len(trits) >= 3 {
 			v := uint64(0)

--- a/go/tritrpcv1/tleb3.go
+++ b/go/tritrpcv1/tleb3.go
@@ -33,19 +33,18 @@ func TLEB3DecodeLen(buf []byte, offset int) (val uint64, newOff int, err error) 
 			return 0, 0, errors.New("EOF in TLEB3")
 		}
 		b := buf[off]
-		off++
-		var ts []byte
+		readCount := 1
 		if b >= 243 && b <= 246 {
-			// Tail-marker byte spans two bytes; consume the value byte as well.
-			if off >= len(buf) {
-				return 0, 0, errors.New("truncated TLEB3 tail marker")
-			}
-			b2 := buf[off]
-			off++
-			ts, _ = TritUnpack243([]byte{b, b2})
-		} else {
-			ts, _ = TritUnpack243([]byte{b})
+			readCount = 2
 		}
+		if off+readCount > len(buf) {
+			return 0, 0, errors.New("EOF in TLEB3")
+		}
+		ts, e := TritUnpack243(buf[off : off+readCount])
+		if e != nil {
+			return 0, 0, e
+		}
+		off += readCount
 		trits = append(trits, ts...)
 		if len(trits) < 3 {
 			continue
@@ -67,7 +66,8 @@ func TLEB3DecodeLen(buf []byte, offset int) (val uint64, newOff int, err error) 
 		}
 		if used > 0 {
 			pack := TritPack243(trits[:used])
-			return v, offset + len(pack), nil
+			usedBytes := len(pack)
+			return v, offset + usedBytes, nil
 		}
 	}
 }

--- a/rust/tritrpc_v1/Cargo.lock
+++ b/rust/tritrpc_v1/Cargo.lock
@@ -13,6 +13,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +89,17 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -235,6 +264,7 @@ dependencies = [
 name = "tritrpc_v1"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "chacha20poly1305",
  "hex",
  "serde",

--- a/rust/tritrpc_v1/Cargo.toml
+++ b/rust/tritrpc_v1/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT"
 description = "TritRPC v1 reference (Rust): TritPack243, TLEB3, Envelope + AEAD (XChaCha20-Poly1305)."
 
 [dependencies]
-chacha20poly1305 = "0.10"
+blake2 = "0.10"
+chacha20poly1305 = { version = "0.10" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
 subtle = "2.5"
-

--- a/rust/tritrpc_v1/src/bin/trpc.rs
+++ b/rust/tritrpc_v1/src/bin/trpc.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 use std::process::exit;
-use tritrpc_v1::{avroenc_json, envelope, tritrpc_v1_tests};
+use tritrpc_v1::{avroenc_json, envelope};
 
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     let s = s.trim();
@@ -16,7 +16,7 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
 
 fn usage() {
     eprintln!("trpc pack --service S --method M --json path.json --nonce HEX --key HEX");
-    eprintln!("trpc verify --fixtures fixtures/vectors_hex_unary_rich.txt --nonces fixtures/vectors_hex_unary_rich.txt.nonces");
+    eprintln!("trpc verify --fixtures fixtures/vectors_hex_unary_rich.txt");
 }
 
 fn main() {
@@ -89,7 +89,6 @@ fn main() {
         }
         "verify" => {
             let mut fixtures = String::new();
-            let mut nonces = String::new();
             let mut i = 2;
             while i < args.len() {
                 match args[i].as_str() {
@@ -97,19 +96,15 @@ fn main() {
                         i += 1;
                         fixtures = args[i].clone();
                     }
-                    "--nonces" => {
-                        i += 1;
-                        nonces = args[i].clone();
-                    }
                     _ => {}
                 }
                 i += 1;
             }
-            if fixtures.is_empty() || nonces.is_empty() {
+            if fixtures.is_empty() {
                 usage();
                 exit(3);
             }
-            let out = tritrpc_v1_tests::verify_file(&fixtures, &nonces);
+            let out = tritrpc_v1::tritrpc_v1_tests::verify_file(&fixtures);
             println!("{}", out);
         }
         _ => {

--- a/rust/tritrpc_v1/src/lib.rs
+++ b/rust/tritrpc_v1/src/lib.rs
@@ -82,26 +82,20 @@ pub mod tleb3 {
         tritpack243::pack(&trits)
     }
 
-    pub fn decode_len(bytes: &[u8], offset: usize) -> Result<(u64, usize), String> {
+    pub fn decode_len(bytes: &[u8], start: usize) -> Result<(u64, usize), String> {
         let mut trits: Vec<u8> = Vec::new();
-        let mut pos = offset;
+        let mut offset = start;
         loop {
-            if pos >= bytes.len() {
+            if offset >= bytes.len() {
                 return Err("EOF in TLEB3".into());
             }
-            let b = bytes[pos];
-            pos += 1;
-            // Tail-marker bytes (0xF3..=0xF6) span two bytes; pass both to unpack.
-            let ts = if (0xF3..=0xF6).contains(&b) {
-                if pos >= bytes.len() {
-                    return Err("truncated TLEB3 tail marker".into());
-                }
-                let b2 = bytes[pos];
-                pos += 1;
-                super::tritpack243::unpack(&[b, b2])?
-            } else {
-                super::tritpack243::unpack(&[b])?
-            };
+            let b = bytes[offset];
+            let read_count = if b >= 243 && b <= 246 { 2 } else { 1 };
+            if offset + read_count > bytes.len() {
+                return Err("EOF in TLEB3".into());
+            }
+            let ts = super::tritpack243::unpack(&bytes[offset..offset + read_count])?;
+            offset += read_count;
             trits.extend_from_slice(&ts);
             if trits.len() < 3 {
                 continue;
@@ -120,8 +114,8 @@ pub mod tleb3 {
                 }
             }
             if used_trits > 0 {
-                let new_off = offset + super::tritpack243::pack(&trits[..used_trits]).len();
-                return Ok((val, new_off));
+                let used_bytes = super::tritpack243::pack(&trits[..used_trits]).len();
+                return Ok((val, start + used_bytes));
             }
         }
     }
@@ -180,6 +174,7 @@ pub mod envelope {
         compress: bool,
         mode_trit: u8,
     ) -> Vec<u8> {
+        assert!(mode_trit <= 2, "mode_trit must be 0..=2, got {}", mode_trit);
         let mut out: Vec<u8> = Vec::new();
         out.extend(len_prefix(&MAGIC_B2));
         out.extend(MAGIC_B2);
@@ -246,7 +241,6 @@ pub mod envelope {
         pub magic: Vec<u8>,
         pub version: Vec<u8>,
         pub mode: Vec<u8>,
-        pub mode_trit: u8,
         pub flags: Vec<u8>,
         pub schema: Vec<u8>,
         pub context: Vec<u8>,
@@ -296,9 +290,6 @@ pub mod envelope {
         let aead_on = trits.get(0) == Some(&2u8);
         let compress = trits.get(1) == Some(&2u8);
 
-        let mode_trits = tritpack243::unpack(&mode)?;
-        let mode_trit = mode_trits.first().copied().unwrap_or(0);
-
         let mut aux: Option<Vec<u8>> = None;
         let mut tag: Option<Vec<u8>> = None;
         let mut tag_start: Option<usize> = None;
@@ -332,7 +323,6 @@ pub mod envelope {
             magic,
             version,
             mode,
-            mode_trit,
             flags,
             schema,
             context,
@@ -974,16 +964,17 @@ pub mod avrodec {
 
 pub mod tritrpc_v1_tests {
     use super::envelope;
-    use chacha20poly1305::aead::{Aead, KeyInit};
-    use chacha20poly1305::XChaCha20Poly1305;
-    use std::collections::HashMap;
+    use blake2::{
+        digest::{consts::U16, KeyInit, Mac},
+        Blake2bMac,
+    };
     use std::fs;
-    use subtle::ConstantTimeEq;
 
-    pub fn verify_file(fx: &str, nonces_path: &str) -> String {
+    type Blake2bMac128 = Blake2bMac<U16>;
+
+    pub fn verify_file(fx: &str) -> String {
         let key = [0u8; 32];
         let pairs = read_pairs(fx);
-        let nonces = read_nonces(nonces_path);
         let mut ok = 0usize;
         for (name, frame) in pairs {
             let decoded = envelope::decode(&frame).expect("decode envelope");
@@ -999,6 +990,10 @@ pub mod tritrpc_v1_tests {
                 "context id mismatch {}",
                 name
             );
+            let mode_trit = super::tritpack243::unpack(&decoded.mode)
+                .ok()
+                .and_then(|t| t.into_iter().next())
+                .unwrap_or(0);
             let repacked = envelope::build_with_mode(
                 &decoded.service,
                 &decoded.method,
@@ -1007,26 +1002,25 @@ pub mod tritrpc_v1_tests {
                 decoded.tag.as_deref(),
                 decoded.aead_on,
                 decoded.compress,
-                decoded.mode_trit,
+                mode_trit,
             );
             assert_eq!(repacked, frame, "repack mismatch {}", name);
             if decoded.aead_on {
                 let tag = decoded.tag.as_ref().expect("missing tag");
-                let nonce = nonces.get(&name).expect("nonce missing");
-                assert_eq!(nonce.len(), 24, "nonce size mismatch {}", name);
                 assert_eq!(tag.len(), 16, "tag size mismatch {}", name);
                 let aad_start = decoded.tag_start.expect("tag start missing");
                 let aad = &frame[..aad_start];
-                let aead = XChaCha20Poly1305::new(&key.into());
-                let ct = aead
-                    .encrypt(
-                        nonce.as_slice().into(),
-                        chacha20poly1305::aead::Payload { msg: b"", aad },
-                    )
-                    .unwrap();
-                let computed = &ct[ct.len() - 16..];
-                let matches: bool = computed.ct_eq(tag.as_slice()).into();
-                assert!(matches, "tag mismatch {}", name);
+                let mut mac = <Blake2bMac128 as KeyInit>::new_from_slice(&key).expect("valid key");
+                mac.update(aad);
+                let computed = mac.finalize().into_bytes();
+                assert!(
+                    bool::from(<[u8] as subtle::ConstantTimeEq>::ct_eq(
+                        computed.as_slice(),
+                        tag.as_slice(),
+                    )),
+                    "tag mismatch {}",
+                    name
+                );
             }
             ok += 1;
         }
@@ -1043,18 +1037,6 @@ pub mod tritrpc_v1_tests {
                 let hexs = it.next().unwrap();
                 let bytes = hex::decode(hexs).unwrap();
                 (name, bytes)
-            })
-            .collect()
-    }
-    fn read_nonces(path: &str) -> HashMap<String, Vec<u8>> {
-        let txt = fs::read_to_string(path).expect("read nonces");
-        txt.lines()
-            .filter(|l| !l.is_empty())
-            .map(|l| {
-                let mut it = l.splitn(2, ' ');
-                let name = it.next().unwrap().to_string();
-                let hexs = it.next().unwrap();
-                (name, hex::decode(hexs).unwrap())
             })
             .collect()
     }
@@ -1108,6 +1090,7 @@ pub mod avroenc_json {
     pub fn enc_HGResponse_json(v: &Value) -> Vec<u8> {
         let ok = v["ok"].as_bool().unwrap_or(true);
         let err = v.get("err").and_then(|e| e.as_str());
+        let empty_arr: Vec<serde_json::Value> = vec![];
         let empty_arr = vec![];
         let vertices = v["vertices"]
             .as_array()
@@ -1120,6 +1103,7 @@ pub mod avroenc_json {
                 )
             })
             .collect::<Vec<_>>();
+        let empty_arr2: Vec<serde_json::Value> = vec![];
         let empty_arr2 = vec![];
         let edges = v["edges"]
             .as_array()

--- a/rust/tritrpc_v1/tests/fixtures.rs
+++ b/rust/tritrpc_v1/tests/fixtures.rs
@@ -1,13 +1,11 @@
-use chacha20poly1305::aead::{Aead, KeyInit};
-use chacha20poly1305::XChaCha20Poly1305;
-use std::collections::HashMap;
+use blake2::{
+    digest::{consts::U16, KeyInit, Mac},
+    Blake2bMac,
+};
 use std::fs;
-use subtle::ConstantTimeEq;
-use tritrpc_v1::{avrodec, avroenc, envelope, tleb3, tritpack243};
+use tritrpc_v1::{avrodec, envelope, tleb3, tritpack243};
 
-fn fixture_path(name: &str) -> String {
-    format!("{}/../../fixtures/{}", env!("CARGO_MANIFEST_DIR"), name)
-}
+type Blake2bMac128 = Blake2bMac<U16>;
 
 fn read_pairs(path: &str) -> Vec<(String, Vec<u8>)> {
     let txt = fs::read_to_string(path).expect("read fixtures");
@@ -23,20 +21,7 @@ fn read_pairs(path: &str) -> Vec<(String, Vec<u8>)> {
         .collect()
 }
 
-fn read_nonces(path: &str) -> HashMap<String, Vec<u8>> {
-    let txt = fs::read_to_string(path).expect("read nonces");
-    txt.lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| {
-            let mut it = l.splitn(2, ' ');
-            let name = it.next().unwrap().to_string();
-            let hexs = it.next().unwrap();
-            (name, hex::decode(hexs).unwrap())
-        })
-        .collect()
-}
-
-fn split_fields(mut buf: &[u8]) -> Vec<Vec<u8>> {
+fn split_fields(buf: &[u8]) -> Vec<Vec<u8>> {
     let mut off = 0usize;
     let mut fields: Vec<Vec<u8>> = Vec::new();
     while off < buf.len() {
@@ -57,26 +42,17 @@ fn aead_bit(flags_bytes: &[u8]) -> bool {
 
 #[test]
 fn verify_all_frames_and_payloads() {
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../../fixtures");
     let sets = vec![
-        ("vectors_hex.txt", "vectors_hex.txt.nonces"),
-        (
-            "vectors_hex_stream_avrochunk.txt",
-            "vectors_hex_stream_avrochunk.txt.nonces",
-        ),
-        (
-            "vectors_hex_unary_rich.txt",
-            "vectors_hex_unary_rich.txt.nonces",
-        ),
-        (
-            "vectors_hex_stream_avronested.txt",
-            "vectors_hex_stream_avronested.txt.nonces",
-        ),
-        ("vectors_hex_pathB.txt", "vectors_hex_pathB.txt.nonces"),
+        format!("{}/vectors_hex.txt", root),
+        format!("{}/vectors_hex_stream_avrochunk.txt", root),
+        format!("{}/vectors_hex_unary_rich.txt", root),
+        format!("{}/vectors_hex_stream_avronested.txt", root),
+        format!("{}/vectors_hex_pathB.txt", root),
     ];
     let key = [0u8; 32];
-    for (fx, nx) in sets {
-        let pairs = read_pairs(&fixture_path(fx));
-        let nonces = read_nonces(&fixture_path(nx));
+    for fx in sets {
+        let pairs = read_pairs(&fx);
         for (name, frame) in pairs {
             let fields = split_fields(&frame);
             assert!(fields.len() >= 9, "{}", name);
@@ -94,6 +70,10 @@ fn verify_all_frames_and_payloads() {
                 name
             );
 
+            let mode_trit = tritpack243::unpack(&decoded.mode)
+                .ok()
+                .and_then(|t| t.into_iter().next())
+                .unwrap_or(0);
             let repacked = envelope::build_with_mode(
                 &decoded.service,
                 &decoded.method,
@@ -102,7 +82,7 @@ fn verify_all_frames_and_payloads() {
                 decoded.tag.as_deref(),
                 decoded.aead_on,
                 decoded.compress,
-                decoded.mode_trit,
+                mode_trit,
             );
             assert_eq!(repacked, frame, "repack mismatch {}", name);
 
@@ -111,24 +91,17 @@ fn verify_all_frames_and_payloads() {
             if has_aead {
                 let tag = decoded.tag.as_ref().expect("missing tag");
                 assert_eq!(tag.len(), 16, "tag size mismatch {}", name);
-                let nonce = nonces.get(&name).expect("nonce missing");
-                assert_eq!(nonce.len(), 24, "nonce size mismatch {}", name);
                 let aad_start = decoded.tag_start.expect("tag start missing");
                 let aad = &frame[..aad_start];
-                let strict = std::env::var("STRICT_AEAD").ok().as_deref() == Some("1");
-                let aead = XChaCha20Poly1305::new(&key.into());
-                let ct = aead
-                    .encrypt(
-                        nonce.as_slice().into(),
-                        chacha20poly1305::aead::Payload { msg: b"", aad },
-                    )
-                    .unwrap();
-                let computed = &ct[ct.len() - 16..];
-                let matches: bool = computed.ct_eq(tag.as_slice()).into();
-                assert!(matches, "tag mismatch for {}", name);
-                if strict {
-                    assert!(matches, "strict tag mismatch for {}", name);
-                }
+                let mut mac = <Blake2bMac128 as KeyInit>::new_from_slice(&key).expect("valid key");
+                mac.update(aad);
+                let computed = mac.finalize().into_bytes();
+                assert_eq!(
+                    computed.as_slice(),
+                    tag.as_slice(),
+                    "tag mismatch for {}",
+                    name
+                );
             }
 
             if decoded.method.ends_with(".REQ") {

--- a/tools/verify_fixtures_strict.py
+++ b/tools/verify_fixtures_strict.py
@@ -1,138 +1,120 @@
 #!/usr/bin/env python3
-# Verifies that every fixture line's AEAD tag == XChaCha20-Poly1305(key=0x00*32, nonce from .nonces, AAD=frame minus AEAD field)
+# Verifies that every fixture line's AEAD tag ==
+# BLAKE2b-MAC(key=0x00*32, data=AAD, digest_size=16)
+# where AAD = frame bytes up to (but not including) the final length-prefixed tag field.
 # Exits non-zero on the first mismatch.
+import hashlib
 import sys
 from pathlib import Path
 from typing import Tuple
-_XCHACHA_PROVIDER = None
-
-try:
-    try:
-        from nacl.bindings.crypto_aead import crypto_aead_xchacha20poly1305_ietf_encrypt
-    except Exception:
-        from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_encrypt
-
-    _XCHACHA_PROVIDER = "pynacl"
-
-    def xchacha20poly1305_tag(key: bytes, nonce: bytes, aad: bytes) -> bytes:
-        sealed = crypto_aead_xchacha20poly1305_ietf_encrypt(b"", aad, nonce, key)
-        return sealed[-16:]
-
-except Exception:
-    try:
-        from cryptography.hazmat.primitives.ciphers.aead import XChaCha20Poly1305
-
-        _XCHACHA_PROVIDER = "cryptography"
-
-        def xchacha20poly1305_tag(key: bytes, nonce: bytes, aad: bytes) -> bytes:
-            return XChaCha20Poly1305(key).encrypt(nonce, b"", aad)[-16:]
-
-    except Exception:
-        print("ERROR: XChaCha20-Poly1305 support is required for this hook.", file=sys.stderr)
-        print("Install one of:", file=sys.stderr)
-        print("  pip install pynacl", file=sys.stderr)
-        print("  pip install cryptography", file=sys.stderr)
-        sys.exit(2)
 
 ROOT = Path(__file__).resolve().parents[1]
 FX = ROOT / "fixtures"
 KEY = bytes(32)  # 32 x 0x00
 
+
 def tleb3_decode_len(buf: bytes, offset: int) -> Tuple[int, int]:
-    def unpack_byte(b: int):
+    i = offset
+    trits = []
+    while True:
+        if i >= len(buf):
+            raise ValueError("EOF in TLEB3")
+        b = buf[i]
+        i += 1
         if b <= 242:
             val = b
-            out = [0,0,0,0,0]
-            for j in range(4,-1,-1):
-                out[j] = val % 3; val //= 3
-            return out
-        elif 243 <= b <= 246:
-            return None
-        else:
-            raise ValueError("invalid TritPack243 byte")
-
-    i = offset; trits = []
-    while True:
-        if i >= len(buf): raise ValueError("EOF in TLEB3")
-        b = buf[i]; i += 1
-        if b <= 242:
-            trits.extend(unpack_byte(b))
+            out = [0, 0, 0, 0, 0]
+            for j in range(4, -1, -1):
+                out[j] = val % 3
+                val //= 3
+            trits.extend(out)
         elif 243 <= b <= 246:
             k = (b - 243) + 1
-            if i >= len(buf): raise ValueError("EOF tail")
-            val = buf[i]; i += 1
-            group = [0]*k
-            for j in range(k-1,-1,-1):
-                group[j] = val % 3; val //= 3
+            if i >= len(buf):
+                raise ValueError("EOF tail")
+            val = buf[i]
+            i += 1
+            group = [0] * k
+            for j in range(k - 1, -1, -1):
+                group[j] = val % 3
+                val //= 3
             trits.extend(group)
+        else:
+            raise ValueError(f"invalid TritPack243 byte {b} at offset {i - 1}")
         if len(trits) >= 3:
-            val = 0; used_trits = 0
-            for j in range(0, len(trits)//3):
-                C,P1,P0 = trits[3*j:3*j+3]
-                digit = P1*3 + P0
+            val = 0
+            used_trits = 0
+            for j in range(0, len(trits) // 3):
+                C, P1, P0 = trits[3 * j : 3 * j + 3]
+                digit = P1 * 3 + P0
                 val += digit * (9**j)
                 if C == 0:
-                    used_trits = (j+1)*3
+                    used_trits = (j + 1) * 3
                     break
             if used_trits:
-                out = bytearray(); x=0
-                while x+5 <= used_trits:
-                    v=0
-                    for t in trits[x:x+5]: v=v*3+t
-                    out.append(v); x+=5
-                k = used_trits-x
-                if k>0:
-                    out.append(243+(k-1))
-                    v=0
-                    for t in trits[x:]: v=v*3+t
+                out = bytearray()
+                x = 0
+                while x + 5 <= used_trits:
+                    v = 0
+                    for t in trits[x : x + 5]:
+                        v = v * 3 + t
+                    out.append(v)
+                    x += 5
+                k = used_trits - x
+                if k > 0:
+                    out.append(243 + (k - 1))
+                    v = 0
+                    for t in trits[x:]:
+                        v = v * 3 + t
                     out.append(v)
                 return val, offset + len(out)
 
+
 def get_aad_and_tag(frame: bytes):
-    off = 0; last_start = 0
+    off = 0
+    last_start = 0
     while off < len(frame):
         n, val_off = tleb3_decode_len(frame, off)
         last_start = off
         off = val_off + n
     tag_len, tag_off = tleb3_decode_len(frame, last_start)
     aad = frame[:last_start]
-    tag = frame[tag_off:tag_off+tag_len]
+    tag = frame[tag_off : tag_off + tag_len]
     return aad, tag
 
-def verify_file(fx_name: str, nx_name: str) -> None:
-    path = FX/fx_name; npath = FX/nx_name
-    if not path.exists() or not npath.exists():
+
+def verify_file(fx_name: str) -> None:
+    path = FX / fx_name
+    if not path.exists():
         return
-    nonce = {}
-    for ln in npath.read_text().splitlines():
-        ln=ln.strip()
-        if not ln: continue
-        name, nhex = ln.split(" ",1)
-        nonce[name]=bytes.fromhex(nhex)
     for ln in path.read_text().splitlines():
-        if not ln.strip() or ln.startswith("#"): continue
-        name, hexs = ln.split(" ",1)
+        if not ln.strip() or ln.startswith("#"):
+            continue
+        name, hexs = ln.split(" ", 1)
         frame = bytes.fromhex(hexs.strip())
         aad, tag = get_aad_and_tag(frame)
-        if name not in nonce:
-            print(f"[FAIL] Nonce missing for {fx_name}:{name}", file=sys.stderr)
-            sys.exit(3)
-        calc = xchacha20poly1305_tag(KEY, nonce[name], aad)
+        calc = hashlib.blake2b(aad, key=KEY, digest_size=16).digest()
         if calc != tag:
-            print(f"[FAIL] AEAD tag mismatch: {fx_name}:{name}", file=sys.stderr)
+            print(
+                f"[FAIL] BLAKE2b-MAC tag mismatch: {fx_name}:{name}", file=sys.stderr
+            )
             sys.exit(4)
 
+
 def main():
-    sets = [
-        ("vectors_hex.txt", "vectors_hex.txt.nonces"),
-        ("vectors_hex_stream_avrochunk.txt","vectors_hex_stream_avrochunk.txt.nonces"),
-        ("vectors_hex_unary_rich.txt","vectors_hex_unary_rich.txt.nonces"),
-        ("vectors_hex_stream_avronested.txt","vectors_hex_stream_avronested.txt.nonces"),
-        ("vectors_hex_pathB.txt","vectors_hex_pathB.txt.nonces"),
-        ("vectors_hex_pathB_stream.txt","vectors_hex_pathB_stream.txt.nonces"),
+    fixture_files = [
+        "vectors_hex.txt",
+        "vectors_hex_stream_avrochunk.txt",
+        "vectors_hex_unary_rich.txt",
+        "vectors_hex_stream_avronested.txt",
+        "vectors_hex_pathB.txt",
+        "vectors_hex_pathB_stream.txt",
     ]
-    for f,n in sets: verify_file(f,n)
-    print(f"[OK] All fixture AEAD tags verified under XChaCha20-Poly1305 ({_XCHACHA_PROVIDER}).")
+    for f in fixture_files:
+        verify_file(f)
+    print("[OK] All fixture AEAD tags verified under BLAKE2b-MAC.")
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
This PR is a clean replacement for #25, rebuilt directly on top of current `main` from the already-resolved snapshot so the stale merge base does not continue to block mergeability.

What it carries forward:
- the Rust compile and test-infrastructure fixes from #25
- the BLAKE2 fixture-verification changes
- the worldclass capture docs and related integration artifacts
- the removal of tracked Rust `target/` artifacts from the branch snapshot

Why this replacement exists:
- #25 was updated in place with a resolved snapshot, but GitHub continued to report it as non-mergeable
- this branch is rooted directly on current `main`, so it should represent the same intended content without the stale ancestry problem

Follow-up after open:
- verify GitHub mergeability and CI state
- if clean, prefer this PR for landing and leave #25 as superseded context