### PR TITLE
feat(heller): seed transport-facing wire artifacts

### DIFF
--- a/docs/heller-v1-transport-seed.md
+++ b/docs/heller-v1-transport-seed.md
@@ -1,0 +1,26 @@
+# Heller v1 transport seed for TriTRPC
+
+## Purpose
+
+This patch seeds transport-adjacent artifacts for the Heller contract family without claiming final canonical frame vectors.
+
+## Included artifacts
+
+- `fixtures/descriptors/heller/v1/heller_wire_v1.proto`
+- `fixtures/descriptors/heller/v1/heller_wire_v1_descriptor.pb`
+- `fixtures/descriptors/heller/v1/encoded_payload_manifest_v8.json`
+- `fixtures/descriptors/heller/v1/sample_event_envelope_v1.avro.bin`
+- `fixtures/descriptors/heller/v1/sample_state_snapshot_v1.avro.bin`
+- `fixtures/descriptors/heller/v1/sample_event_envelope_v1.protobuf.bin`
+- `fixtures/descriptors/heller/v1/sample_state_snapshot_v1.protobuf.bin`
+
+## Boundary
+
+These files are descriptor and payload examples. They are not yet canonical TriTRPC frame fixtures.
+
+The remaining work for full transport admission is:
+
+- assign stable schema/context labels and derive IDs where required
+- bind the payloads to specific SERVICE/METHOD surfaces
+- emit canonical frame vectors plus nonce fixtures
+- verify byte parity through the existing Rust/Go conformance flow

--- a/fixtures/descriptors/heller/v1/encoded_payload_manifest_v8.json
+++ b/fixtures/descriptors/heller/v1/encoded_payload_manifest_v8.json
@@ -1,0 +1,30 @@
+{
+  "event_envelope": {
+    "json_schema": "heller_event_envelope.schema.json",
+    "avro_schema": "heller_event_envelope.avsc",
+    "protobuf_schema": "heller_wire_v1.proto#HellerEventEnvelope",
+    "sample_json": "sample_event_envelope_v8.json",
+    "avro_binary_file": "sample_event_envelope_v1.avro.bin",
+    "protobuf_binary_file": "sample_event_envelope_v1.protobuf.bin",
+    "avro_size_bytes": 299,
+    "protobuf_size_bytes": 317,
+    "avro_sha256": "fba232ba000ff2d26ba47d11a7ca60b780520d52c5f25a1f06218f3272087443",
+    "protobuf_sha256": "4c7faf0e8ce2b71d2d71c238872d1cb057e76c02382976cdcdd436cb442fd261",
+    "avro_base64": "CjEuMC4wPnBhY2thZ2luZ190b19lZHVjYXRpb246ZXBvY2g6MDAscGFja2FnaW5nX3RvX2VkdWNhdGlvbgAAWHByb29mOi8vcmVwcm8vYnVpbGQvcGFja2FnaW5nLWVkdWNhdGlvbi0wMDAxEBIAAAAAAAAAJECamZmZmZnpP83MzMzMzOw/mpmZmZmZ6T9mZmZmZmbmPwAAAAAAAAA+QCpLbm93bGVkZ2UrQXR0cmlidXRpb24CAAIkZXhwby1wYWNrLWVkdS0wMDAxAkZtZXRhOi8vcGFja2FnaW5nL2VkdWNhdGlvbi9zaG93Y2FzZQJwUGFja2FnaW5nIHJlcHJvZHVjaWJpbGl0eSBldmVudCB3aXRoIGVkdWNhdGlvbiBzcGlsbG92ZXI=",
+    "protobuf_base64": "CgUxLjAuMBIfcGFja2FnaW5nX3RvX2VkdWNhdGlvbjplcG9jaDowMBoWcGFja2FnaW5nX3RvX2VkdWNhdGlvbigBMixwcm9vZjovL3JlcHJvL2J1aWxkL3BhY2thZ2luZy1lZHVjYXRpb24tMDAwMTgIQAlIAVEAAAAAAAAkQFokCZqZmZmZmek/Ec3MzMzMzOw/GZqZmZmZmek/IWZmZmZmZuY/apUBCQAAAAAAAD5AEhVLbm93bGVkZ2UrQXR0cmlidXRpb24YASISZXhwby1wYWNrLWVkdS0wMDAxKiNtZXRhOi8vcGFja2FnaW5nL2VkdWNhdGlvbi9zaG93Y2FzZTI4UGFja2FnaW5nIHJlcHJvZHVjaWJpbGl0eSBldmVudCB3aXRoIGVkdWNhdGlvbiBzcGlsbG92ZXI="
+  },
+  "state_snapshot": {
+    "json_schema": "heller_state_snapshot.schema.json",
+    "avro_schema": "heller_state_snapshot.avsc",
+    "protobuf_schema": "heller_wire_v1.proto#HellerStateSnapshot",
+    "sample_json": "sample_state_snapshot_v8.json",
+    "avro_binary_file": "sample_state_snapshot_v1.avro.bin",
+    "protobuf_binary_file": "sample_state_snapshot_v1.protobuf.bin",
+    "avro_size_bytes": 454,
+    "protobuf_size_bytes": 509,
+    "avro_sha256": "7fbf1b4c51f7edfdfeb1c0513e8d9b6342542a19127338f1abe3c2bb1f2700c4",
+    "protobuf_sha256": "3d75baf61e92c3fc141450022ec243ce749d0ccf976ff049a5509fe61ec6df27",
+    "avro_base64": "CjEuMC4wNHBhY2thZ2luZ19lZHVjYXRpb25fZG9tYWluLHBhY2thZ2luZ190b19lZHVjYXRpb24AAAAAAADAckAAAAAAAABJQAAAAAAAADRAAAAAAACAM0AAAAAAAADwP5qZmZmZmck/AAAAAAD4c0AAAAAAAIBJQDMzMzMzMzRAmpmZmZmZ6T/NzMzMzMzsP5qZmZmZmek/ZmZmZmZm5j8g0m9fB87ZPwAAAAAAADlAAAAAAAAA8D80MzMzMzPDP2ZmZmZmJjpAjUMibr2X7j8xVHxGUJSjPzyY+7rGfnc/jUMibr2X7j8xVHxGUJSjPzyY+7rGfnc/FgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0oUmFieL5z+PxFe5ZZm0PwAAAAAAAAAAAAAAAAAAAAAAAiRleHBvLXBhY2stZWR1LTAwMDGamZmZmZm5P5qZmZmZmck/AAAAAAAA+D8AAAAAAAAAQAEAAQEBAQEBAQI+cGFja2FnaW5nX3RvX2VkdWNhdGlvbjplcG9jaDowMAACJHNoYTI1NjpwbGFjZWhvbGRlcg==",
+    "protobuf_base64": "CgUxLjAuMBIacGFja2FnaW5nX2VkdWNhdGlvbl9kb21haW4aFnBhY2thZ2luZ190b19lZHVjYXRpb24qGwkAAAAAAMByQBEAAAAAAABJQBkAAAAAAAA0QDIbCQAAAAAAgDNAEQAAAAAAAPA/GZqZmZmZmck/OhsJAAAAAAD4c0ARAAAAAACASUAZMzMzMzMzNEBCLQmamZmZmZnpPxHNzMzMzMzsPxmamZmZmZnpPyFmZmZmZmbmPykg0m9fB87ZP0okCQAAAAAAADlAEQAAAAAAAPA/GTQzMzMzM8M/IWZmZmZmJjpAUhsJjUMibr2X7j8RMVR8RlCUoz8ZPJj7usZ+dz9aGwmNQyJuvZfuPxExVHxGUJSjPxk8mPu6xn53P2JYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADShSYWJ4vnP4/EV7llmbQ/AAAAAAAAAAAAAAAAAAAAAGo6ChJleHBvLXBhY2stZWR1LTAwMDERmpmZmZmZuT8ZmpmZmZmZyT8hAAAAAAAA+D8pAAAAAAAAAEAwAXIOCAEQARgBIAEoATABOAF6H3BhY2thZ2luZ190b19lZHVjYXRpb246ZXBvY2g6MDCCARJzaGEyNTY6cGxhY2Vob2xkZXI="
+  }
+}

--- a/fixtures/descriptors/heller/v1/heller_wire_v1.proto
+++ b/fixtures/descriptors/heller/v1/heller_wire_v1.proto
@@ -1,0 +1,134 @@
+syntax = "proto3";
+package socioprophet.heller.v1;
+
+enum EventType {
+  EVENT_TYPE_UNSPECIFIED = 0;
+  EVENT_TYPE_MINT = 1;
+  EVENT_TYPE_BURN = 2;
+  EVENT_TYPE_STAKE = 3;
+  EVENT_TYPE_SETTLE = 4;
+  EVENT_TYPE_SLASH = 5;
+  EVENT_TYPE_TRANSFER_PRICE = 6;
+  EVENT_TYPE_COLLATERALIZE = 7;
+  EVENT_TYPE_GOVERNANCE_FEE = 8;
+  EVENT_TYPE_RESERVE_RECOVERY = 9;
+  EVENT_TYPE_DOCUMENTATION_DECAY = 10;
+  EVENT_TYPE_BRIDGE_TOP_UP = 11;
+}
+
+enum TokenTier {
+  TOKEN_TIER_UNSPECIFIED = 0;
+  TOKEN_TIER_MICRO = 1;
+  TOKEN_TIER_CREDIT = 2;
+  TOKEN_TIER_RESERVE = 3;
+  TOKEN_TIER_NONE = 4;
+}
+
+enum Denomination {
+  DENOMINATION_UNSPECIFIED = 0;
+  DENOMINATION_MICRO = 1;
+  DENOMINATION_CREDIT = 2;
+  DENOMINATION_RESERVE = 3;
+}
+
+message QualityCQSP {
+  double C = 1;
+  double Q = 2;
+  double S = 3;
+  double P = 4;
+}
+
+message Recipient {
+  string recipient_id = 1;
+  double weight = 2;
+}
+
+message EventPayload {
+  double amount = 1;
+  string class_id = 2;
+  Denomination denomination = 3;
+  string exposure_id = 4;
+  string metadata_uri = 5;
+  string reason = 6;
+}
+
+message HellerEventEnvelope {
+  string schema_version = 1;
+  string event_id = 2;
+  string scenario_id = 3;
+  uint32 epoch = 4;
+  EventType event_type = 5;
+  string proof_ref = 6;
+  uint32 sphere_from = 7;
+  uint32 sphere_to = 8;
+  TokenTier token_tier = 9;
+  double delta_ep = 10;
+  QualityCQSP quality = 11;
+  repeated Recipient recipients = 12;
+  EventPayload payload = 13;
+}
+
+message SupplyVector {
+  double micro = 1;
+  double credit = 2;
+  double reserve = 3;
+}
+
+message KnowledgeVector {
+  double C = 1;
+  double Q = 2;
+  double S = 3;
+  double P = 4;
+  double K = 5;
+}
+
+message ValuationVector {
+  double V_U = 1;
+  double V_C = 2;
+  double V_G = 3;
+  double V_total = 4;
+}
+
+message ShareVector {
+  double U = 1;
+  double C = 2;
+  double G = 3;
+}
+
+message Exposure {
+  string exposure_id = 1;
+  double credit_outstanding = 2;
+  double collateral_posted = 3;
+  double alpha_required = 4;
+  double coverage_ratio = 5;
+  bool is_open = 6;
+}
+
+message InvariantFlags {
+  bool supply_nonnegative = 1;
+  bool signed_share_sum_ok = 2;
+  bool simplex_sum_ok = 3;
+  bool collateral_ok = 4;
+  bool epoch_monotone = 5;
+  bool unique_events = 6;
+  bool all_ok = 7;
+}
+
+message HellerStateSnapshot {
+  string schema_version = 1;
+  string domain_id = 2;
+  string scenario_id = 3;
+  uint32 epoch = 4;
+  SupplyVector base_supply = 5;
+  SupplyVector delta_supply = 6;
+  SupplyVector absolute_supply = 7;
+  KnowledgeVector knowledge = 8;
+  ValuationVector valuations = 9;
+  ShareVector signed_shares = 10;
+  ShareVector simplex_shares = 11;
+  repeated double loop_state = 12;
+  repeated Exposure open_exposures = 13;
+  InvariantFlags invariants = 14;
+  repeated string event_ids_applied = 15;
+  string checkpoint_hash = 16;
+}


### PR DESCRIPTION
## Summary

Seed transport-facing Heller wire artifacts in TriTRPC.

## Included

- transport seed note
- protobuf wire surface
- encoded payload manifest with base64 payload examples

## Intent

This PR makes the Heller wire siblings visible in the transport repo without claiming final canonical frame vectors.

## Explicit non-goals in this PR

- final SERVICE/METHOD binding
- schema/context ID freeze
- canonical frame vectors with nonce fixtures
- parity verification through Rust/Go conformance yet

## Follow-on

- derive stable transport IDs where required
- bind specific service/method surfaces
- emit canonical frame vectors and verify byte parity
- align with the storage standards contract family PR
