### PR TITLE
spec(transport): SOC / chain profile — owner-sealed multi-hop receipt binding

### DIFF
--- a/.github/workflows/validate-receipt-soc-profile.yml
+++ b/.github/workflows/validate-receipt-soc-profile.yml
@@ -1,0 +1,33 @@
+name: validate-receipt-soc-profile
+
+on:
+  pull_request:
+    paths:
+      - "spec/transport/receipt_binding.md"
+      - "examples/transport/receipt_events.soc.example.json"
+      - "examples/transport/receipt_events.soc.*.invalid.json"
+      - "tools/verify_receipt_soc_profile.py"
+      - ".github/workflows/validate-receipt-soc-profile.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "spec/transport/receipt_binding.md"
+      - "examples/transport/receipt_events.soc.example.json"
+      - "examples/transport/receipt_events.soc.*.invalid.json"
+      - "tools/verify_receipt_soc_profile.py"
+      - ".github/workflows/validate-receipt-soc-profile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate SOC / chain profile
+        run: python tools/verify_receipt_soc_profile.py

--- a/examples/transport/receipt_events.soc.example.json
+++ b/examples/transport/receipt_events.soc.example.json
@@ -1,0 +1,85 @@
+{
+  "trace_id": "trace_soc_fed_hr_001",
+  "chain_id": "soc://alice/fed-hr/001",
+  "events": [
+    {
+      "event_id": "evt_soc_000",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_send",
+      "parent_span_id": "span_intent",
+      "event_type": "rpc.request.sent",
+      "ts": "2026-08-03T02:00:00.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 0,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope00",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "request_bytes": 2048
+      }
+    },
+    {
+      "event_id": "evt_soc_001",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop1",
+      "parent_span_id": "span_send",
+      "event_type": "rpc.hop.sealed",
+      "ts": "2026-08-03T02:00:01.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 1,
+        "route_id": "route://relay/schema-xform@v1",
+        "peer_id": "node://relay-pseudo-7f",
+        "envelope_hash": "sha256:envelope01",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo"
+      }
+    },
+    {
+      "event_id": "evt_soc_002",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop2",
+      "parent_span_id": "span_hop1",
+      "event_type": "rpc.hop.sealed",
+      "ts": "2026-08-03T02:00:02.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 2,
+        "route_id": "route://enclave/opaque-compute@v1",
+        "peer_id": "node://enclave-pseudo-3a",
+        "envelope_hash": "sha256:envelope02",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo"
+      }
+    },
+    {
+      "event_id": "evt_soc_003",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_recv",
+      "parent_span_id": "span_hop2",
+      "event_type": "rpc.response.received",
+      "ts": "2026-08-03T02:00:03.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 3,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope03",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "response_bytes": 8192,
+        "latency_ms": 740
+      }
+    }
+  ]
+}

--- a/examples/transport/receipt_events.soc.sabotage-continues.invalid.json
+++ b/examples/transport/receipt_events.soc.sabotage-continues.invalid.json
@@ -1,0 +1,86 @@
+{
+  "trace_id": "trace_soc_fed_hr_001",
+  "chain_id": "soc://alice/fed-hr/001",
+  "events": [
+    {
+      "event_id": "evt_soc_000",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_send",
+      "parent_span_id": "span_intent",
+      "event_type": "rpc.request.sent",
+      "ts": "2026-08-03T02:00:00.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 0,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope00",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "request_bytes": 2048
+      }
+    },
+    {
+      "event_id": "evt_soc_001",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop1",
+      "parent_span_id": "span_send",
+      "event_type": "rpc.hop.sealed",
+      "ts": "2026-08-03T02:00:01.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 1,
+        "route_id": "route://relay/schema-xform@v1",
+        "peer_id": "node://relay-pseudo-7f",
+        "envelope_hash": "sha256:envelope01",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo"
+      }
+    },
+    {
+      "event_id": "evt_soc_002",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop2",
+      "parent_span_id": "span_hop1",
+      "event_type": "rpc.fail",
+      "ts": "2026-08-03T02:00:02.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 2,
+        "route_id": "route://enclave/opaque-compute@v1",
+        "peer_id": "node://enclave-pseudo-3a",
+        "envelope_hash": "sha256:envelope02",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "failure_class": "sabotage"
+      }
+    },
+    {
+      "event_id": "evt_soc_003",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_recv",
+      "parent_span_id": "span_hop2",
+      "event_type": "rpc.response.received",
+      "ts": "2026-08-03T02:00:03.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 3,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope03",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "response_bytes": 8192,
+        "latency_ms": 740
+      }
+    }
+  ]
+}

--- a/examples/transport/receipt_events.soc.unsealed.invalid.json
+++ b/examples/transport/receipt_events.soc.unsealed.invalid.json
@@ -1,0 +1,85 @@
+{
+  "trace_id": "trace_soc_fed_hr_001",
+  "chain_id": "soc://alice/fed-hr/001",
+  "events": [
+    {
+      "event_id": "evt_soc_000",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_send",
+      "parent_span_id": "span_intent",
+      "event_type": "rpc.request.sent",
+      "ts": "2026-08-03T02:00:00.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 0,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope00",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "request_bytes": 2048
+      }
+    },
+    {
+      "event_id": "evt_soc_001",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop1",
+      "parent_span_id": "span_send",
+      "event_type": "rpc.hop.sealed",
+      "ts": "2026-08-03T02:00:01.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 1,
+        "route_id": "route://relay/schema-xform@v1",
+        "peer_id": "node://relay-pseudo-7f",
+        "envelope_hash": "sha256:envelope01",
+        "sealed": false,
+        "sealed_to": "owner://anchor-alice-pseudo"
+      }
+    },
+    {
+      "event_id": "evt_soc_002",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_hop2",
+      "parent_span_id": "span_hop1",
+      "event_type": "rpc.hop.sealed",
+      "ts": "2026-08-03T02:00:02.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 2,
+        "route_id": "route://enclave/opaque-compute@v1",
+        "peer_id": "node://enclave-pseudo-3a",
+        "envelope_hash": "sha256:envelope02",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo"
+      }
+    },
+    {
+      "event_id": "evt_soc_003",
+      "trace_id": "trace_soc_fed_hr_001",
+      "span_id": "span_recv",
+      "parent_span_id": "span_hop2",
+      "event_type": "rpc.response.received",
+      "ts": "2026-08-03T02:00:03.000Z",
+      "producer": "tritrpc",
+      "payload": {
+        "protocol": "tritrpc",
+        "chain_id": "soc://alice/fed-hr/001",
+        "chain_position": 3,
+        "route_id": "route://planner/soc-entry@v1",
+        "peer_id": "node://alice-pseudo",
+        "envelope_hash": "sha256:envelope03",
+        "sealed": true,
+        "sealed_to": "owner://anchor-alice-pseudo",
+        "response_bytes": 8192,
+        "latency_ms": 740
+      }
+    }
+  ]
+}

--- a/spec/transport/receipt_binding.md
+++ b/spec/transport/receipt_binding.md
@@ -153,3 +153,71 @@ A TriTRPC-integrated receipt path is acceptable for v0.1 when:
 2. the receipt shows a deterministic transport identity,
 3. retry behavior is visible if it occurred,
 4. the receipt builder can consume TriTRPC events without custom per-case hacks.
+
+---
+
+## SOC / Chain Profile (v0.2, additive)
+
+A **Semantic Obfuscation Chain (SOC)** is a governed **multi-hop** RPC: a request is pulled through
+a chain of trust-bound relays/enclaves, each performing one transform (schema resolution, opaque
+compute, braiding). Its privacy model requires that **no single relay observes the whole path** —
+yet §"Normative statements" requires that **the transport path is not invisible**. These reconcile
+through **owner-sealing**: the receipt is complete *to the owner* and cloaked *to observers*.
+
+### Chain shape
+A SOC is exactly one TriTRPC **trace**. Each hop is a **span**, parent-linked to the previous hop's
+span (`parent_span_id`). The ordered spans are the route. Per-hop transport additions:
+- `transport.chain_id` — the SOC identity (stable across all hops).
+- `transport.chain_position` — 0-based hop index.
+- `transport.sealed` — MUST be `true` for a SOC hop: the hop's `transport.*` block is AEAD-sealed
+  (the v1 XChaCha20-Poly1305 lane) to the OWNER, not to the relay.
+- `transport.sealed_to` — the pseudonymous owner anchor the block is sealed to.
+
+### Owner-sealed visibility rule (NORMATIVE)
+1. In a SOC, each hop's `transport.*` metadata MUST be sealed to the owner (`sealed: true`). A relay
+   MUST NOT be able to read the transport metadata of a hop it is not a party to.
+2. `route_id` and `peer_id` MAY be pseudonymous (Identity-is-Contextual), but MUST be stable within
+   the trace so the owner can reassemble the route.
+3. The full ordered route MUST be reconstructable by the **owner** (whose cloud-twin holds every
+   hop's sealed block) and MUST NOT be reconstructable by any single relay (each relay sees only its
+   own span and its parent link).
+4. A SOC receipt is **complete** (satisfies "invisible transport is incomplete") iff every hop
+   carries a `sealed` transport block AND the owner can assemble the full trace. Governance sees
+   everything owner-side; observers see noise.
+
+### `failure_class` extension
+SOC introduces adversarial hops, so `transport.failure_class` adds:
+- `sabotage` — a relay/enclave returned a well-formed but adversarially-corrupted result (detected
+  by proof mismatch); the hop is refused, not actuated.
+- `refused_by_policy` — the hop was refused by the local policy gate (trust below `trust_min`, or a
+  purpose/consent gate) before execution.
+A `sabotage`/`refused_by_policy` hop MUST **fail closed**: the chain aborts at that span, downstream
+spans MUST NOT run, and the receipt records the terminal `failure_class`.
+
+### New event: `rpc.hop.sealed`
+Emitted once per SOC hop when its transport block is sealed to the owner.
+```json
+{
+  "event_type": "rpc.hop.sealed",
+  "payload": {
+    "protocol": "tritrpc",
+    "chain_id": "soc://alice/fed-hr/001",
+    "chain_position": 1,
+    "route_id": "route://relay/opaque@v1",
+    "peer_id": "node://relay-pseudo-7f",
+    "envelope_hash": "sha256:...",
+    "sealed": true,
+    "sealed_to": "owner://anchor-alice-pseudo"
+  }
+}
+```
+
+### Acceptance gate for the SOC profile
+A SOC path is acceptable when:
+1. all hop events share one `trace_id`, and spans form a parent-linked chain;
+2. every hop transport block is `sealed: true` with a `sealed_to`;
+3. `route_id`/`peer_id` are stable within the trace;
+4. any `sabotage`/`refused_by_policy` hop terminates the chain (no downstream spans);
+5. the owner can assemble the full ordered route from the sealed blocks; no single relay can.
+
+`tools/verify_receipt_soc_profile.py` is the self-testing gate for this profile.

--- a/tools/verify_receipt_soc_profile.py
+++ b/tools/verify_receipt_soc_profile.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Verify the SOC / Chain Profile of the TriTRPC Receipt Transport Binding (v0.2, additive).
+
+A Semantic Obfuscation Chain is a governed MULTI-HOP RPC. This gate enforces the profile's five
+acceptance rules on a captured trace, so the "complete to the owner, cloaked to observers" property
+is checkable, not just prose:
+
+  1. all hop events share one trace_id, and spans form a parent-linked chain;
+  2. every hop transport block is sealed:true with a sealed_to (owner-sealed — a relay can't read a
+     hop it isn't party to);
+  3. route_id/peer_id are stable within the trace (so the owner can reassemble the route);
+  4. any sabotage/refused_by_policy hop terminates the chain (no downstream spans) — fail closed;
+  5. the ordered route is reconstructable from the sealed blocks (chain_position 0..n-1, contiguous).
+
+Self-testing: the canonical example must pass; the invalid examples must be rejected. Stdlib only,
+matching this repo's validator convention.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EX = ROOT / "examples" / "transport"
+VALID = EX / "receipt_events.soc.example.json"
+INVALID = [
+    EX / "receipt_events.soc.unsealed.invalid.json",
+    EX / "receipt_events.soc.sabotage-continues.invalid.json",
+]
+TERMINAL = {"sabotage", "refused_by_policy"}
+
+
+class ProfileError(Exception):
+    pass
+
+
+def fail(msg: str) -> None:
+    raise ProfileError(msg)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def verify_soc(doc: Any) -> None:
+    if not isinstance(doc, dict) or not isinstance(doc.get("events"), list) or not doc["events"]:
+        fail("document must have a non-empty events array")
+    events = doc["events"]
+
+    # Rule 1: one trace; spans parent-linked into a chain.
+    traces = {e.get("trace_id") for e in events}
+    if len(traces) != 1 or None in traces:
+        fail(f"a SOC is exactly one trace; found trace_ids {traces}")
+    spans = [e.get("span_id") for e in events]
+    if len(set(spans)) != len(spans):
+        fail("span_ids must be unique within the chain")
+    seen: set[str] = set()
+    for e in events:
+        parent = e.get("parent_span_id")
+        # each hop's parent must be a prior span (except the first, whose parent is the pre-chain intent)
+        if seen and parent not in seen:
+            fail(f"span {e.get('span_id')} parent {parent!r} is not a prior span (chain broken)")
+        seen.add(e.get("span_id"))
+
+    # Rules 2,3,5: sealing, stable ids, contiguous positions — over the hop events that carry a chain.
+    positions, route_ids, peer_ids, chain_ids = [], set(), set(), set()
+    terminal_at = None
+    for i, e in enumerate(events):
+        p = e.get("payload") or {}
+        if "chain_id" not in p:
+            continue
+        chain_ids.add(p["chain_id"])
+        # Rule 2: owner-sealed
+        if p.get("sealed") is not True or not str(p.get("sealed_to") or "").strip():
+            fail(f"hop {p.get('chain_position')} is not owner-sealed (sealed:true + sealed_to required)")
+        # Rule 3: stable route/peer within the trace
+        route_ids.add(p.get("route_id")); peer_ids.add(p.get("peer_id"))
+        positions.append(p.get("chain_position"))
+        # Rule 4: a terminal failure_class must be the LAST hop (chain aborts, no downstream)
+        if e.get("event_type") == "rpc.fail" and p.get("failure_class") in TERMINAL:
+            terminal_at = i
+    if len(chain_ids) != 1:
+        fail(f"all hops must share one chain_id; found {chain_ids}")
+    # Rule 5: positions are 0..n-1 contiguous (the owner can order the route)
+    if sorted(positions) != list(range(len(positions))):
+        fail(f"chain_position must be contiguous 0..n-1; found {sorted(positions)}")
+    # ids stable enough to reassemble — a pseudonymous route may repeat; must not be empty/None
+    if None in route_ids or None in peer_ids:
+        fail("every hop must carry route_id and peer_id (stable within the trace)")
+
+    # Rule 4 (fail-closed): if a terminal hop occurred, NO event may follow it.
+    if terminal_at is not None and terminal_at != len(events) - 1:
+        fail("a sabotage/refused_by_policy hop must terminate the chain — no downstream spans allowed")
+
+
+def main() -> int:
+    try:
+        verify_soc(load(VALID))
+        for path in INVALID:
+            try:
+                verify_soc(load(path))
+            except ProfileError:
+                continue
+            fail(f"expected {path.name} to be rejected, but it passed")
+    except ProfileError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: SOC/chain profile validation passed (1 example, 2 invalid rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The one spec addition that unlocks governed privacy-preserving multi-hop RPC

From the Obfuscation-Manifesto ⟷ TriTRPC conformance assessment: a **Semantic Obfuscation Chain (SOC)** is a governed multi-hop RPC, and there's a head-on tension — the mesh wants *no single relay to see the whole path*, but the binding's normative rule says *an invisible transport path is an incomplete receipt*. 

This resolves it via **owner-sealing**: the receipt is **complete to the owner and cloaked to observers**, using TriTRPC's existing AEAD lane + trace/span model (nothing new invented).

**Added to `spec/transport/receipt_binding.md` (v0.2, additive):**
- **Chain shape** — a SOC is one trace, span-per-hop parent-linked; per-hop transport gains `chain_id`, `chain_position`, `sealed` (AEAD-to-owner, MUST be true), `sealed_to`.
- **Owner-sealed visibility rule (normative)** — each hop sealed to the owner; `route_id`/`peer_id` may be pseudonymous but stable within the trace; the full ordered route is reconstructable **only** by the owner's cloud-twin, never by a single relay.
- **`failure_class` += `sabotage`, `refused_by_policy`** — a terminal hop MUST fail closed (no downstream spans).
- **new event `rpc.hop.sealed`.**

**Self-testing gate** (`tools/verify_receipt_soc_profile.py`, stdlib per repo convention): the canonical SOC example passes; two negatives are rejected — an **unsealed hop** (a relay could read transport metadata it isn't party to) and a **sabotage-continues** chain (a terminal hop with downstream spans still running). CI workflow on path filters.

Companion to the estate mapping: SOC ≈ sp-orchestrator+policy-fabric loop; this is the transport binding that makes each SOC hop governed without breaking privacy.