### PR TITLE
Enforce exact Avro LOM diagram drift checks

### DIFF
--- a/docs/diagrams/heller_event_envelope_lom.dot
+++ b/docs/diagrams/heller_event_envelope_lom.dot
@@ -2,125 +2,98 @@ digraph avro_lom_schema {
   graph [rankdir=LR, splines=ortho, nodesep="0.35", ranksep="0.70", labelloc="b", label="LOM-style Avro schema view: socioprophet.heller.v1.HellerEventEnvelope"];
   node [fontname="Helvetica", fontsize="10"];
   edge [color="black", arrowsize="0.6"];
-
   lane_0 [shape=plaintext, label="Schema"];
   lane_1 [shape=plaintext, label="Category"];
   lane_2 [shape=plaintext, label="Aggregate Element"];
   lane_3 [shape=plaintext, label="Simple Data Element"];
   lane_4 [shape=plaintext, label="Datatype"];
   lane_5 [shape=plaintext, label="Value"];
-
-  root [shape=box, style="rounded", label="socioprophet.heller.v1\nHellerEventEnvelope"];
-
-  schema_version [shape=box, style="rounded", label="schema_version"];
-  event_id [shape=box, style="rounded", label="event_id"];
-  scenario_id [shape=box, style="rounded", label="scenario_id"];
-  epoch [shape=box, style="rounded", label="epoch"];
-  event_type [shape=box, style="rounded", label="event_type"];
-  proof_ref [shape=box, style="rounded", label="proof_ref"];
-  sphere_from [shape=box, style="rounded", label="sphere_from"];
-  sphere_to [shape=box, style="rounded", label="sphere_to"];
-  token_tier [shape=box, style="rounded", label="token_tier"];
-  delta_ep [shape=box, style="rounded", label="delta_ep"];
-  quality [shape=box, style="rounded", label="quality"];
-  recipients [shape=box, style="rounded", label="recipients"];
-  payload [shape=box, style="rounded", label="payload"];
-
-  quality_C [shape=box, style="rounded", label="C"];
-  quality_Q [shape=box, style="rounded", label="Q"];
-  quality_S [shape=box, style="rounded", label="S"];
-  quality_P [shape=box, style="rounded", label="P"];
-  recipients_items [shape=box, style="rounded", label="items[]"];
-  recipient_id [shape=box, style="rounded", label="recipient_id"];
-  recipient_weight [shape=box, style="rounded", label="weight"];
-  payload_amount [shape=box, style="rounded", label="amount"];
-  payload_class_id [shape=box, style="rounded", label="class_id"];
-  payload_denomination [shape=box, style="rounded", label="denomination"];
-  payload_exposure_id [shape=box, style="rounded", label="exposure_id"];
-  payload_metadata_uri [shape=box, style="rounded", label="metadata_uri"];
-  payload_reason [shape=box, style="rounded", label="reason"];
-
-  type_string [shape=box, style="solid", label="string"];
-  type_int [shape=box, style="solid", label="int"];
-  type_double [shape=box, style="solid", label="double"];
-  type_event_type [shape=box, style="solid", label="enum EventType"];
-  type_token_tier [shape=box, style="solid", label="enum TokenTier"];
-  type_denomination_union [shape=box, style="solid", label="null | enum Denomination"];
-  type_null_string [shape=box, style="solid", label="null | string"];
-
-  value_placeholder [shape=plaintext, label="..."];
-
-  { rank=same; lane_0; root; }
-  { rank=same; lane_1; schema_version; event_id; scenario_id; epoch; event_type; proof_ref; sphere_from; sphere_to; token_tier; delta_ep; quality; recipients; payload; }
-  { rank=same; lane_2; quality_C; quality_Q; quality_S; quality_P; recipients_items; payload_amount; payload_class_id; payload_denomination; payload_exposure_id; payload_metadata_uri; payload_reason; }
-  { rank=same; lane_3; recipient_id; recipient_weight; }
-  { rank=same; lane_4; type_string; type_int; type_double; type_event_type; type_token_tier; type_denomination_union; type_null_string; }
-  { rank=same; lane_5; value_placeholder; }
-
+  socioprophet_heller_v1_HellerEventEnvelope_0 [shape=box, style="rounded", label="socioprophet.heller.v1\\nHellerEventEnvelope"];
+  socioprophet_heller_v1_HellerEventEnvelope_schema_version_1 [shape=box, style="rounded", label="schema_version"];
+  socioprophet_heller_v1_HellerEventEnvelope_schema_version_datatype_2 [shape=box, style="solid", label="string"];
+  socioprophet_heller_v1_HellerEventEnvelope_schema_version_value_3 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_event_id_4 [shape=box, style="rounded", label="event_id"];
+  socioprophet_heller_v1_HellerEventEnvelope_event_id_datatype_5 [shape=box, style="solid", label="string"];
+  socioprophet_heller_v1_HellerEventEnvelope_event_id_value_6 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_scenario_id_7 [shape=box, style="rounded", label="scenario_id"];
+  socioprophet_heller_v1_HellerEventEnvelope_scenario_id_datatype_8 [shape=box, style="solid", label="string"];
+  socioprophet_heller_v1_HellerEventEnvelope_scenario_id_value_9 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_epoch_10 [shape=box, style="rounded", label="epoch"];
+  socioprophet_heller_v1_HellerEventEnvelope_epoch_datatype_11 [shape=box, style="solid", label="int"];
+  socioprophet_heller_v1_HellerEventEnvelope_epoch_value_12 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_event_type_13 [shape=box, style="rounded", label="event_type"];
+  socioprophet_heller_v1_HellerEventEnvelope_event_type_datatype_14 [shape=box, style="solid", label="enum EventType"];
+  socioprophet_heller_v1_HellerEventEnvelope_event_type_value_15 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_proof_ref_16 [shape=box, style="rounded", label="proof_ref"];
+  socioprophet_heller_v1_HellerEventEnvelope_proof_ref_datatype_17 [shape=box, style="solid", label="string"];
+  socioprophet_heller_v1_HellerEventEnvelope_proof_ref_value_18 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_from_19 [shape=box, style="rounded", label="sphere_from"];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_from_datatype_20 [shape=box, style="solid", label="int"];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_from_value_21 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_to_22 [shape=box, style="rounded", label="sphere_to"];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_to_datatype_23 [shape=box, style="solid", label="int"];
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_to_value_24 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_token_tier_25 [shape=box, style="rounded", label="token_tier"];
+  socioprophet_heller_v1_HellerEventEnvelope_token_tier_datatype_26 [shape=box, style="solid", label="enum TokenTier"];
+  socioprophet_heller_v1_HellerEventEnvelope_token_tier_value_27 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_delta_ep_28 [shape=box, style="rounded", label="delta_ep"];
+  socioprophet_heller_v1_HellerEventEnvelope_delta_ep_datatype_29 [shape=box, style="solid", label="double"];
+  socioprophet_heller_v1_HellerEventEnvelope_delta_ep_value_30 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_quality_31 [shape=box, style="rounded", label="quality"];
+  socioprophet_heller_v1_HellerEventEnvelope_quality_datatype_32 [shape=box, style="solid", label="record QualityCQSP"];
+  socioprophet_heller_v1_HellerEventEnvelope_quality_value_33 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_recipients_34 [shape=box, style="rounded", label="recipients"];
+  socioprophet_heller_v1_HellerEventEnvelope_recipients_datatype_35 [shape=box, style="solid", label="array<record Recipient>"];
+  socioprophet_heller_v1_HellerEventEnvelope_recipients_value_36 [shape=plaintext, style="solid", label="..."];
+  socioprophet_heller_v1_HellerEventEnvelope_payload_37 [shape=box, style="rounded", label="payload"];
+  socioprophet_heller_v1_HellerEventEnvelope_payload_datatype_38 [shape=box, style="solid", label="record EventPayload"];
+  socioprophet_heller_v1_HellerEventEnvelope_payload_value_39 [shape=plaintext, style="solid", label="..."];
+  { rank=same; lane_0; socioprophet_heller_v1_HellerEventEnvelope_0; }
+  { rank=same; lane_1; socioprophet_heller_v1_HellerEventEnvelope_schema_version_1; socioprophet_heller_v1_HellerEventEnvelope_event_id_4; socioprophet_heller_v1_HellerEventEnvelope_scenario_id_7; socioprophet_heller_v1_HellerEventEnvelope_epoch_10; socioprophet_heller_v1_HellerEventEnvelope_event_type_13; socioprophet_heller_v1_HellerEventEnvelope_proof_ref_16; socioprophet_heller_v1_HellerEventEnvelope_sphere_from_19; socioprophet_heller_v1_HellerEventEnvelope_sphere_to_22; socioprophet_heller_v1_HellerEventEnvelope_token_tier_25; socioprophet_heller_v1_HellerEventEnvelope_delta_ep_28; socioprophet_heller_v1_HellerEventEnvelope_quality_31; socioprophet_heller_v1_HellerEventEnvelope_recipients_34; socioprophet_heller_v1_HellerEventEnvelope_payload_37; }
+  { rank=same; lane_4; socioprophet_heller_v1_HellerEventEnvelope_schema_version_datatype_2; socioprophet_heller_v1_HellerEventEnvelope_event_id_datatype_5; socioprophet_heller_v1_HellerEventEnvelope_scenario_id_datatype_8; socioprophet_heller_v1_HellerEventEnvelope_epoch_datatype_11; socioprophet_heller_v1_HellerEventEnvelope_event_type_datatype_14; socioprophet_heller_v1_HellerEventEnvelope_proof_ref_datatype_17; socioprophet_heller_v1_HellerEventEnvelope_sphere_from_datatype_20; socioprophet_heller_v1_HellerEventEnvelope_sphere_to_datatype_23; socioprophet_heller_v1_HellerEventEnvelope_token_tier_datatype_26; socioprophet_heller_v1_HellerEventEnvelope_delta_ep_datatype_29; socioprophet_heller_v1_HellerEventEnvelope_quality_datatype_32; socioprophet_heller_v1_HellerEventEnvelope_recipients_datatype_35; socioprophet_heller_v1_HellerEventEnvelope_payload_datatype_38; }
+  { rank=same; lane_5; socioprophet_heller_v1_HellerEventEnvelope_schema_version_value_3; socioprophet_heller_v1_HellerEventEnvelope_event_id_value_6; socioprophet_heller_v1_HellerEventEnvelope_scenario_id_value_9; socioprophet_heller_v1_HellerEventEnvelope_epoch_value_12; socioprophet_heller_v1_HellerEventEnvelope_event_type_value_15; socioprophet_heller_v1_HellerEventEnvelope_proof_ref_value_18; socioprophet_heller_v1_HellerEventEnvelope_sphere_from_value_21; socioprophet_heller_v1_HellerEventEnvelope_sphere_to_value_24; socioprophet_heller_v1_HellerEventEnvelope_token_tier_value_27; socioprophet_heller_v1_HellerEventEnvelope_delta_ep_value_30; socioprophet_heller_v1_HellerEventEnvelope_quality_value_33; socioprophet_heller_v1_HellerEventEnvelope_recipients_value_36; socioprophet_heller_v1_HellerEventEnvelope_payload_value_39; }
   lane_0 -> lane_1 [style=invis, weight=20];
   lane_1 -> lane_2 [style=invis, weight=20];
   lane_2 -> lane_3 [style=invis, weight=20];
   lane_3 -> lane_4 [style=invis, weight=20];
   lane_4 -> lane_5 [style=invis, weight=20];
-
-  root -> schema_version;
-  root -> event_id;
-  root -> scenario_id;
-  root -> epoch;
-  root -> event_type;
-  root -> proof_ref;
-  root -> sphere_from;
-  root -> sphere_to;
-  root -> token_tier;
-  root -> delta_ep;
-  root -> quality;
-  root -> recipients;
-  root -> payload;
-
-  schema_version -> type_string;
-  event_id -> type_string;
-  scenario_id -> type_string;
-  epoch -> type_int;
-  event_type -> type_event_type;
-  proof_ref -> type_string;
-  sphere_from -> type_int;
-  sphere_to -> type_int;
-  token_tier -> type_token_tier;
-  delta_ep -> type_double;
-
-  quality -> quality_C;
-  quality -> quality_Q;
-  quality -> quality_S;
-  quality -> quality_P;
-  quality_C -> type_double;
-  quality_Q -> type_double;
-  quality_S -> type_double;
-  quality_P -> type_double;
-
-  recipients -> recipients_items;
-  recipients_items -> recipient_id;
-  recipients_items -> recipient_weight;
-  recipient_id -> type_string;
-  recipient_weight -> type_double;
-
-  payload -> payload_amount;
-  payload -> payload_class_id;
-  payload -> payload_denomination;
-  payload -> payload_exposure_id;
-  payload -> payload_metadata_uri;
-  payload -> payload_reason;
-  payload_amount -> type_double;
-  payload_class_id -> type_string;
-  payload_denomination -> type_denomination_union;
-  payload_exposure_id -> type_null_string;
-  payload_metadata_uri -> type_null_string;
-  payload_reason -> type_null_string;
-
-  type_string -> value_placeholder;
-  type_int -> value_placeholder;
-  type_double -> value_placeholder;
-  type_event_type -> value_placeholder;
-  type_token_tier -> value_placeholder;
-  type_denomination_union -> value_placeholder;
-  type_null_string -> value_placeholder;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_schema_version_1;
+  socioprophet_heller_v1_HellerEventEnvelope_schema_version_1 -> socioprophet_heller_v1_HellerEventEnvelope_schema_version_datatype_2;
+  socioprophet_heller_v1_HellerEventEnvelope_schema_version_1 -> socioprophet_heller_v1_HellerEventEnvelope_schema_version_value_3;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_event_id_4;
+  socioprophet_heller_v1_HellerEventEnvelope_event_id_4 -> socioprophet_heller_v1_HellerEventEnvelope_event_id_datatype_5;
+  socioprophet_heller_v1_HellerEventEnvelope_event_id_4 -> socioprophet_heller_v1_HellerEventEnvelope_event_id_value_6;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_scenario_id_7;
+  socioprophet_heller_v1_HellerEventEnvelope_scenario_id_7 -> socioprophet_heller_v1_HellerEventEnvelope_scenario_id_datatype_8;
+  socioprophet_heller_v1_HellerEventEnvelope_scenario_id_7 -> socioprophet_heller_v1_HellerEventEnvelope_scenario_id_value_9;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_epoch_10;
+  socioprophet_heller_v1_HellerEventEnvelope_epoch_10 -> socioprophet_heller_v1_HellerEventEnvelope_epoch_datatype_11;
+  socioprophet_heller_v1_HellerEventEnvelope_epoch_10 -> socioprophet_heller_v1_HellerEventEnvelope_epoch_value_12;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_event_type_13;
+  socioprophet_heller_v1_HellerEventEnvelope_event_type_13 -> socioprophet_heller_v1_HellerEventEnvelope_event_type_datatype_14;
+  socioprophet_heller_v1_HellerEventEnvelope_event_type_13 -> socioprophet_heller_v1_HellerEventEnvelope_event_type_value_15;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_proof_ref_16;
+  socioprophet_heller_v1_HellerEventEnvelope_proof_ref_16 -> socioprophet_heller_v1_HellerEventEnvelope_proof_ref_datatype_17;
+  socioprophet_heller_v1_HellerEventEnvelope_proof_ref_16 -> socioprophet_heller_v1_HellerEventEnvelope_proof_ref_value_18;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_from_19;
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_from_19 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_from_datatype_20;
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_from_19 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_from_value_21;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_to_22;
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_to_22 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_to_datatype_23;
+  socioprophet_heller_v1_HellerEventEnvelope_sphere_to_22 -> socioprophet_heller_v1_HellerEventEnvelope_sphere_to_value_24;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_token_tier_25;
+  socioprophet_heller_v1_HellerEventEnvelope_token_tier_25 -> socioprophet_heller_v1_HellerEventEnvelope_token_tier_datatype_26;
+  socioprophet_heller_v1_HellerEventEnvelope_token_tier_25 -> socioprophet_heller_v1_HellerEventEnvelope_token_tier_value_27;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_delta_ep_28;
+  socioprophet_heller_v1_HellerEventEnvelope_delta_ep_28 -> socioprophet_heller_v1_HellerEventEnvelope_delta_ep_datatype_29;
+  socioprophet_heller_v1_HellerEventEnvelope_delta_ep_28 -> socioprophet_heller_v1_HellerEventEnvelope_delta_ep_value_30;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_quality_31;
+  socioprophet_heller_v1_HellerEventEnvelope_quality_31 -> socioprophet_heller_v1_HellerEventEnvelope_quality_datatype_32;
+  socioprophet_heller_v1_HellerEventEnvelope_quality_31 -> socioprophet_heller_v1_HellerEventEnvelope_quality_value_33;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_recipients_34;
+  socioprophet_heller_v1_HellerEventEnvelope_recipients_34 -> socioprophet_heller_v1_HellerEventEnvelope_recipients_datatype_35;
+  socioprophet_heller_v1_HellerEventEnvelope_recipients_34 -> socioprophet_heller_v1_HellerEventEnvelope_recipients_value_36;
+  socioprophet_heller_v1_HellerEventEnvelope_0 -> socioprophet_heller_v1_HellerEventEnvelope_payload_37;
+  socioprophet_heller_v1_HellerEventEnvelope_payload_37 -> socioprophet_heller_v1_HellerEventEnvelope_payload_datatype_38;
+  socioprophet_heller_v1_HellerEventEnvelope_payload_37 -> socioprophet_heller_v1_HellerEventEnvelope_payload_value_39;
 }

--- a/tools/check_avro_lom_diagrams.py
+++ b/tools/check_avro_lom_diagrams.py
@@ -1,150 +1,90 @@
 #!/usr/bin/env python3
-"""Check checked-in Avro LOM DOT diagrams for schema coverage drift.
+"""Regenerate checked-in Avro LOM DOT diagrams and fail on exact drift.
 
-The diagrams are non-normative views over `.avsc` sources. This checker enforces
-that every Avro field name and expected field type label remains represented in
-the checked-in DOT artifact. It is intentionally stable for hand-tuned DOT
-layouts while still failing when a schema evolves and the diagram is not updated.
+The diagrams are non-normative views over `.avsc` sources, but once committed
+they must be reproducible from `tools/render_avro_schema_lom.py`. This checker
+runs the renderer for each registered schema/diagram pair and compares the
+result byte-for-byte against the checked-in DOT file.
 """
 from __future__ import annotations
 
 import argparse
-import json
+import difflib
+import subprocess
 import sys
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Set, Tuple
+from typing import Iterable, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
-PRIMITIVES = {"null", "boolean", "int", "long", "float", "double", "bytes", "string"}
-DIAGRAMS: Tuple[Tuple[str, str], ...] = (
-    (
-        "fixtures/descriptors/heller/v1/heller_event_envelope.avsc",
-        "docs/diagrams/heller_event_envelope_lom.dot",
+RENDERER = ROOT / "tools" / "render_avro_schema_lom.py"
+
+
+@dataclass(frozen=True)
+class DiagramSpec:
+    schema: str
+    diagram: str
+    max_depth: int = 1
+
+
+DIAGRAMS: Tuple[DiagramSpec, ...] = (
+    DiagramSpec(
+        schema="fixtures/descriptors/heller/v1/heller_event_envelope.avsc",
+        diagram="docs/diagrams/heller_event_envelope_lom.dot",
+        max_depth=1,
     ),
 )
 
 
-def normalize(avro_type: Any) -> Tuple[str, Any]:
-    if isinstance(avro_type, str):
-        return ("primitive", avro_type) if avro_type in PRIMITIVES else ("named", avro_type)
-    if isinstance(avro_type, list):
-        return "union", avro_type
-    if isinstance(avro_type, dict):
-        if "logicalType" in avro_type and isinstance(avro_type.get("type"), str):
-            return "logical", avro_type
-        type_value = avro_type.get("type")
-        if type_value in {"record", "enum", "fixed", "array", "map"}:
-            return type_value, avro_type
-        if isinstance(type_value, list):
-            return "union", type_value
-        if isinstance(type_value, str):
-            return normalize(type_value)
-    return "unknown", avro_type
+def render_to_temp(spec: DiagramSpec, output_path: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(RENDERER),
+            "--schema",
+            str(ROOT / spec.schema),
+            "--out",
+            str(output_path),
+            "--max-depth",
+            str(spec.max_depth),
+        ],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
-def qualified_name(schema: dict[str, Any]) -> str:
-    name = schema.get("name", "Root")
-    namespace = schema.get("namespace")
-    return f"{namespace}.{name}" if namespace else name
-
-
-def type_label(avro_type: Any) -> str:
-    kind, obj = normalize(avro_type)
-    if kind in {"primitive", "named"}:
-        return str(obj)
-    if kind == "logical":
-        return f"{obj.get('type')}({obj.get('logicalType')})"
-    if kind == "enum":
-        return f"enum {obj.get('name')}"
-    if kind == "fixed":
-        return f"fixed {qualified_name(obj)}[{obj.get('size')}]"
-    if kind == "array":
-        return "items[]"
-    if kind == "map":
-        return "values{}"
-    if kind == "union":
-        return " | ".join(type_label(option) for option in obj)
-    if kind == "record":
-        return "record"
-    return json.dumps(obj, sort_keys=True)
-
-
-def collect_expected_labels(schema: dict[str, Any]) -> Set[str]:
-    labels: Set[str] = {qualified_name(schema), schema.get("name", "Root")}
-    registry: dict[str, Any] = {}
-
-    def register(avro_type: Any) -> None:
-        kind, obj = normalize(avro_type)
-        if kind in {"record", "enum", "fixed"} and isinstance(obj, dict) and "name" in obj:
-            registry[obj["name"]] = obj
-            registry[qualified_name(obj)] = obj
-        if kind == "record":
-            for field_obj in obj.get("fields", []):
-                register(field_obj.get("type"))
-        elif kind == "array":
-            register(obj.get("items"))
-        elif kind == "map":
-            register(obj.get("values"))
-        elif kind == "union":
-            for option in obj:
-                register(option)
-
-    def resolve(avro_type: Any) -> Tuple[str, Any]:
-        kind, obj = normalize(avro_type)
-        if kind == "named" and obj in registry:
-            return normalize(registry[obj])
-        return kind, obj
-
-    def visit_field_type(avro_type: Any) -> None:
-        kind, obj = resolve(avro_type)
-        if kind != "record":
-            labels.add(type_label(avro_type))
-        if kind == "record":
-            for field_obj in obj.get("fields", []):
-                labels.add(field_obj["name"])
-                visit_field_type(field_obj["type"])
-        elif kind == "array":
-            labels.add("items[]")
-            item_kind, item_obj = resolve(obj.get("items"))
-            if item_kind == "record":
-                for field_obj in item_obj.get("fields", []):
-                    labels.add(field_obj["name"])
-                    visit_field_type(field_obj["type"])
-            else:
-                visit_field_type(obj.get("items"))
-        elif kind == "map":
-            labels.add("values{}")
-            visit_field_type(obj.get("values"))
-        elif kind == "union":
-            labels.add("union")
-
-    register(schema)
-    for field_obj in schema.get("fields", []):
-        labels.add(field_obj["name"])
-        visit_field_type(field_obj["type"])
-    return {label for label in labels if label and label != "record"}
-
-
-def check_pair(schema_rel: str, diagram_rel: str) -> bool:
-    schema_path = ROOT / schema_rel
-    diagram_path = ROOT / diagram_rel
+def check_spec(spec: DiagramSpec) -> bool:
+    schema_path = ROOT / spec.schema
+    diagram_path = ROOT / spec.diagram
     if not schema_path.exists():
-        print(f"[FAIL] missing schema source: {schema_rel}", file=sys.stderr)
+        print(f"[FAIL] missing schema source: {spec.schema}", file=sys.stderr)
         return False
     if not diagram_path.exists():
-        print(f"[FAIL] missing diagram artifact: {diagram_rel}", file=sys.stderr)
+        print(f"[FAIL] missing diagram artifact: {spec.diagram}", file=sys.stderr)
         return False
 
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    diagram = diagram_path.read_text(encoding="utf-8")
-    missing = sorted(label for label in collect_expected_labels(schema) if label not in diagram)
-    if not missing:
-        print(f"[OK] {diagram_rel} covers {schema_rel}")
+    with tempfile.TemporaryDirectory(prefix="avro-lom-diagram-") as tmpdir:
+        generated_path = Path(tmpdir) / Path(spec.diagram).name
+        render_to_temp(spec, generated_path)
+        expected = diagram_path.read_text(encoding="utf-8")
+        actual = generated_path.read_text(encoding="utf-8")
+
+    if expected == actual:
+        print(f"[OK] {spec.diagram} exactly matches renderer output for {spec.schema}")
         return True
 
-    print(f"[FAIL] {diagram_rel} is missing labels from {schema_rel}:", file=sys.stderr)
-    for label in missing:
-        print(f"  - {label}", file=sys.stderr)
+    print(f"[FAIL] {spec.diagram} drifted from renderer output for {spec.schema}", file=sys.stderr)
+    diff = difflib.unified_diff(
+        expected.splitlines(keepends=True),
+        actual.splitlines(keepends=True),
+        fromfile=spec.diagram,
+        tofile=f"generated:{spec.diagram}",
+    )
+    sys.stderr.writelines(diff)
     return False
 
 
@@ -153,8 +93,8 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser.parse_args(argv)
 
     ok = True
-    for schema_rel, diagram_rel in DIAGRAMS:
-        ok = check_pair(schema_rel, diagram_rel) and ok
+    for spec in DIAGRAMS:
+        ok = check_spec(spec) and ok
     return 0 if ok else 2
 
 


### PR DESCRIPTION
## Summary

Tightens the Avro LOM diagram guard from schema-coverage checking to exact renderer-output drift checking.

## Changes

- Replace coverage-only logic in `tools/check_avro_lom_diagrams.py` with byte-for-byte regenerated DOT comparison.
- Register `docs/diagrams/heller_event_envelope_lom.dot` as the exact output of `tools/render_avro_schema_lom.py` for `fixtures/descriptors/heller/v1/heller_event_envelope.avsc` with `--max-depth 1`.
- Regenerate `docs/diagrams/heller_event_envelope_lom.dot` to match that renderer profile.

## Validation

Connector-side validation:

- Branch is 2 commits ahead of `main` and 0 behind.
- Changed files are limited to `docs/diagrams/heller_event_envelope_lom.dot` and `tools/check_avro_lom_diagrams.py`.

CI should run `make verify`, which includes `avro-lom-diagrams`.