### PR TITLE
[Rebased] Add GhostEventV3 transport scaffold

### DIFF
--- a/docs/ghost-event-v3-transport.md
+++ b/docs/ghost-event-v3-transport.md
@@ -1,0 +1,28 @@
+# GhostEventV3 transport note
+
+## Purpose
+This note records the transport implications of the Event-IR → GhostEvent interop specification.
+
+## Scope
+GhostEventV3 extends the Ghost event envelope with semantic basis-binding fields:
+- `prime_registry_ref`
+- `prime_registry_state_hash`
+- `event_ir_hash`
+- `prime_vector`
+
+## Transport expectations
+Implementations carrying GhostEventV3 over TritRPC/TriTRPC SHOULD preserve:
+- canonical event hashing semantics
+- deterministic payload ordering within fixture vectors
+- the malformed vs blocked distinction
+
+## Fixture implications
+GhostEventV3 fixture families SHOULD exercise at least:
+- valid sparse prime vectors
+- duplicate basis index rejection
+- unresolved registry rejection
+- registry state hash mismatch rejection
+- deprecated-topic warning behavior where policy permits
+
+## Relationship to the first Ghost fixture PR
+This note is intentionally narrow and builds on the initial Ghost transport scaffold without expanding the entire fixture corpus in one step.

--- a/fixtures/ghost/manifest.v0.2.json
+++ b/fixtures/ghost/manifest.v0.2.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2",
+  "notes": "GhostEventV3 transport implications over the existing Ghost fixture surface.",
+  "required_fields": [
+    "prime_registry_ref",
+    "prime_registry_state_hash",
+    "event_ir_hash",
+    "prime_vector"
+  ],
+  "fixture_classes": ["happy", "warning", "blocked", "malformed"],
+  "minimum_cases": {
+    "ghost_event_v3": [
+      "happy.valid_sparse_vector",
+      "blocked.duplicate_basis_index",
+      "blocked.registry_state_hash_mismatch",
+      "malformed.bad_prime_vector_type"
+    ]
+  }
+}


### PR DESCRIPTION
This is a clean replacement for #36, rebuilt directly on top of current `main`.

What it carries forward:
- `docs/ghost-event-v3-transport.md`
- `fixtures/ghost/manifest.v0.2.json`

Why this replacement exists:
- #36 drifted far behind current `main` and GitHub reported it as non-mergeable
- this branch is rooted directly on current `main` with the same intended narrow GhostEventV3 transport slice

Follow-up after open:
- verify GitHub mergeability
- verify `ci` workflow attachment on the rebased head
- if clean, prefer this PR for review and landing instead of #36
