### PR TITLE
Repair Heller descriptor manifest references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,8 @@ go-test:
 fixtures: descriptor-manifest-refs
 	python tools/verify_fixtures_strict.py
 
-# Warn-only until legacy descriptor manifests are repaired. Direct invocation of
-# tools/check_descriptor_manifest_refs.py remains strict and exits non-zero on
-# missing local schema/sample/binary references.
 descriptor-manifest-refs:
-	python tools/check_descriptor_manifest_refs.py --warn-only
+	python tools/check_descriptor_manifest_refs.py
 
 aux-shape:
 	python tools/verify_policy_evidence_aux_shape.py

--- a/docs/diagrams/heller_event_envelope_lom.dot
+++ b/docs/diagrams/heller_event_envelope_lom.dot
@@ -1,0 +1,126 @@
+digraph avro_lom_schema {
+  graph [rankdir=LR, splines=ortho, nodesep="0.35", ranksep="0.70", labelloc="b", label="LOM-style Avro schema view: socioprophet.heller.v1.HellerEventEnvelope"];
+  node [fontname="Helvetica", fontsize="10"];
+  edge [color="black", arrowsize="0.6"];
+
+  lane_0 [shape=plaintext, label="Schema"];
+  lane_1 [shape=plaintext, label="Category"];
+  lane_2 [shape=plaintext, label="Aggregate Element"];
+  lane_3 [shape=plaintext, label="Simple Data Element"];
+  lane_4 [shape=plaintext, label="Datatype"];
+  lane_5 [shape=plaintext, label="Value"];
+
+  root [shape=box, style="rounded", label="socioprophet.heller.v1\nHellerEventEnvelope"];
+
+  schema_version [shape=box, style="rounded", label="schema_version"];
+  event_id [shape=box, style="rounded", label="event_id"];
+  scenario_id [shape=box, style="rounded", label="scenario_id"];
+  epoch [shape=box, style="rounded", label="epoch"];
+  event_type [shape=box, style="rounded", label="event_type"];
+  proof_ref [shape=box, style="rounded", label="proof_ref"];
+  sphere_from [shape=box, style="rounded", label="sphere_from"];
+  sphere_to [shape=box, style="rounded", label="sphere_to"];
+  token_tier [shape=box, style="rounded", label="token_tier"];
+  delta_ep [shape=box, style="rounded", label="delta_ep"];
+  quality [shape=box, style="rounded", label="quality"];
+  recipients [shape=box, style="rounded", label="recipients"];
+  payload [shape=box, style="rounded", label="payload"];
+
+  quality_C [shape=box, style="rounded", label="C"];
+  quality_Q [shape=box, style="rounded", label="Q"];
+  quality_S [shape=box, style="rounded", label="S"];
+  quality_P [shape=box, style="rounded", label="P"];
+  recipients_items [shape=box, style="rounded", label="items[]"];
+  recipient_id [shape=box, style="rounded", label="recipient_id"];
+  recipient_weight [shape=box, style="rounded", label="weight"];
+  payload_amount [shape=box, style="rounded", label="amount"];
+  payload_class_id [shape=box, style="rounded", label="class_id"];
+  payload_denomination [shape=box, style="rounded", label="denomination"];
+  payload_exposure_id [shape=box, style="rounded", label="exposure_id"];
+  payload_metadata_uri [shape=box, style="rounded", label="metadata_uri"];
+  payload_reason [shape=box, style="rounded", label="reason"];
+
+  type_string [shape=box, style="solid", label="string"];
+  type_int [shape=box, style="solid", label="int"];
+  type_double [shape=box, style="solid", label="double"];
+  type_event_type [shape=box, style="solid", label="enum EventType"];
+  type_token_tier [shape=box, style="solid", label="enum TokenTier"];
+  type_denomination_union [shape=box, style="solid", label="null | enum Denomination"];
+  type_null_string [shape=box, style="solid", label="null | string"];
+
+  value_placeholder [shape=plaintext, label="..."];
+
+  { rank=same; lane_0; root; }
+  { rank=same; lane_1; schema_version; event_id; scenario_id; epoch; event_type; proof_ref; sphere_from; sphere_to; token_tier; delta_ep; quality; recipients; payload; }
+  { rank=same; lane_2; quality_C; quality_Q; quality_S; quality_P; recipients_items; payload_amount; payload_class_id; payload_denomination; payload_exposure_id; payload_metadata_uri; payload_reason; }
+  { rank=same; lane_3; recipient_id; recipient_weight; }
+  { rank=same; lane_4; type_string; type_int; type_double; type_event_type; type_token_tier; type_denomination_union; type_null_string; }
+  { rank=same; lane_5; value_placeholder; }
+
+  lane_0 -> lane_1 [style=invis, weight=20];
+  lane_1 -> lane_2 [style=invis, weight=20];
+  lane_2 -> lane_3 [style=invis, weight=20];
+  lane_3 -> lane_4 [style=invis, weight=20];
+  lane_4 -> lane_5 [style=invis, weight=20];
+
+  root -> schema_version;
+  root -> event_id;
+  root -> scenario_id;
+  root -> epoch;
+  root -> event_type;
+  root -> proof_ref;
+  root -> sphere_from;
+  root -> sphere_to;
+  root -> token_tier;
+  root -> delta_ep;
+  root -> quality;
+  root -> recipients;
+  root -> payload;
+
+  schema_version -> type_string;
+  event_id -> type_string;
+  scenario_id -> type_string;
+  epoch -> type_int;
+  event_type -> type_event_type;
+  proof_ref -> type_string;
+  sphere_from -> type_int;
+  sphere_to -> type_int;
+  token_tier -> type_token_tier;
+  delta_ep -> type_double;
+
+  quality -> quality_C;
+  quality -> quality_Q;
+  quality -> quality_S;
+  quality -> quality_P;
+  quality_C -> type_double;
+  quality_Q -> type_double;
+  quality_S -> type_double;
+  quality_P -> type_double;
+
+  recipients -> recipients_items;
+  recipients_items -> recipient_id;
+  recipients_items -> recipient_weight;
+  recipient_id -> type_string;
+  recipient_weight -> type_double;
+
+  payload -> payload_amount;
+  payload -> payload_class_id;
+  payload -> payload_denomination;
+  payload -> payload_exposure_id;
+  payload -> payload_metadata_uri;
+  payload -> payload_reason;
+  payload_amount -> type_double;
+  payload_class_id -> type_string;
+  payload_denomination -> type_denomination_union;
+  payload_exposure_id -> type_null_string;
+  payload_metadata_uri -> type_null_string;
+  payload_reason -> type_null_string;
+
+  type_string -> value_placeholder;
+  type_int -> value_placeholder;
+  type_double -> value_placeholder;
+  type_event_type -> value_placeholder;
+  type_token_tier -> value_placeholder;
+  type_denomination_union -> value_placeholder;
+  type_null_string -> value_placeholder;
+}

--- a/docs/heller-v1-transport-seed.md
+++ b/docs/heller-v1-transport-seed.md
@@ -8,11 +8,20 @@ This patch seeds transport-adjacent artifacts for the Heller contract family wit
 
 - `fixtures/descriptors/heller/v1/heller_wire_v1.proto`
 - `fixtures/descriptors/heller/v1/heller_wire_v1_descriptor.pb`
+- `fixtures/descriptors/heller/v1/heller_event_envelope.avsc`
+- `fixtures/descriptors/heller/v1/heller_state_snapshot.avsc`
+- `fixtures/descriptors/heller/v1/heller_event_envelope.schema.json`
+- `fixtures/descriptors/heller/v1/heller_state_snapshot.schema.json`
+- `fixtures/descriptors/heller/v1/sample_event_envelope_v8.json`
+- `fixtures/descriptors/heller/v1/sample_state_snapshot_v8.json`
 - `fixtures/descriptors/heller/v1/encoded_payload_manifest_v8.json`
-- `fixtures/descriptors/heller/v1/sample_event_envelope_v1.avro.bin`
-- `fixtures/descriptors/heller/v1/sample_state_snapshot_v1.avro.bin`
-- `fixtures/descriptors/heller/v1/sample_event_envelope_v1.protobuf.bin`
-- `fixtures/descriptors/heller/v1/sample_state_snapshot_v1.protobuf.bin`
+- `docs/diagrams/heller_event_envelope_lom.dot`
+
+## Embedded encoded payloads
+
+`encoded_payload_manifest_v8.json` records the Avro and protobuf binary payloads as embedded base64 strings with their expected byte sizes and SHA-256 hashes.
+
+The manifest may still name logical payload files such as `sample_event_envelope_v1.avro.bin`, but those binary payload references are satisfied by the embedded `*_base64`, `*_size_bytes`, and `*_sha256` fields. `tools/check_descriptor_manifest_refs.py` validates those embedded payloads in strict mode.
 
 ## Boundary
 

--- a/fixtures/descriptors/heller/v1/heller_event_envelope.avsc
+++ b/fixtures/descriptors/heller/v1/heller_event_envelope.avsc
@@ -1,0 +1,175 @@
+{
+  "type": "record",
+  "name": "HellerEventEnvelope",
+  "namespace": "socioprophet.heller.v1",
+  "fields": [
+    {
+      "name": "schema_version",
+      "type": "string"
+    },
+    {
+      "name": "event_id",
+      "type": "string"
+    },
+    {
+      "name": "scenario_id",
+      "type": "string"
+    },
+    {
+      "name": "epoch",
+      "type": "int"
+    },
+    {
+      "name": "event_type",
+      "type": {
+        "type": "enum",
+        "name": "EventType",
+        "symbols": [
+          "mint",
+          "burn",
+          "stake",
+          "settle",
+          "slash",
+          "transfer_price",
+          "collateralize",
+          "governance_fee",
+          "reserve_recovery",
+          "documentation_decay",
+          "bridge_top_up"
+        ]
+      }
+    },
+    {
+      "name": "proof_ref",
+      "type": "string"
+    },
+    {
+      "name": "sphere_from",
+      "type": "int"
+    },
+    {
+      "name": "sphere_to",
+      "type": "int"
+    },
+    {
+      "name": "token_tier",
+      "type": {
+        "type": "enum",
+        "name": "TokenTier",
+        "symbols": [
+          "micro",
+          "credit",
+          "reserve",
+          "none"
+        ]
+      }
+    },
+    {
+      "name": "delta_ep",
+      "type": "double"
+    },
+    {
+      "name": "quality",
+      "type": {
+        "type": "record",
+        "name": "QualityCQSP",
+        "fields": [
+          {
+            "name": "C",
+            "type": "double"
+          },
+          {
+            "name": "Q",
+            "type": "double"
+          },
+          {
+            "name": "S",
+            "type": "double"
+          },
+          {
+            "name": "P",
+            "type": "double"
+          }
+        ]
+      }
+    },
+    {
+      "name": "recipients",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Recipient",
+          "fields": [
+            {
+              "name": "recipient_id",
+              "type": "string"
+            },
+            {
+              "name": "weight",
+              "type": "double"
+            }
+          ]
+        }
+      },
+      "default": []
+    },
+    {
+      "name": "payload",
+      "type": {
+        "type": "record",
+        "name": "EventPayload",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "double"
+          },
+          {
+            "name": "class_id",
+            "type": "string"
+          },
+          {
+            "name": "denomination",
+            "type": [
+              "null",
+              {
+                "type": "enum",
+                "name": "Denomination",
+                "symbols": [
+                  "micro",
+                  "credit",
+                  "reserve"
+                ]
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "exposure_id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "metadata_uri",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "reason",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/descriptors/heller/v1/heller_event_envelope.schema.json
+++ b/fixtures/descriptors/heller/v1/heller_event_envelope.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.example/schemas/heller/event-envelope.schema.json",
+  "title": "Heller Event Envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "scenario_id",
+    "epoch",
+    "event_type",
+    "proof_ref",
+    "sphere_from",
+    "sphere_to",
+    "token_tier",
+    "delta_ep",
+    "quality",
+    "payload"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._:-]{6,128}$"
+    },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_:-]{3,128}$"
+    },
+    "epoch": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "mint",
+        "burn",
+        "stake",
+        "settle",
+        "slash",
+        "transfer_price",
+        "collateralize",
+        "governance_fee",
+        "reserve_recovery",
+        "documentation_decay",
+        "bridge_top_up"
+      ]
+    },
+    "proof_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "sphere_from": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 11
+    },
+    "sphere_to": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 11
+    },
+    "token_tier": {
+      "type": "string",
+      "enum": [
+        "micro",
+        "credit",
+        "reserve",
+        "none"
+      ]
+    },
+    "delta_ep": {
+      "type": "number"
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "C",
+        "Q",
+        "S",
+        "P"
+      ],
+      "properties": {
+        "C": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "Q": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "S": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "P": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "recipients": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "recipient_id",
+          "weight"
+        ],
+        "properties": {
+          "recipient_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "weight": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "amount",
+        "class_id"
+      ],
+      "properties": {
+        "amount": {
+          "type": "number"
+        },
+        "class_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "denomination": {
+          "type": "string",
+          "enum": [
+            "micro",
+            "credit",
+            "reserve"
+          ]
+        },
+        "exposure_id": {
+          "type": "string"
+        },
+        "metadata_uri": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/fixtures/descriptors/heller/v1/heller_state_snapshot.avsc
+++ b/fixtures/descriptors/heller/v1/heller_state_snapshot.avsc
@@ -1,0 +1,227 @@
+{
+  "type": "record",
+  "name": "HellerStateSnapshot",
+  "namespace": "socioprophet.heller.v1",
+  "fields": [
+    {
+      "name": "schema_version",
+      "type": "string"
+    },
+    {
+      "name": "domain_id",
+      "type": "string"
+    },
+    {
+      "name": "scenario_id",
+      "type": "string"
+    },
+    {
+      "name": "epoch",
+      "type": "int"
+    },
+    {
+      "name": "base_supply",
+      "type": {
+        "type": "record",
+        "name": "SupplyVector",
+        "fields": [
+          {
+            "name": "micro",
+            "type": "double"
+          },
+          {
+            "name": "credit",
+            "type": "double"
+          },
+          {
+            "name": "reserve",
+            "type": "double"
+          }
+        ]
+      }
+    },
+    {
+      "name": "delta_supply",
+      "type": "SupplyVector"
+    },
+    {
+      "name": "absolute_supply",
+      "type": "SupplyVector"
+    },
+    {
+      "name": "knowledge",
+      "type": {
+        "type": "record",
+        "name": "KnowledgeVector",
+        "fields": [
+          {
+            "name": "C",
+            "type": "double"
+          },
+          {
+            "name": "Q",
+            "type": "double"
+          },
+          {
+            "name": "S",
+            "type": "double"
+          },
+          {
+            "name": "P",
+            "type": "double"
+          },
+          {
+            "name": "K",
+            "type": "double"
+          }
+        ]
+      }
+    },
+    {
+      "name": "valuations",
+      "type": {
+        "type": "record",
+        "name": "ValuationVector",
+        "fields": [
+          {
+            "name": "V_U",
+            "type": "double"
+          },
+          {
+            "name": "V_C",
+            "type": "double"
+          },
+          {
+            "name": "V_G",
+            "type": "double"
+          },
+          {
+            "name": "V_total",
+            "type": "double"
+          }
+        ]
+      }
+    },
+    {
+      "name": "signed_shares",
+      "type": {
+        "type": "record",
+        "name": "ShareVector",
+        "fields": [
+          {
+            "name": "U",
+            "type": "double"
+          },
+          {
+            "name": "C",
+            "type": "double"
+          },
+          {
+            "name": "G",
+            "type": "double"
+          }
+        ]
+      }
+    },
+    {
+      "name": "simplex_shares",
+      "type": "ShareVector"
+    },
+    {
+      "name": "loop_state",
+      "type": {
+        "type": "array",
+        "items": "double"
+      }
+    },
+    {
+      "name": "open_exposures",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Exposure",
+          "fields": [
+            {
+              "name": "exposure_id",
+              "type": "string"
+            },
+            {
+              "name": "credit_outstanding",
+              "type": "double"
+            },
+            {
+              "name": "collateral_posted",
+              "type": "double"
+            },
+            {
+              "name": "alpha_required",
+              "type": "double"
+            },
+            {
+              "name": "coverage_ratio",
+              "type": "double"
+            },
+            {
+              "name": "is_open",
+              "type": "boolean"
+            }
+          ]
+        }
+      },
+      "default": []
+    },
+    {
+      "name": "invariants",
+      "type": {
+        "type": "record",
+        "name": "InvariantFlags",
+        "fields": [
+          {
+            "name": "supply_nonnegative",
+            "type": "boolean"
+          },
+          {
+            "name": "signed_share_sum_ok",
+            "type": "boolean"
+          },
+          {
+            "name": "simplex_sum_ok",
+            "type": "boolean"
+          },
+          {
+            "name": "collateral_ok",
+            "type": "boolean"
+          },
+          {
+            "name": "epoch_monotone",
+            "type": "boolean"
+          },
+          {
+            "name": "unique_events",
+            "type": "boolean"
+          },
+          {
+            "name": "all_ok",
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+    {
+      "name": "event_ids_applied",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "checkpoint_hash",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    }
+  ]
+}

--- a/fixtures/descriptors/heller/v1/heller_state_snapshot.schema.json
+++ b/fixtures/descriptors/heller/v1/heller_state_snapshot.schema.json
@@ -1,0 +1,309 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.example/schemas/heller/state-snapshot.schema.json",
+  "title": "Heller Domain State Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "domain_id",
+    "scenario_id",
+    "epoch",
+    "base_supply",
+    "delta_supply",
+    "absolute_supply",
+    "knowledge",
+    "valuations",
+    "signed_shares",
+    "simplex_shares",
+    "loop_state",
+    "open_exposures",
+    "invariants",
+    "event_ids_applied"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "domain_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_:-]{3,128}$"
+    },
+    "epoch": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "base_supply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "micro",
+        "credit",
+        "reserve"
+      ],
+      "properties": {
+        "micro": {
+          "type": "number",
+          "minimum": 0
+        },
+        "credit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "reserve": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "delta_supply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "micro",
+        "credit",
+        "reserve"
+      ],
+      "properties": {
+        "micro": {
+          "type": "number"
+        },
+        "credit": {
+          "type": "number"
+        },
+        "reserve": {
+          "type": "number"
+        }
+      }
+    },
+    "absolute_supply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "micro",
+        "credit",
+        "reserve"
+      ],
+      "properties": {
+        "micro": {
+          "type": "number",
+          "minimum": 0
+        },
+        "credit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "reserve": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "knowledge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "C",
+        "Q",
+        "S",
+        "P",
+        "K"
+      ],
+      "properties": {
+        "C": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "Q": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "S": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "P": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "K": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "valuations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "V_U",
+        "V_C",
+        "V_G",
+        "V_total"
+      ],
+      "properties": {
+        "V_U": {
+          "type": "number"
+        },
+        "V_C": {
+          "type": "number"
+        },
+        "V_G": {
+          "type": "number"
+        },
+        "V_total": {
+          "type": "number"
+        }
+      }
+    },
+    "signed_shares": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "U",
+        "C",
+        "G"
+      ],
+      "properties": {
+        "U": {
+          "type": "number"
+        },
+        "C": {
+          "type": "number"
+        },
+        "G": {
+          "type": "number"
+        }
+      }
+    },
+    "simplex_shares": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "U",
+        "C",
+        "G"
+      ],
+      "properties": {
+        "U": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "C": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "G": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "loop_state": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 11,
+      "maxItems": 11
+    },
+    "open_exposures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "exposure_id",
+          "credit_outstanding",
+          "collateral_posted",
+          "alpha_required",
+          "coverage_ratio",
+          "is_open"
+        ],
+        "properties": {
+          "exposure_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "credit_outstanding": {
+            "type": "number",
+            "minimum": 0
+          },
+          "collateral_posted": {
+            "type": "number",
+            "minimum": 0
+          },
+          "alpha_required": {
+            "type": "number",
+            "minimum": 1
+          },
+          "coverage_ratio": {
+            "type": "number",
+            "minimum": 0
+          },
+          "is_open": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "invariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "supply_nonnegative",
+        "signed_share_sum_ok",
+        "simplex_sum_ok",
+        "collateral_ok",
+        "epoch_monotone",
+        "unique_events",
+        "all_ok"
+      ],
+      "properties": {
+        "supply_nonnegative": {
+          "type": "boolean"
+        },
+        "signed_share_sum_ok": {
+          "type": "boolean"
+        },
+        "simplex_sum_ok": {
+          "type": "boolean"
+        },
+        "collateral_ok": {
+          "type": "boolean"
+        },
+        "epoch_monotone": {
+          "type": "boolean"
+        },
+        "unique_events": {
+          "type": "boolean"
+        },
+        "all_ok": {
+          "type": "boolean"
+        }
+      }
+    },
+    "event_ids_applied": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "checkpoint_hash": {
+      "type": "string"
+    }
+  }
+}

--- a/fixtures/descriptors/heller/v1/sample_event_envelope_v8.json
+++ b/fixtures/descriptors/heller/v1/sample_event_envelope_v8.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0.0",
+  "event_id": "packaging_to_education:epoch:00",
+  "scenario_id": "packaging_to_education",
+  "epoch": 0,
+  "event_type": "mint",
+  "proof_ref": "proof://repro/build/packaging-education-0001",
+  "sphere_from": 8,
+  "sphere_to": 9,
+  "token_tier": "micro",
+  "delta_ep": 10.0,
+  "quality": {
+    "C": 0.8,
+    "Q": 0.9,
+    "S": 0.8,
+    "P": 0.7
+  },
+  "payload": {
+    "amount": 30.0,
+    "class_id": "Knowledge+Attribution",
+    "denomination": "micro",
+    "exposure_id": "expo-pack-edu-0001",
+    "metadata_uri": "meta://packaging/education/showcase",
+    "reason": "Packaging reproducibility event with education spillover"
+  }
+}

--- a/fixtures/descriptors/heller/v1/sample_state_snapshot_v8.json
+++ b/fixtures/descriptors/heller/v1/sample_state_snapshot_v8.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "1.0.0",
+  "domain_id": "packaging_education_domain",
+  "scenario_id": "packaging_to_education",
+  "epoch": 0,
+  "base_supply": {
+    "micro": 300.0,
+    "credit": 50.0,
+    "reserve": 20.0
+  },
+  "delta_supply": {
+    "micro": 19.5,
+    "credit": 1.0,
+    "reserve": 0.2
+  },
+  "absolute_supply": {
+    "micro": 319.5,
+    "credit": 51.0,
+    "reserve": 20.2
+  },
+  "knowledge": {
+    "C": 0.8,
+    "Q": 0.9,
+    "S": 0.8,
+    "P": 0.7,
+    "K": 0.4032
+  },
+  "valuations": {
+    "V_U": 25.0,
+    "V_C": 1.0,
+    "V_G": 0.15000000000000002,
+    "V_total": 26.15
+  },
+  "signed_shares": {
+    "U": 0.9560229445506693,
+    "C": 0.03824091778202677,
+    "G": 0.005736137667304016
+  },
+  "simplex_shares": {
+    "U": 0.9560229445506693,
+    "C": 0.03824091778202677,
+    "G": 0.005736137667304016
+  },
+  "loop_state": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.735736411345153,
+    0.08046565794917825,
+    0.0,
+    0.0
+  ],
+  "open_exposures": [
+    {
+      "exposure_id": "expo-pack-edu-0001",
+      "credit_outstanding": 0.1,
+      "collateral_posted": 0.2,
+      "alpha_required": 1.5,
+      "coverage_ratio": 2.0,
+      "is_open": true
+    }
+  ],
+  "invariants": {
+    "supply_nonnegative": true,
+    "signed_share_sum_ok": true,
+    "simplex_sum_ok": true,
+    "collateral_ok": true,
+    "epoch_monotone": true,
+    "unique_events": true,
+    "all_ok": true
+  },
+  "event_ids_applied": [
+    "packaging_to_education:epoch:00"
+  ],
+  "checkpoint_hash": "sha256:placeholder"
+}

--- a/tools/check_descriptor_manifest_refs.py
+++ b/tools/check_descriptor_manifest_refs.py
@@ -3,17 +3,22 @@
 
 The checker scans fixture descriptor manifests and validates file-name fields that
 look like local schema, sample, or encoded payload artifact references. Strict mode
-is the default so a direct invocation exposes fixture debt. CI can pass
-`--warn-only` while legacy manifests are being repaired.
+is the default.
+
+Binary payload refs may be satisfied by a same-record embedded base64 payload when
+the manifest also supplies matching size and SHA-256 fields. This lets descriptor
+manifests remain self-contained while still catching stale schema/sample/proto refs.
 """
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_GLOB = "fixtures/**/encoded_payload_manifest*.json"
@@ -55,6 +60,14 @@ class MissingRef:
     expected: Path
 
 
+@dataclass(frozen=True)
+class InvalidEmbeddedPayload:
+    manifest: Path
+    object_path: str
+    key: str
+    reason: str
+
+
 def is_local_file_ref(key: str, value: Any) -> bool:
     if not isinstance(value, str):
         return False
@@ -68,12 +81,12 @@ def is_local_file_ref(key: str, value: Any) -> bool:
     return value.split("#", 1)[0].endswith(LOCAL_EXTENSIONS)
 
 
-def iter_refs(node: Any, object_path: str = "$") -> Iterable[tuple[str, str, str]]:
+def iter_refs(node: Any, object_path: str = "$") -> Iterable[tuple[str, Dict[str, Any], str, str]]:
     if isinstance(node, dict):
         for key, value in node.items():
             next_path = f"{object_path}.{key}"
             if is_local_file_ref(key, value):
-                yield object_path, key, value
+                yield object_path, node, key, value
             yield from iter_refs(value, next_path)
     elif isinstance(node, list):
         for index, value in enumerate(node):
@@ -85,6 +98,41 @@ def expected_path(base: Path, value: str) -> Path:
     return (base / file_part).resolve()
 
 
+def embedded_prefix(key: str) -> Optional[str]:
+    if key.endswith("_binary_file"):
+        return key.removesuffix("_binary_file")
+    return None
+
+
+def embedded_payload_is_valid(record: Dict[str, Any], key: str) -> tuple[bool, Optional[str]]:
+    prefix = embedded_prefix(key)
+    if prefix is None:
+        return False, None
+
+    b64_key = f"{prefix}_base64"
+    sha_key = f"{prefix}_sha256"
+    size_key = f"{prefix}_size_bytes"
+    if b64_key not in record:
+        return False, None
+
+    try:
+        payload = base64.b64decode(record[b64_key], validate=True)
+    except Exception as exc:  # noqa: BLE001 - report exact validation failure in CLI output.
+        return False, f"{b64_key} is not valid base64: {exc}"
+
+    expected_size = record.get(size_key)
+    if expected_size is not None and len(payload) != expected_size:
+        return False, f"{size_key}={expected_size} but decoded {len(payload)} bytes"
+
+    expected_sha = record.get(sha_key)
+    if expected_sha is not None:
+        actual_sha = hashlib.sha256(payload).hexdigest()
+        if actual_sha != expected_sha:
+            return False, f"{sha_key}={expected_sha} but decoded payload sha256={actual_sha}"
+
+    return True, None
+
+
 def relative_to_root(path: Path, root: Path) -> Union[Path, str]:
     try:
         return path.relative_to(root)
@@ -92,19 +140,27 @@ def relative_to_root(path: Path, root: Path) -> Union[Path, str]:
         return str(path)
 
 
-def check_manifest(path: Path) -> List[MissingRef]:
+def check_manifest(path: Path) -> tuple[List[MissingRef], List[InvalidEmbeddedPayload]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise SystemExit(f"[FAIL] {path}: invalid JSON: {exc}") from exc
 
     missing: List[MissingRef] = []
+    invalid_embedded: List[InvalidEmbeddedPayload] = []
     base = path.parent
-    for object_path, key, value in iter_refs(data):
+    for object_path, record, key, value in iter_refs(data):
         expected = expected_path(base, value)
-        if not expected.exists():
-            missing.append(MissingRef(path, object_path, key, value, expected))
-    return missing
+        if expected.exists():
+            continue
+        embedded_ok, embedded_error = embedded_payload_is_valid(record, key)
+        if embedded_ok:
+            continue
+        if embedded_error is not None:
+            invalid_embedded.append(InvalidEmbeddedPayload(path, object_path, key, embedded_error))
+            continue
+        missing.append(MissingRef(path, object_path, key, value, expected))
+    return missing, invalid_embedded
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -122,21 +178,27 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     all_missing: List[MissingRef] = []
+    all_invalid: List[InvalidEmbeddedPayload] = []
     for manifest in manifests:
         manifest_path = manifest if manifest.is_absolute() else root / manifest
-        all_missing.extend(check_manifest(manifest_path.resolve()))
+        missing, invalid = check_manifest(manifest_path.resolve())
+        all_missing.extend(missing)
+        all_invalid.extend(invalid)
 
-    if not all_missing:
-        print(f"[OK] checked {len(manifests)} descriptor manifest(s); all local refs exist")
+    if not all_missing and not all_invalid:
+        print(f"[OK] checked {len(manifests)} descriptor manifest(s); all local refs or embedded payloads are valid")
         return 0
 
     stream = sys.stderr if not args.warn_only else sys.stdout
     status = "WARN" if args.warn_only else "FAIL"
-    print(f"[{status}] {len(all_missing)} missing descriptor manifest reference(s):", file=stream)
+    print(f"[{status}] descriptor manifest reference validation found issues:", file=stream)
     for ref in all_missing:
         rel_manifest = relative_to_root(ref.manifest, root)
         rel_expected = relative_to_root(ref.expected, root)
-        print(f"  - {rel_manifest}: {ref.object_path}.{ref.key} -> {ref.value} (missing {rel_expected})", file=stream)
+        print(f"  - missing {rel_manifest}: {ref.object_path}.{ref.key} -> {ref.value} (expected {rel_expected})", file=stream)
+    for invalid in all_invalid:
+        rel_manifest = relative_to_root(invalid.manifest, root)
+        print(f"  - invalid embedded payload {rel_manifest}: {invalid.object_path}.{invalid.key}: {invalid.reason}", file=stream)
 
     return 0 if args.warn_only else 2
 


### PR DESCRIPTION
## Summary

Closes #60.

This PR repairs the Heller descriptor-manifest reference lane now that #56 added the strict-capable manifest checker and Avro LOM renderer.

## Changes

- Restore Heller Avro descriptor schemas from the canonical `SocioProphet/socioprophet-standards-storage` Heller contract artifacts:
  - `fixtures/descriptors/heller/v1/heller_event_envelope.avsc`
  - `fixtures/descriptors/heller/v1/heller_state_snapshot.avsc`
- Restore JSON Schema mirrors from the same standards source:
  - `heller_event_envelope.schema.json`
  - `heller_state_snapshot.schema.json`
- Restore Heller sample JSON payloads under the filenames referenced by the manifest:
  - `sample_event_envelope_v8.json`
  - `sample_state_snapshot_v8.json`
- Add `docs/diagrams/heller_event_envelope_lom.dot` as a Heller event schema LOM-style DOT diagram.
- Extend `tools/check_descriptor_manifest_refs.py` so missing `*_binary_file` references can be satisfied by same-record embedded `*_base64`, `*_size_bytes`, and `*_sha256` fields, with strict validation of decoded size and SHA-256.
- Switch `descriptor-manifest-refs` in `Makefile` from warn-only to strict mode.
- Update `docs/heller-v1-transport-seed.md` to clarify that binary payloads are embedded in the manifest and validated by the checker.

## Validation

Connector-side validation:

- Branch is 10 commits ahead of `main` and 0 behind.
- Changed files are scoped to Heller descriptor fixtures/docs, `Makefile`, and the descriptor manifest checker.
- Embedded base64 payloads in the manifest were decoded and checked locally against their listed byte sizes and SHA-256 values before opening this PR.

CI should run `make verify`, which now includes strict descriptor manifest reference checking.

## Notes

The binary payload file names remain logical manifest references. Physical binary payload files are not required while the manifest carries valid embedded base64 payloads with matching size/hash metadata.