### PR TITLE
[Rebased] Integration/worldclass phase4

### DIFF
--- a/docs/vnext/integration/worldclass_phase4/README.md
+++ b/docs/vnext/integration/worldclass_phase4/README.md
@@ -1,0 +1,19 @@
+# Worldclass phase 4 native test target slice
+
+This branch starts the first native-test-target-oriented slice on top of the runnable phase-3 reference tooling.
+
+## Scope of slice 1
+
+This slice targets exactly one stable reviewed fixture family:
+- `fixture_semantic_beacon_sequence.json`
+
+## Intent
+
+The purpose is not to implement the full runtime semantics yet.
+The purpose is to define and emit a compact native-test manifest that a Rust or Go test can consume later.
+
+## Deliverables in this slice
+
+1. a manifest emitter for the semantic beacon fixture family
+2. one example native-test manifest output
+3. acceptance gates describing when this slice is good enough to stack into real runtime tests

--- a/docs/vnext/integration/worldclass_phase4/acceptance_gates.md
+++ b/docs/vnext/integration/worldclass_phase4/acceptance_gates.md
@@ -1,0 +1,22 @@
+# Phase 4 acceptance gates
+
+This note defines when the first native-test-target slice should be considered complete enough to merge into the phase-3 branch.
+
+## Required artifacts
+
+- [ ] `emit_native_test_manifest.py` exists and reads the reviewed semantic beacon fixture family
+- [ ] at least one example native-test manifest output is present
+- [ ] the slice remains limited to one stable fixture family
+
+## Scope control
+
+- [ ] no hot-path runtime behavior is changed in this PR
+- [ ] no fixture family other than semantic beacon sequences is targeted here
+- [ ] the output is a test-manifest bridge, not yet a native runtime implementation
+
+## Follow-on trigger
+
+Once this PR is accepted, the next slice can target:
+1. a minimal Rust or Go test that consumes the emitted manifest shape
+2. one stable assertion path over the semantic beacon fixture family
+3. extension of the same pattern to a second fixture family only after the first is stable

--- a/docs/vnext/integration/worldclass_phase4/examples/native_test_manifest.example.json
+++ b/docs/vnext/integration/worldclass_phase4/examples/native_test_manifest.example.json
@@ -1,0 +1,31 @@
+{
+  "event_count": 4,
+  "fixture_family": "semantic_beacon_sequence",
+  "required_assertions": [
+    {
+      "braid": "str.sch",
+      "index": 0,
+      "kind": "stream-open",
+      "state": "verified-review-local"
+    },
+    {
+      "bundle_h": "bh:intent-ce1002-v1",
+      "index": 1,
+      "kind": "beacon-intent",
+      "semantic_refs": [
+        "cell-kairos-ce-001",
+        "tcell-chrono-001"
+      ]
+    },
+    {
+      "index": 2,
+      "kind": "stream-data"
+    },
+    {
+      "bundle_h": "bh:commit-ce1002-v1",
+      "index": 3,
+      "kind": "beacon-commit"
+    }
+  ],
+  "sequence_id": "seq-semantic-beacon-001"
+}

--- a/docs/vnext/integration/worldclass_phase4/tools/emit_native_test_manifest.py
+++ b/docs/vnext/integration/worldclass_phase4/tools/emit_native_test_manifest.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def load(path: str):
+    return json.loads(Path(path).read_text())
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: emit_native_test_manifest.py <semantic_fixture.json>")
+        return 2
+
+    fixture = load(sys.argv[1])
+    events = fixture.get("events", [])
+
+    manifest = {
+        "fixture_family": "semantic_beacon_sequence",
+        "sequence_id": fixture.get("sequence_id"),
+        "event_count": len(events),
+        "required_assertions": [],
+    }
+
+    for i, ev in enumerate(events):
+        kind = ev.get("kind")
+        assertion = {"index": i, "kind": kind}
+        if ev.get("bundle_h"):
+            assertion["bundle_h"] = ev.get("bundle_h")
+        if ev.get("semantic_refs"):
+            assertion["semantic_refs"] = ev.get("semantic_refs")
+        defaults = ev.get("defaults", {})
+        if defaults.get("braid"):
+            assertion["braid"] = defaults.get("braid")
+        if defaults.get("state"):
+            assertion["state"] = defaults.get("state")
+        manifest["required_assertions"].append(assertion)
+
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This is a clean replacement for #41, rebuilt directly on top of current `main` so CI and mergeability can attach normally.

What it carries forward:
- `docs/vnext/integration/worldclass_phase4/README.md`
- `docs/vnext/integration/worldclass_phase4/acceptance_gates.md`
- `docs/vnext/integration/worldclass_phase4/examples/native_test_manifest.example.json`
- `docs/vnext/integration/worldclass_phase4/tools/emit_native_test_manifest.py`

Why this replacement exists:
- #41 was only four files, but its branch had drifted far behind current `main`
- the old branch was showing mergeability/check attachment instability
- this branch is rooted directly on current `main` with the same intended phase4 slice

Follow-up after open:
- verify GitHub mergeability
- verify `ci` workflow attachment on the rebased head
- if clean, prefer this PR for review and landing instead of #41
