### PR TITLE
verify: drop dangling pathB_stream fixture entry + fail loud on missing files

### DIFF
--- a/tools/verify_fixtures_strict.py
+++ b/tools/verify_fixtures_strict.py
@@ -73,8 +73,10 @@ def get_aad_and_tag(frame: bytes):
 
 def verify_file(fx_name: str, nx_name: str) -> None:
     path = FX/fx_name; npath = FX/nx_name
-    if not path.exists() or not npath.exists():
-        return
+    missing = [str(p) for p in (path, npath) if not p.exists()]
+    if missing:
+        print(f"[FAIL] listed fixture file(s) missing: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(2)
     nonce = {}
     for ln in npath.read_text().splitlines():
         ln=ln.strip()
@@ -101,7 +103,6 @@ def main():
         ("vectors_hex_unary_rich.txt","vectors_hex_unary_rich.txt.nonces"),
         ("vectors_hex_stream_avronested.txt","vectors_hex_stream_avronested.txt.nonces"),
         ("vectors_hex_pathB.txt","vectors_hex_pathB.txt.nonces"),
-        ("vectors_hex_pathB_stream.txt","vectors_hex_pathB_stream.txt.nonces"),
         ("vectors_hex_prophet_lane1.txt", "vectors_hex_prophet_lane1.txt.nonces"),
     ]
     for f,n in sets: verify_file(f,n)


### PR DESCRIPTION
## Problem
`tools/verify_fixtures_strict.py`'s `sets` list referenced `("vectors_hex_pathB_stream.txt", "…​.nonces")`, but `fixtures/vectors_hex_pathB_stream.txt` **does not exist** and `verify_file()` **silently `return`ed** on the missing path — so that lane was never verified and the gap was invisible (no CI failure).

## Decision: remove the entry (option b), not generate vectors (option a)
Evidence the lane isn't real:
- **Never existed** — absent from *all* of git history (`git log --all` empty); the `sets` entry has been a dangling no-op since the repo was assembled.
- **Not a documented contract** — the only reference to `pathB_stream` anywhere is that one `sets` line. Path-B (`docs/THEORY.md` §5) is a *ternary payload-encoding* axis compatible with the same envelope/AEAD; streaming is a separate axis already covered by `vectors_hex_stream_avrochunk`/`avronested`.
- **No in-repo generator** — frames carry BLAKE2b-MAC tags produced out-of-repo. Fabricating self-consistent frames (option a) would cross-check against nothing and fake coverage.

## Changes
1. Remove the stale `pathB_stream` `sets` entry.
2. `verify_file` now **fails (exit 2)** with a clear message when a listed fixture/nonces file is missing, instead of silently skipping — so future dangling references surface in CI immediately.

## Verification
- `verify_fixtures_strict.py` → `[OK] All fixture AEAD tags verified`, exit 0.
- Fail-loud path confirmed to exit non-zero on a missing file.
- `make verify` → exit 0 (all lanes real).