### PR TITLE
Wire policy/evidence AUX verifier into make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures integration-audit
+.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures aux-shape integration-audit
 
-verify: fmt rust-test go-test fixtures
+verify: fmt rust-test go-test fixtures aux-shape
 
 fmt: rust-fmt go-fmt
 
@@ -19,6 +19,8 @@ go-test:
 fixtures:
 	python tools/verify_fixtures_strict.py
 
+aux-shape:
+	python tools/verify_policy_evidence_aux_shape.py
 
 integration-audit:
 	./tools/audit_branch_pr_integration.sh main HEAD


### PR DESCRIPTION
## Summary

This follow-up PR makes the policy/evidence AUX verifier part of the repository verification path.

It updates `Makefile` so:
- `.PHONY` includes `aux-shape`
- `verify` depends on `aux-shape`
- `aux-shape` runs `python tools/verify_policy_evidence_aux_shape.py`

## Why

PR #37 published the TriTRPC policy/evidence AUX profile, examples, and shape verifier. This PR turns that verifier into an enforced repo-local gate instead of leaving it as optional tooling.

## Review focus

- Is `make verify` the right enforcement surface for the AUX shape gate?
- Should this later become part of full cross-language AUX-bearing frame verification once deterministic frame vectors are added?
