### PR TITLE
Add deterministic Avro schema LOM renderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures aux-shape integration-audit
+.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures descriptor-manifest-refs aux-shape integration-audit
 
 verify: fmt rust-test go-test fixtures aux-shape
 
@@ -16,8 +16,14 @@ rust-test:
 go-test:
 	cd go/tritrpcv1 && go test -mod=mod ./...
 
-fixtures:
+fixtures: descriptor-manifest-refs
 	python tools/verify_fixtures_strict.py
+
+# Warn-only until legacy descriptor manifests are repaired. Direct invocation of
+# tools/check_descriptor_manifest_refs.py remains strict and exits non-zero on
+# missing local schema/sample/binary references.
+descriptor-manifest-refs:
+	python tools/check_descriptor_manifest_refs.py --warn-only
 
 aux-shape:
 	python tools/verify_policy_evidence_aux_shape.py

--- a/docs/schema-visualization.md
+++ b/docs/schema-visualization.md
@@ -1,0 +1,87 @@
+# Avro schema visualization
+
+Status: non-normative documentation tooling
+
+## Purpose
+
+TriTRPC uses Avro on the Path-A payload lane and preserves Avro as an important schema contract surface. A schema diagram is useful for review, onboarding, and protocol discussion, but it must never become the protocol authority. The `.avsc` source, canonical fixture vectors, and implementation tests remain normative.
+
+`tools/render_avro_schema_lom.py` renders an Avro record schema as a Graphviz DOT diagram using a LOM-inspired lane grammar:
+
+1. `Schema`
+2. `Category`
+3. `Aggregate Element`
+4. `Simple Data Element`
+5. `Datatype`
+6. `Value`
+
+The result is deterministic text output. Reviewers can diff it, regenerate it, and render it through Graphviz when image artifacts are needed.
+
+## Usage
+
+```bash
+python tools/render_avro_schema_lom.py \
+  --schema path/to/schema.avsc \
+  --out docs/diagrams/schema_lom.dot
+```
+
+Optional rendering, when Graphviz is installed:
+
+```bash
+dot -Tsvg docs/diagrams/schema_lom.dot -o docs/diagrams/schema_lom.svg
+dot -Tpng docs/diagrams/schema_lom.dot -o docs/diagrams/schema_lom.png
+```
+
+## Boundary
+
+This repository owns the canonical TriTRPC protocol renderer because TriTRPC owns the Avro/Path-A protocol semantics, fixture vectors, and deterministic reference behavior.
+
+Downstream consumers may wrap the renderer:
+
+- `SourceOS-Linux/sourceos-spec` may generalize the pattern into a contract visualization profile.
+- `SourceOS-Linux/sourceos-devtools` may expose an operator command such as `sourceosctl schemas diagram`.
+- Linux realization repositories should consume generated documentation only; they should not own protocol schema visualization rules.
+
+## DALL-E / generated art policy
+
+Image-generation output can be used as a visual style sketch, but it is not evidence. It must not be treated as a protocol diagram unless every field, type, edge, and label was generated from a checked-in schema or reviewed against one.
+
+For protocol documentation, the accepted source of truth is:
+
+```text
+.avsc / fixture manifest / canonical fixture vectors -> deterministic DOT -> optional rendered image
+```
+
+not:
+
+```text
+prompt -> image model -> plausible diagram
+```
+
+## Descriptor manifest reference checks
+
+`tools/check_descriptor_manifest_refs.py` scans descriptor manifests, such as `encoded_payload_manifest*.json`, and reports local schema/sample/binary references that point at missing files.
+
+Strict mode:
+
+```bash
+python tools/check_descriptor_manifest_refs.py
+```
+
+Warn-only compatibility mode:
+
+```bash
+python tools/check_descriptor_manifest_refs.py --warn-only
+```
+
+Warn-only mode exists so legacy fixture debt can be exposed in `make verify` without blocking unrelated parity work. Once the existing missing descriptor artifacts are repaired, CI should switch to strict mode.
+
+## Review rule
+
+A committed diagram must satisfy all of the following:
+
+- generated from a checked-in schema;
+- reproducible with the committed renderer;
+- labeled as non-normative;
+- regenerated when the source schema changes;
+- excluded from semantic claims unless validated against the schema and fixture vectors.

--- a/tools/check_descriptor_manifest_refs.py
+++ b/tools/check_descriptor_manifest_refs.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Check descriptor manifests for missing local artifact references.
+
+The checker scans fixture descriptor manifests and validates file-name fields that
+look like local schema, sample, or encoded payload artifact references. Strict mode
+is the default so a direct invocation exposes fixture debt. CI can pass
+`--warn-only` while legacy manifests are being repaired.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Union
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_GLOB = "fixtures/**/encoded_payload_manifest*.json"
+LOCAL_REF_SUFFIXES = (
+    "_schema",
+    "schema",
+    "sample_json",
+    "json_file",
+    "avro_binary_file",
+    "protobuf_binary_file",
+    "binary_file",
+    "file",
+)
+IGNORED_KEYS = (
+    "base64",
+    "sha256",
+    "size_bytes",
+    "hash",
+    "digest",
+)
+LOCAL_EXTENSIONS = (
+    ".json",
+    ".jsonld",
+    ".schema.json",
+    ".avsc",
+    ".proto",
+    ".bin",
+    ".txt",
+    ".nonces",
+)
+
+
+@dataclass(frozen=True)
+class MissingRef:
+    manifest: Path
+    object_path: str
+    key: str
+    value: str
+    expected: Path
+
+
+def is_local_file_ref(key: str, value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered_key = key.lower()
+    if any(token in lowered_key for token in IGNORED_KEYS):
+        return False
+    if not value or value.startswith(("http://", "https://", "urn:", "sha", "data:")):
+        return False
+    if any(lowered_key.endswith(suffix) for suffix in LOCAL_REF_SUFFIXES):
+        return True
+    return value.split("#", 1)[0].endswith(LOCAL_EXTENSIONS)
+
+
+def iter_refs(node: Any, object_path: str = "$") -> Iterable[tuple[str, str, str]]:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            next_path = f"{object_path}.{key}"
+            if is_local_file_ref(key, value):
+                yield object_path, key, value
+            yield from iter_refs(value, next_path)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from iter_refs(value, f"{object_path}[{index}]")
+
+
+def expected_path(base: Path, value: str) -> Path:
+    file_part = value.split("#", 1)[0]
+    return (base / file_part).resolve()
+
+
+def relative_to_root(path: Path, root: Path) -> Union[Path, str]:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return str(path)
+
+
+def check_manifest(path: Path) -> List[MissingRef]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"[FAIL] {path}: invalid JSON: {exc}") from exc
+
+    missing: List[MissingRef] = []
+    base = path.parent
+    for object_path, key, value in iter_refs(data):
+        expected = expected_path(base, value)
+        if not expected.exists():
+            missing.append(MissingRef(path, object_path, key, value, expected))
+    return missing
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root")
+    parser.add_argument("--glob", default=DEFAULT_GLOB, help="Manifest glob relative to root")
+    parser.add_argument("--warn-only", action="store_true", help="Report missing refs without failing")
+    parser.add_argument("manifests", nargs="*", type=Path, help="Specific manifest paths to check")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    manifests = args.manifests or sorted(root.glob(args.glob))
+    if not manifests:
+        print(f"[OK] no descriptor manifests matched {args.glob}")
+        return 0
+
+    all_missing: List[MissingRef] = []
+    for manifest in manifests:
+        manifest_path = manifest if manifest.is_absolute() else root / manifest
+        all_missing.extend(check_manifest(manifest_path.resolve()))
+
+    if not all_missing:
+        print(f"[OK] checked {len(manifests)} descriptor manifest(s); all local refs exist")
+        return 0
+
+    stream = sys.stderr if not args.warn_only else sys.stdout
+    status = "WARN" if args.warn_only else "FAIL"
+    print(f"[{status}] {len(all_missing)} missing descriptor manifest reference(s):", file=stream)
+    for ref in all_missing:
+        rel_manifest = relative_to_root(ref.manifest, root)
+        rel_expected = relative_to_root(ref.expected, root)
+        print(f"  - {rel_manifest}: {ref.object_path}.{ref.key} -> {ref.value} (missing {rel_expected})", file=stream)
+
+    return 0 if args.warn_only else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/render_avro_schema_lom.py
+++ b/tools/render_avro_schema_lom.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Render an Avro record schema as a deterministic LOM-style Graphviz DOT diagram.
+
+The output is a non-normative view over the normative `.avsc` source. DOT is used
+so diagrams remain reviewable and reproducible in protocol documentation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+PRIMITIVES = {"null", "boolean", "int", "long", "float", "double", "bytes", "string"}
+LANES = ("Schema", "Category", "Aggregate Element", "Simple Data Element", "Datatype", "Value")
+
+
+@dataclass
+class Node:
+    key: str
+    label: str
+    lane: int
+    shape: str = "rounded"
+    children: List["Node"] = field(default_factory=list)
+
+
+def normalize(avro_type: Any) -> Tuple[str, Any]:
+    if isinstance(avro_type, str):
+        return ("primitive", avro_type) if avro_type in PRIMITIVES else ("named", avro_type)
+    if isinstance(avro_type, list):
+        return "union", avro_type
+    if isinstance(avro_type, dict):
+        if "logicalType" in avro_type and isinstance(avro_type.get("type"), str):
+            return "logical", avro_type
+        type_value = avro_type.get("type")
+        if type_value in {"record", "enum", "fixed", "array", "map"}:
+            return type_value, avro_type
+        if isinstance(type_value, list):
+            return "union", type_value
+        if isinstance(type_value, str):
+            return normalize(type_value)
+    return "unknown", avro_type
+
+
+def qualified_name(schema: Dict[str, Any]) -> str:
+    name = schema.get("name", "Root")
+    namespace = schema.get("namespace")
+    return f"{namespace}.{name}" if namespace else name
+
+
+def type_label(avro_type: Any) -> str:
+    kind, obj = normalize(avro_type)
+    if kind in {"primitive", "named"}:
+        return str(obj)
+    if kind == "logical":
+        return f"{obj.get('type')}({obj.get('logicalType')})"
+    if kind == "record":
+        return f"record {qualified_name(obj)}"
+    if kind == "enum":
+        return f"enum {qualified_name(obj)}"
+    if kind == "fixed":
+        return f"fixed {qualified_name(obj)}[{obj.get('size')}]"
+    if kind == "array":
+        return f"array<{type_label(obj.get('items'))}>"
+    if kind == "map":
+        return f"map<string,{type_label(obj.get('values'))}>"
+    if kind == "union":
+        return " | ".join(type_label(option) for option in obj)
+    return json.dumps(obj, sort_keys=True)
+
+
+def union_branch_label(avro_type: Any) -> str:
+    kind, obj = normalize(avro_type)
+    if kind in {"record", "enum", "fixed"}:
+        return qualified_name(obj)
+    return type_label(avro_type)
+
+
+class Builder:
+    def __init__(self, schema: Dict[str, Any], max_depth: int) -> None:
+        if schema.get("type") != "record":
+            raise ValueError("root schema must be an Avro record")
+        self.schema = schema
+        self.max_depth = max_depth
+        self.registry: Dict[str, Dict[str, Any]] = {}
+        self._register(schema)
+
+    def _register(self, avro_type: Any) -> None:
+        kind, obj = normalize(avro_type)
+        if kind in {"record", "enum", "fixed"} and isinstance(obj, dict) and "name" in obj:
+            self.registry[obj["name"]] = obj
+            self.registry[qualified_name(obj)] = obj
+        if kind == "record":
+            for field_obj in obj.get("fields", []):
+                self._register(field_obj.get("type"))
+        elif kind == "array":
+            self._register(obj.get("items"))
+        elif kind == "map":
+            self._register(obj.get("values"))
+        elif kind == "union":
+            for option in obj:
+                self._register(option)
+
+    def build(self) -> Node:
+        root = Node(qualified_name(self.schema), qualified_name(self.schema), 0)
+        for field_obj in self.schema.get("fields", []):
+            self.add_field(root, field_obj["name"], field_obj["type"], 1, f"{root.key}.{field_obj['name']}")
+        return root
+
+    def resolve(self, avro_type: Any) -> Tuple[str, Any]:
+        kind, obj = normalize(avro_type)
+        if kind == "named" and obj in self.registry:
+            return normalize(self.registry[obj])
+        return kind, obj
+
+    def add_field(self, parent: Node, name: str, avro_type: Any, depth: int, path: str) -> None:
+        node = Node(path, name, min(depth, self.max_depth))
+        parent.children.append(node)
+        self.expand(node, avro_type, depth, path)
+
+    def expand(self, node: Node, avro_type: Any, depth: int, path: str) -> None:
+        kind, obj = self.resolve(avro_type)
+        if kind == "record" and depth < self.max_depth:
+            for field_obj in obj.get("fields", []):
+                self.add_field(node, field_obj["name"], field_obj["type"], depth + 1, f"{path}.{field_obj['name']}")
+        elif kind == "array" and depth < self.max_depth:
+            child = Node(f"{path}.items", "items[]", min(depth + 1, self.max_depth))
+            node.children.append(child)
+            self.expand(child, obj.get("items"), depth + 1, f"{path}.items")
+        elif kind == "map" and depth < self.max_depth:
+            child = Node(f"{path}.values", "values{}", min(depth + 1, self.max_depth))
+            node.children.append(child)
+            self.expand(child, obj.get("values"), depth + 1, f"{path}.values")
+        elif kind == "union" and depth < self.max_depth:
+            union_node = Node(f"{path}.union", "union", min(depth + 1, self.max_depth))
+            node.children.append(union_node)
+            for index, option in enumerate(obj):
+                branch = Node(f"{path}.union.{index}", union_branch_label(option), min(depth + 2, self.max_depth))
+                union_node.children.append(branch)
+                self.expand(branch, option, depth + 2, f"{path}.union.{index}")
+        else:
+            node.children.append(Node(f"{path}.datatype", type_label(avro_type), 4, "box"))
+            node.children.append(Node(f"{path}.value", "...", 5, "plain"))
+
+
+def walk(root: Node) -> Tuple[List[Node], List[Tuple[Node, Node]]]:
+    nodes: List[Node] = []
+    edges: List[Tuple[Node, Node]] = []
+
+    def rec(node: Node) -> None:
+        nodes.append(node)
+        for child in node.children:
+            edges.append((node, child))
+            rec(child)
+
+    rec(root)
+    return nodes, edges
+
+
+def esc(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def node_id(key: str, index: int) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_]", "_", key)
+    if not safe or safe[0].isdigit():
+        safe = "n_" + safe
+    return f"{safe}_{index}"
+
+
+def wrap(value: str, width: int = 28) -> str:
+    if len(value) <= width:
+        return value
+    chunks: List[str] = []
+    while len(value) > width:
+        cut = max(value.rfind(".", 0, width), value.rfind("_", 0, width), value.rfind("|", 0, width))
+        if cut < 8:
+            cut = width
+        chunks.append(value[:cut].strip())
+        value = value[cut:].strip(" ._|,/")
+    if value:
+        chunks.append(value)
+    return "\\n".join(chunks)
+
+
+def render(root: Node, title: str) -> str:
+    nodes, edges = walk(root)
+    ids = {id(node): node_id(node.key, index) for index, node in enumerate(nodes)}
+    out = [
+        "digraph avro_lom_schema {",
+        f'  graph [rankdir=LR, splines=ortho, nodesep="0.35", ranksep="0.70", labelloc="b", label="{esc(title)}"];',
+        '  node [fontname="Helvetica", fontsize="10"];',
+        '  edge [color="black", arrowsize="0.6"];',
+    ]
+    headers = []
+    for index, lane in enumerate(LANES):
+        header = f"lane_{index}"
+        headers.append(header)
+        out.append(f'  {header} [shape=plaintext, label="{esc(lane)}"];')
+    for node in nodes:
+        shape = "plaintext" if node.shape == "plain" else "box"
+        style = "rounded" if node.shape == "rounded" else "solid"
+        out.append(f'  {ids[id(node)]} [shape={shape}, style="{style}", label="{esc(wrap(node.label))}"];')
+    for lane_index in range(len(LANES)):
+        lane_nodes = [ids[id(node)] for node in nodes if node.lane == lane_index]
+        if lane_nodes:
+            out.append("  { rank=same; " + headers[lane_index] + "; " + "; ".join(lane_nodes) + "; }")
+    for left, right in zip(headers, headers[1:]):
+        out.append(f"  {left} -> {right} [style=invis, weight=20];")
+    for parent, child in edges:
+        out.append(f"  {ids[id(parent)]} -> {ids[id(child)]};")
+    out.append("}")
+    return "\n".join(out) + "\n"
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Render Avro .avsc as a LOM-style Graphviz DOT diagram")
+    parser.add_argument("--schema", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--title")
+    parser.add_argument("--max-depth", type=int, default=3)
+    args = parser.parse_args(argv)
+
+    schema = json.loads(args.schema.read_text(encoding="utf-8"))
+    root = Builder(schema, args.max_depth).build()
+    title = args.title or f"LOM-style Avro schema view: {qualified_name(schema)}"
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(render(root, title), encoding="utf-8")
+    print(f"[OK] wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #47.

This PR adds deterministic, schema-source-derived Avro visualization tooling for TriTRPC protocol documentation.

## Changes

- Add `tools/render_avro_schema_lom.py` to render Avro `.avsc` record schemas as LOM-style Graphviz DOT diagrams.
- Add `tools/check_descriptor_manifest_refs.py` to detect missing local schema/sample/binary references in descriptor manifests.
- Document the schema visualization boundary in `docs/schema-visualization.md`, including the rule that image-generation output is not protocol evidence.
- Wire descriptor manifest reference checking into `make fixtures` in warn-only mode while preserving the new upstream `aux-shape` verification target.

## Validation

Connector-side validation:

- Branch is 4 commits ahead of `main` and 0 behind.
- Changed files are limited to `Makefile`, `docs/schema-visualization.md`, and two tools under `tools/`.
- The branch was reset onto current `main` before replaying the changes, so it preserves the upstream `aux-shape` target added after the first branch cut.

Local CI was not run in this connector environment. The descriptor checker is intentionally warn-only from `make fixtures` because current descriptor manifests appear to reference local artifacts that are not present in the repo; direct invocation remains strict and exits non-zero on missing references.

## Notes

The renderer emits DOT rather than PNG/SVG so diagrams remain deterministic, reviewable, and renderable by Graphviz-compatible tooling. Generated image outputs should be treated as derived artifacts, not normative protocol sources.