### PR TITLE
spec(transport): SOC relay-contract binding + obfuscation profile (manifesto items a/b/c)

### DIFF
--- a/.github/workflows/validate-obfuscation-profile.yml
+++ b/.github/workflows/validate-obfuscation-profile.yml
@@ -1,0 +1,35 @@
+name: validate-obfuscation-profile
+
+on:
+  pull_request:
+    paths:
+      - "schemas/jsonschema/obfuscation-profile.v0.schema.json"
+      - "spec/transport/obfuscation_profile.md"
+      - "examples/transport/obfuscation_profile.example.json"
+      - "examples/transport/obfuscation_profile.*.invalid.json"
+      - "tools/verify_obfuscation_profile.py"
+      - ".github/workflows/validate-obfuscation-profile.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "schemas/jsonschema/obfuscation-profile.v0.schema.json"
+      - "spec/transport/obfuscation_profile.md"
+      - "examples/transport/obfuscation_profile.example.json"
+      - "examples/transport/obfuscation_profile.*.invalid.json"
+      - "tools/verify_obfuscation_profile.py"
+      - ".github/workflows/validate-obfuscation-profile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate obfuscation profile
+        run: python tools/verify_obfuscation_profile.py

--- a/.github/workflows/validate-soc-relay-contract.yml
+++ b/.github/workflows/validate-soc-relay-contract.yml
@@ -1,0 +1,33 @@
+name: validate-soc-relay-contract
+
+on:
+  pull_request:
+    paths:
+      - "schemas/jsonschema/soc-relay-contract.v0.schema.json"
+      - "examples/transport/soc_relay_contract.example.json"
+      - "examples/transport/soc_relay_contract.*.invalid.json"
+      - "tools/verify_soc_relay_contract.py"
+      - ".github/workflows/validate-soc-relay-contract.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "schemas/jsonschema/soc-relay-contract.v0.schema.json"
+      - "examples/transport/soc_relay_contract.example.json"
+      - "examples/transport/soc_relay_contract.*.invalid.json"
+      - "tools/verify_soc_relay_contract.py"
+      - ".github/workflows/validate-soc-relay-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate SOC relay-contract binding
+        run: python tools/verify_soc_relay_contract.py

--- a/examples/transport/obfuscation_profile.bad-jitter.invalid.json
+++ b/examples/transport/obfuscation_profile.bad-jitter.invalid.json
@@ -1,0 +1,14 @@
+{
+  "profileId": "obf://alice/soc-default",
+  "kFold": 3,
+  "decoyEntropyRatio": 0.6,
+  "braiding": {
+    "enabled": true,
+    "minParticipants": 3
+  },
+  "jitterMs": {
+    "min": 200,
+    "max": 50
+  },
+  "paddingBytes": 512
+}

--- a/examples/transport/obfuscation_profile.example.json
+++ b/examples/transport/obfuscation_profile.example.json
@@ -1,0 +1,14 @@
+{
+  "profileId": "obf://alice/soc-default",
+  "kFold": 3,
+  "decoyEntropyRatio": 0.6,
+  "braiding": {
+    "enabled": true,
+    "minParticipants": 3
+  },
+  "jitterMs": {
+    "min": 20,
+    "max": 180
+  },
+  "paddingBytes": 512
+}

--- a/examples/transport/obfuscation_profile.no-anonymity.invalid.json
+++ b/examples/transport/obfuscation_profile.no-anonymity.invalid.json
@@ -1,0 +1,14 @@
+{
+  "profileId": "obf://alice/soc-default",
+  "kFold": 1,
+  "decoyEntropyRatio": 0.6,
+  "braiding": {
+    "enabled": true,
+    "minParticipants": 3
+  },
+  "jitterMs": {
+    "min": 20,
+    "max": 180
+  },
+  "paddingBytes": 512
+}

--- a/examples/transport/soc_relay_contract.adhoc-id.invalid.json
+++ b/examples/transport/soc_relay_contract.adhoc-id.invalid.json
@@ -1,0 +1,21 @@
+{
+  "contract_id": "soc-relay-0481",
+  "sender": "agent~alice-pseudo",
+  "relay": "relay~morpheus-pseudo",
+  "task": "opaque_compute",
+  "trust_min": 4,
+  "token_bid": "0.00083 OBF",
+  "privacy_required": true,
+  "transport": {
+    "protocol": "tritrpc",
+    "route_id": "relay~kali",
+    "peer_id": "node://relay-pseudo-7f",
+    "envelope_hash": "sha256:envelope01",
+    "chain_id": "soc://alice/fed-hr/001",
+    "chain_position": 1,
+    "sealed": true,
+    "sealed_to": "owner://anchor-alice-pseudo",
+    "retry_count": 0
+  },
+  "signature": "sig(agent~alice-pseudo)"
+}

--- a/examples/transport/soc_relay_contract.example.json
+++ b/examples/transport/soc_relay_contract.example.json
@@ -1,0 +1,21 @@
+{
+  "contract_id": "soc-relay-0481",
+  "sender": "agent~alice-pseudo",
+  "relay": "relay~morpheus-pseudo",
+  "task": "opaque_compute",
+  "trust_min": 4,
+  "token_bid": "0.00083 OBF",
+  "privacy_required": true,
+  "transport": {
+    "protocol": "tritrpc",
+    "route_id": "route://relay/opaque@v1",
+    "peer_id": "node://relay-pseudo-7f",
+    "envelope_hash": "sha256:envelope01",
+    "chain_id": "soc://alice/fed-hr/001",
+    "chain_position": 1,
+    "sealed": true,
+    "sealed_to": "owner://anchor-alice-pseudo",
+    "retry_count": 0
+  },
+  "signature": "sig(agent~alice-pseudo)"
+}

--- a/examples/transport/soc_relay_contract.unsealed.invalid.json
+++ b/examples/transport/soc_relay_contract.unsealed.invalid.json
@@ -1,0 +1,21 @@
+{
+  "contract_id": "soc-relay-0481",
+  "sender": "agent~alice-pseudo",
+  "relay": "relay~morpheus-pseudo",
+  "task": "opaque_compute",
+  "trust_min": 4,
+  "token_bid": "0.00083 OBF",
+  "privacy_required": true,
+  "transport": {
+    "protocol": "tritrpc",
+    "route_id": "route://relay/opaque@v1",
+    "peer_id": "node://relay-pseudo-7f",
+    "envelope_hash": "sha256:envelope01",
+    "chain_id": "soc://alice/fed-hr/001",
+    "chain_position": 1,
+    "sealed": false,
+    "sealed_to": "owner://anchor-alice-pseudo",
+    "retry_count": 0
+  },
+  "signature": "sig(agent~alice-pseudo)"
+}

--- a/schemas/jsonschema/obfuscation-profile.v0.schema.json
+++ b/schemas/jsonschema/obfuscation-profile.v0.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/obfuscation-profile.v0.schema.json",
+  "title": "ObfuscationProfile v0",
+  "description": "OPTIONAL TriTRPC transport profile for TRAFFIC-ANALYSIS resistance (the genuinely-new layer from the Obfuscation Manifesto). The v1 AEAD lane gives payload confidentiality; it does NOT hide metadata/timing. This profile declares checkable cover-traffic parameters a SOC hop MAY apply: K-fold decoys, relay braiding, timing jitter, and padding. All parameters are fail-closed (a profile that provides no anonymity is refused).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profileId", "kFold", "jitterMs"],
+  "properties": {
+    "profileId": { "type": "string", "minLength": 1 },
+    "kFold": { "type": "integer", "minimum": 2, "description": "K-fold anonymity: K-1 decoys per real packet. K=1 provides zero anonymity and is refused." },
+    "decoyEntropyRatio": { "type": "number", "exclusiveMinimum": 0, "maximum": 1, "description": "how much decoys must differ from the real packet (>0)." },
+    "braiding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minParticipants": { "type": "integer", "minimum": 2 }
+      }
+    },
+    "jitterMs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "max"],
+      "properties": {
+        "min": { "type": "integer", "minimum": 1 },
+        "max": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "paddingBytes": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/schemas/jsonschema/soc-relay-contract.v0.schema.json
+++ b/schemas/jsonschema/soc-relay-contract.v0.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/soc-relay-contract.v0.schema.json",
+  "title": "SocRelayContract v0",
+  "description": "A Semantic-Obfuscation-Chain relay contract (the Obfuscation-Manifesto relay_contract) BOUND to the TriTRPC Receipt Transport Binding SOC profile. Each hop's contract carries an owner-sealed transport{} block using the binding's route://peer:// URI shapes, so the SOC receipt is complete-to-owner and cloaked-to-observers. This is the conformance fix: a relay contract is SOC-conformant only if its transport is owner-sealed and URI-addressed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_id", "sender", "relay", "task", "trust_min", "transport", "signature"],
+  "properties": {
+    "contract_id": { "type": "string", "minLength": 1 },
+    "sender": { "type": "string", "minLength": 1, "description": "pseudonymous sender anchor" },
+    "relay": { "type": "string", "minLength": 1, "description": "pseudonymous relay anchor" },
+    "task": { "type": "string", "enum": ["schema_transform", "opaque_compute", "dag_commit", "braid", "relay"] },
+    "trust_min": { "type": "integer", "minimum": 0 },
+    "token_bid": { "type": "string" },
+    "privacy_required": { "type": "boolean" },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["protocol", "route_id", "peer_id", "envelope_hash", "chain_id", "chain_position", "sealed", "sealed_to"],
+      "properties": {
+        "protocol": { "const": "tritrpc" },
+        "route_id": { "type": "string", "pattern": "^route://" },
+        "peer_id": { "type": "string", "pattern": "^node://" },
+        "envelope_hash": { "type": "string", "pattern": "^sha256:" },
+        "chain_id": { "type": "string", "pattern": "^soc://" },
+        "chain_position": { "type": "integer", "minimum": 0 },
+        "sealed": { "const": true },
+        "sealed_to": { "type": "string", "pattern": "^owner://" },
+        "retry_count": { "type": "integer", "minimum": 0 },
+        "timeout_count": { "type": "integer", "minimum": 0 },
+        "failure_class": { "type": "string", "enum": ["upstream_unreachable", "deadline_exceeded", "sabotage", "refused_by_policy"] }
+      }
+    },
+    "signature": { "type": "string", "minLength": 1 }
+  }
+}

--- a/spec/transport/obfuscation_profile.md
+++ b/spec/transport/obfuscation_profile.md
@@ -1,0 +1,25 @@
+# TriTRPC Obfuscation Profile v0 (optional)
+
+The v1 AEAD lane (XChaCha20-Poly1305) protects payload **confidentiality**. It does not defeat
+**traffic analysis** — packet counts, sizes, and timings still leak. The Obfuscation Manifesto's
+threat model is exactly traffic analysis, so this OPTIONAL profile declares the checkable
+cover-traffic parameters a SOC hop MAY apply. Declaring the profile makes the obfuscation an
+auditable, fail-closed configuration rather than an ad-hoc behaviour.
+
+## Parameters (all fail-closed)
+- `kFold` (≥ 2) — K-fold anonymity: each real packet is accompanied by K−1 decoys. `K=1` provides
+  zero anonymity and is **refused**.
+- `decoyEntropyRatio` (0 < r ≤ 1) — how much decoys must differ from the real packet; `0` (identical
+  decoys) is refused.
+- `braiding.enabled` — if true, `braiding.minParticipants` ≥ 2 (a braid of one is not a braid).
+- `jitterMs` (`min`, `max`) — bounded timing jitter, `1 ≤ min ≤ max` (a zero/inverted window is
+  refused).
+- `paddingBytes` (≥ 0) — fixed padding target to blur size.
+
+## Relationship to the SOC profile
+A SOC hop's relay contract MAY reference an obfuscation profile. The obfuscation profile shapes the
+**wire behaviour** (cover traffic); the SOC profile's owner-sealed `transport{}` block still records
+the **governed receipt** (so the owner audits the real path beneath the cover). Confidentiality
+(AEAD) + traffic-analysis resistance (this profile) + governed visibility (owner-sealing) compose.
+
+`tools/verify_obfuscation_profile.py` is the fail-closed gate.

--- a/tools/verify_obfuscation_profile.py
+++ b/tools/verify_obfuscation_profile.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Verify TriTRPC obfuscation profiles (traffic-analysis resistance) — fail-closed parameters.
+
+The v1 AEAD lane hides payloads, not traffic patterns. This gate checks that a declared obfuscation
+profile actually provides anonymity: K-fold ≥ 2 (K=1 is no anonymity), a bounded positive jitter
+window, and a braid of ≥ 2 participants when braiding is on. A profile that provides no cover is
+refused. Self-testing (stdlib, repo convention): the example passes; the no-anonymity and bad-jitter
+negatives are rejected.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EX = ROOT / "examples" / "transport"
+VALID = EX / "obfuscation_profile.example.json"
+INVALID = [EX / "obfuscation_profile.no-anonymity.invalid.json",
+           EX / "obfuscation_profile.bad-jitter.invalid.json"]
+KEYS = {"profileId", "kFold", "decoyEntropyRatio", "braiding", "jitterMs", "paddingBytes"}
+
+
+class ProfileError(Exception):
+    pass
+
+
+def fail(m: str) -> None:
+    raise ProfileError(m)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def verify_profile(rec: Any) -> None:
+    if not isinstance(rec, dict):
+        fail("profile must be an object")
+    extra = sorted(set(rec) - KEYS)
+    if extra:
+        fail(f"unexpected fields: {extra}")
+    if not isinstance(rec.get("profileId"), str) or not rec["profileId"]:
+        fail("profileId: expected non-empty string")
+
+    k = rec.get("kFold")
+    if not isinstance(k, int) or isinstance(k, bool) or k < 2:
+        fail("kFold must be an integer >= 2 (K=1 provides zero anonymity)")
+
+    r = rec.get("decoyEntropyRatio")
+    if r is not None and (not isinstance(r, (int, float)) or isinstance(r, bool) or not (0 < r <= 1)):
+        fail("decoyEntropyRatio must be in (0, 1]")
+
+    braid = rec.get("braiding")
+    if braid is not None:
+        if not isinstance(braid, dict) or not isinstance(braid.get("enabled"), bool):
+            fail("braiding must be an object with a boolean 'enabled'")
+        if braid.get("enabled"):
+            mp = braid.get("minParticipants")
+            if not isinstance(mp, int) or isinstance(mp, bool) or mp < 2:
+                fail("braiding.minParticipants must be >= 2 when braiding is enabled (a braid of one is not a braid)")
+
+    j = rec.get("jitterMs")
+    if not isinstance(j, dict):
+        fail("jitterMs must be an object")
+    lo, hi = j.get("min"), j.get("max")
+    if not all(isinstance(v, int) and not isinstance(v, bool) for v in (lo, hi)):
+        fail("jitterMs.min and .max must be integers")
+    if not (1 <= lo <= hi):
+        fail(f"jitterMs must satisfy 1 <= min <= max (got min={lo}, max={hi})")
+
+    pad = rec.get("paddingBytes")
+    if pad is not None and (not isinstance(pad, int) or isinstance(pad, bool) or pad < 0):
+        fail("paddingBytes must be a non-negative integer")
+
+
+def main() -> int:
+    try:
+        verify_profile(load(VALID))
+        for path in INVALID:
+            try:
+                verify_profile(load(path))
+            except ProfileError:
+                continue
+            fail(f"expected {path.name} to be rejected, but it passed")
+    except ProfileError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: obfuscation profile validated (1 example, 2 invalid rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_soc_relay_contract.py
+++ b/tools/verify_soc_relay_contract.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Verify SOC relay contracts bind to the TriTRPC Receipt Transport Binding SOC profile.
+
+The Obfuscation-Manifesto relay contract records semantic labour but not the transport path — an
+incomplete receipt by the binding's rule. This gate enforces that every SOC relay contract carries
+an owner-sealed, URI-addressed transport block, so each hop's receipt is complete-to-owner and
+cloaked-to-observers:
+
+  (a) transport is owner-sealed (protocol=tritrpc, sealed:true + sealed_to);
+  (b) route_id/peer_id/chain_id/sealed_to use the binding's URI shapes (route://, node://, soc://,
+      owner://) — not ad-hoc ids like "relay~kali" — so hops correlate across a trace;
+      failure_class (if present) is in the SOC-extended set.
+
+Self-testing (stdlib, repo convention): the canonical example passes; the ad-hoc-id and unsealed
+negatives are rejected. A validate_schema drift-guard keeps the schema and this validator in lockstep.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "jsonschema" / "soc-relay-contract.v0.schema.json"
+EX = ROOT / "examples" / "transport"
+VALID = EX / "soc_relay_contract.example.json"
+INVALID = [EX / "soc_relay_contract.adhoc-id.invalid.json", EX / "soc_relay_contract.unsealed.invalid.json"]
+
+TASKS = {"schema_transform", "opaque_compute", "dag_commit", "braid", "relay"}
+FAILURE_CLASSES = {"upstream_unreachable", "deadline_exceeded", "sabotage", "refused_by_policy"}
+URI = {"route_id": "route://", "peer_id": "node://", "chain_id": "soc://", "sealed_to": "owner://"}
+TRANSPORT_KEYS = {"protocol", "route_id", "peer_id", "envelope_hash", "chain_id", "chain_position",
+                  "sealed", "sealed_to", "retry_count", "timeout_count", "failure_class"}
+CONTRACT_KEYS = {"contract_id", "sender", "relay", "task", "trust_min", "token_bid",
+                 "privacy_required", "transport", "signature"}
+
+
+class ContractError(Exception):
+    pass
+
+
+def fail(m: str) -> None:
+    raise ContractError(m)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def need_str(o: dict, k: str) -> str:
+    v = o.get(k)
+    if not isinstance(v, str) or not v:
+        fail(f"{k}: expected non-empty string")
+    return v
+
+
+def verify_contract(rec: Any) -> None:
+    if not isinstance(rec, dict):
+        fail("contract must be an object")
+    extra = sorted(set(rec) - CONTRACT_KEYS)
+    if extra:
+        fail(f"unexpected contract fields: {extra}")
+    for k in ("contract_id", "sender", "relay", "signature"):
+        need_str(rec, k)
+    if rec.get("task") not in TASKS:
+        fail(f"task must be one of {sorted(TASKS)}")
+    if not isinstance(rec.get("trust_min"), int) or rec["trust_min"] < 0:
+        fail("trust_min must be a non-negative integer")
+
+    t = rec.get("transport")
+    if not isinstance(t, dict):
+        fail("transport must be an object (an owner-sealed transport block is required)")
+    tx_extra = sorted(set(t) - TRANSPORT_KEYS)
+    if tx_extra:
+        fail(f"unexpected transport fields: {tx_extra}")
+    if t.get("protocol") != "tritrpc":
+        fail("transport.protocol must be 'tritrpc'")
+    # (b) URI shapes — ad-hoc ids like "relay~kali" are refused
+    for key, prefix in URI.items():
+        val = need_str(t, key)
+        if not val.startswith(prefix):
+            fail(f"transport.{key} must use the {prefix!r} URI shape (got {val!r})")
+    if not re.match(r"^sha256:", str(t.get("envelope_hash", ""))):
+        fail("transport.envelope_hash must be a sha256: digest")
+    if not isinstance(t.get("chain_position"), int) or t["chain_position"] < 0:
+        fail("transport.chain_position must be a non-negative integer")
+    # (a) owner-sealed
+    if t.get("sealed") is not True:
+        fail("transport.sealed must be true (owner-sealed) for a SOC hop")
+    if "failure_class" in t and t["failure_class"] not in FAILURE_CLASSES:
+        fail(f"transport.failure_class must be one of {sorted(FAILURE_CLASSES)}")
+
+
+def validate_schema(schema: Any) -> None:
+    """Schema and validator must not drift (dependency-light, repo convention)."""
+    if not isinstance(schema, dict) or schema.get("additionalProperties") is not False:
+        fail("schema root must be strict")
+    props = schema.get("properties", {})
+    if props.get("title") is not None:  # noqa: SIM102 (title is a top-level key, not a property)
+        pass
+    tx = props.get("transport", {})
+    if tx.get("additionalProperties") is not False:
+        fail("schema transport must be strict")
+    txp = tx.get("properties", {})
+    if txp.get("protocol", {}).get("const") != "tritrpc":
+        fail("schema must pin transport.protocol const 'tritrpc'")
+    if txp.get("sealed", {}).get("const") is not True:
+        fail("schema must pin transport.sealed const true (owner-sealed)")
+    for key, prefix in URI.items():
+        if txp.get(key, {}).get("pattern") != f"^{prefix}":
+            fail(f"schema must pin transport.{key} pattern ^{prefix}")
+    if set(tx.get("required", [])) < {"protocol", "route_id", "peer_id", "chain_id", "sealed", "sealed_to"}:
+        fail("schema transport.required drifted from the owner-sealed/URI invariant")
+
+
+def main() -> int:
+    try:
+        validate_schema(load(SCHEMA))
+        verify_contract(load(VALID))
+        for path in INVALID:
+            try:
+                verify_contract(load(path))
+            except ContractError:
+                continue
+            fail(f"expected {path.name} to be rejected, but it passed")
+    except ContractError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: SOC relay-contract binding validated (1 example, 2 invalid rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_soc_relay_contract.py
+++ b/tools/verify_soc_relay_contract.py
@@ -98,8 +98,6 @@ def validate_schema(schema: Any) -> None:
     if not isinstance(schema, dict) or schema.get("additionalProperties") is not False:
         fail("schema root must be strict")
     props = schema.get("properties", {})
-    if props.get("title") is not None:  # noqa: SIM102 (title is a top-level key, not a property)
-        pass
     tx = props.get("transport", {})
     if tx.get("additionalProperties") is not False:
         fail("schema transport must be strict")


### PR DESCRIPTION
## Completes the Obfuscation-Manifesto ⟷ TriTRPC binding (on top of the SOC/chain profile #78)

**(a)+(b) SocRelayContract** — the manifesto's `relay_contract` bound to the receipt binding. Every hop carries an **owner-sealed `transport{}` block** (`protocol=tritrpc`, `sealed:true`+`sealed_to`) using the binding's **URI shapes** (`route://`, `node://`, `soc://`, `owner://`), so hops correlate across a trace and ad-hoc ids like `relay~kali` are refused. *This is the conformance fix: a relay contract's proof is now transport-complete-to-owner.* Self-testing validator + `validate_schema` drift-guard; adhoc-id + unsealed negatives refused.

**(c) Obfuscation Profile** — the genuinely-new **traffic-analysis-resistance** layer. AEAD hides payloads, not traffic patterns; this declares fail-closed cover-traffic params: `kFold ≥ 2` (K=1 = zero anonymity → refused), bounded positive `jitterMs` (1 ≤ min ≤ max), a braid of ≥ 2, `decoyEntropyRatio ∈ (0,1]`, padding. **Confidentiality (AEAD) + traffic-analysis resistance (this) + governed visibility (owner-sealing) compose.** Validator; no-anonymity + bad-jitter negatives refused.

Two CI workflows on path filters. **De-dup note preserved:** the manifesto's SOC maps onto the estate loop (sp-orchestrator + policy-fabric); this binds its *transport* to TriTRPC rather than forking a parallel stack.

With #78 (SOC/chain profile), this closes all three remaining items from the conformance assessment.