### PR TITLE
feat(reference): SOC-hop executor — makes the SOC contracts live (fail-closed, FIPS-clean)

### DIFF
--- a/.github/workflows/validate-soc-hop-reference.yml
+++ b/.github/workflows/validate-soc-hop-reference.yml
@@ -1,0 +1,33 @@
+name: validate-soc-hop-reference
+
+on:
+  pull_request:
+    paths:
+      - "reference/soc_hop.py"
+      - "tools/verify_soc_hop_reference.py"
+      - "examples/transport/soc_relay_contract.example.json"
+      - "examples/transport/obfuscation_profile.example.json"
+      - ".github/workflows/validate-soc-hop-reference.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/soc_hop.py"
+      - "tools/verify_soc_hop_reference.py"
+      - "examples/transport/soc_relay_contract.example.json"
+      - "examples/transport/obfuscation_profile.example.json"
+      - ".github/workflows/validate-soc-hop-reference.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate reference SOC-hop executor
+        run: python tools/verify_soc_hop_reference.py

--- a/reference/soc_hop.py
+++ b/reference/soc_hop.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Reference SOC-hop executor — makes the SOC contracts LIVE (Obfuscation-Manifesto follow-through).
+
+Consumes the two contracts shipped alongside it — a `SocRelayContract` (owner-sealed transport
+binding) and an optional `ObfuscationProfile` (traffic-analysis resistance) — and deterministically
+produces what a real SOC hop emits:
+
+  * the obfuscation PLAN — K-fold decoy set (1 real packet hidden among K-1 decoys), a per-packet
+    timing-jitter schedule inside the declared window, a braid plan, and a padded packet size;
+  * the owner-sealed `rpc.hop.sealed` transport RECEIPT event (per the SOC/chain profile).
+
+Fail-closed: an unsealed / non-tritrpc / ad-hoc-id contract, or a no-anonymity profile, is REFUSED
+before any hop is produced. Deterministic (seeded from contract_id + envelope_hash) so the plan is
+reproducible and auditable. This is a reference planner, not a network stack: it does not send
+packets — it produces the checkable artifacts a conformant SOC hop must.
+
+FIPS: the deterministic stream uses SHA-256 (FIPS 180-4 approved) and no non-FIPS primitive. This
+planner performs NO AEAD itself; the owner-sealing AEAD is carried out by the transport lane, which
+in a FIPS deployment MUST be a FIPS-approved AEAD (AES-256-GCM), not XChaCha20-Poly1305. This module
+does not touch the tritrpc v4/vNext wire format.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+class SocHopError(Exception):
+    pass
+
+
+def _fail(m: str) -> None:
+    raise SocHopError(m)
+
+
+def _rng_stream(seed_material: str):
+    """Deterministic byte stream (SHA-256 CTR) — dependency-free, reproducible across platforms."""
+    counter = 0
+    while True:
+        block = hashlib.sha256(f"{seed_material}:{counter}".encode()).digest()
+        for b in block:
+            yield b
+        counter += 1
+
+
+def _check_contract(contract: dict) -> dict:
+    t = (contract or {}).get("transport")
+    if not isinstance(t, dict):
+        _fail("contract.transport missing (an owner-sealed transport block is required)")
+    if t.get("protocol") != "tritrpc":
+        _fail("contract.transport.protocol must be 'tritrpc'")
+    if t.get("sealed") is not True or not str(t.get("sealed_to") or "").strip():
+        _fail("contract.transport must be owner-sealed (sealed:true + sealed_to)")
+    for key, prefix in (("route_id", "route://"), ("peer_id", "node://"),
+                        ("chain_id", "soc://"), ("sealed_to", "owner://")):
+        if not str(t.get(key, "")).startswith(prefix):
+            _fail(f"contract.transport.{key} must use the {prefix!r} URI shape")
+    if not isinstance(t.get("chain_position"), int) or t["chain_position"] < 0:
+        _fail("contract.transport.chain_position must be a non-negative integer")
+    return t
+
+
+def _check_profile(profile: dict) -> dict:
+    k = (profile or {}).get("kFold")
+    if not isinstance(k, int) or isinstance(k, bool) or k < 2:
+        _fail("obfuscation profile kFold must be an integer >= 2 (K=1 provides zero anonymity)")
+    j = profile.get("jitterMs") or {}
+    lo, hi = j.get("min"), j.get("max")
+    if not (isinstance(lo, int) and isinstance(hi, int) and 1 <= lo <= hi):
+        _fail("obfuscation profile jitterMs must satisfy 1 <= min <= max")
+    braid = profile.get("braiding") or {}
+    if braid.get("enabled") and (not isinstance(braid.get("minParticipants"), int) or braid["minParticipants"] < 2):
+        _fail("obfuscation braiding requires minParticipants >= 2 when enabled")
+    return profile
+
+
+def execute_soc_hop(contract: dict, profile: dict, message: bytes) -> dict:
+    """Plan one SOC hop. Raises SocHopError (fail-closed) on any invalid input."""
+    t = _check_contract(contract)
+    _check_profile(profile)
+
+    seed = f"{contract.get('contract_id')}:{t.get('envelope_hash')}"
+    stream = _rng_stream(seed)
+
+    k = profile["kFold"]
+    lo, hi = profile["jitterMs"]["min"], profile["jitterMs"]["max"]
+    pad = int(profile.get("paddingBytes") or 0)
+    real_size = max(len(message), pad)
+
+    # Which of the K packets carries the real payload (hidden, deterministic).
+    real_index = next(stream) % k
+    packets = []
+    for i in range(k):
+        jitter = lo + (next(stream) % (hi - lo + 1))       # deterministic jitter in [lo, hi]
+        # decoys are padded to the same target size so packet size does not distinguish them
+        packets.append({
+            "index": i,
+            "is_real": i == real_index,
+            "size_bytes": real_size,
+            "jitter_ms": jitter,
+        })
+
+    plan = {
+        "kFold": k,
+        "decoyCount": k - 1,
+        "realIndex": real_index,
+        "paddedSizeBytes": real_size,
+        "packets": packets,
+    }
+    braid = profile.get("braiding") or {}
+    if braid.get("enabled"):
+        plan["braid"] = {"participants": braid["minParticipants"]}
+
+    sealed_event = {
+        "event_id": "evt_" + hashlib.sha256(seed.encode()).hexdigest()[:12],
+        "trace_id": t["chain_id"].replace("soc://", "trace_").replace("/", "_"),
+        "span_id": f"span_hop{t['chain_position']}",
+        "parent_span_id": f"span_hop{t['chain_position'] - 1}" if t["chain_position"] else "span_send",
+        "event_type": "rpc.hop.sealed",
+        "producer": "tritrpc",
+        "payload": {
+            "protocol": "tritrpc",
+            "chain_id": t["chain_id"],
+            "chain_position": t["chain_position"],
+            "route_id": t["route_id"],
+            "peer_id": t["peer_id"],
+            "envelope_hash": t["envelope_hash"],
+            "sealed": True,
+            "sealed_to": t["sealed_to"],
+        },
+    }
+    return {"sealed_event": sealed_event, "obfuscation_plan": plan}
+
+
+if __name__ == "__main__":  # tiny demo on the shipped examples
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    c = json.loads((root / "examples/transport/soc_relay_contract.example.json").read_text())
+    p = json.loads((root / "examples/transport/obfuscation_profile.example.json").read_text())
+    print(json.dumps(execute_soc_hop(c, p, b"real-soc-payload"), indent=2))

--- a/tools/verify_soc_hop_reference.py
+++ b/tools/verify_soc_hop_reference.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Verify the reference SOC-hop executor makes the SOC contracts LIVE and fail-closed.
+
+Runs reference/soc_hop.py on the shipped example contract + obfuscation profile and asserts the
+produced hop is real and conformant: exactly K-1 decoys, every packet's jitter inside the declared
+window, one hidden real packet, and an owner-sealed rpc.hop.sealed receipt that satisfies the
+SOC/chain profile. Then asserts fail-closed refusal on an unsealed contract and a no-anonymity
+profile, and reproducibility (same inputs -> identical plan). Stdlib, repo convention.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+sys.path.insert(0, str(ROOT / "tools"))
+import soc_hop  # noqa: E402
+
+EX = ROOT / "examples" / "transport"
+
+
+def owner_sealed_ok(event: dict) -> str | None:
+    """Per-event owner-sealed conformance (the single-hop analogue of the SOC/chain profile —
+    the full-chain contiguity rule doesn't apply to one emitted hop)."""
+    if event.get("event_type") != "rpc.hop.sealed":
+        return "event_type must be rpc.hop.sealed"
+    p = event.get("payload") or {}
+    if p.get("protocol") != "tritrpc":
+        return "payload.protocol must be tritrpc"
+    if p.get("sealed") is not True or not str(p.get("sealed_to") or "").startswith("owner://"):
+        return "hop must be owner-sealed (sealed:true + sealed_to owner://)"
+    for key, prefix in (("route_id", "route://"), ("peer_id", "node://"), ("chain_id", "soc://")):
+        if not str(p.get(key, "")).startswith(prefix):
+            return f"payload.{key} must use the {prefix!r} URI shape"
+    return None
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(name: str):
+    return json.loads((EX / name).read_text())
+
+
+def main() -> int:
+    contract = load("soc_relay_contract.example.json")
+    profile = load("obfuscation_profile.example.json")
+
+    out = soc_hop.execute_soc_hop(contract, profile, b"real-soc-payload")
+    plan, event = out["obfuscation_plan"], out["sealed_event"]
+
+    # 1. K-fold: exactly K-1 decoys + one real packet.
+    k = profile["kFold"]
+    reals = [p for p in plan["packets"] if p["is_real"]]
+    if plan["decoyCount"] != k - 1 or len(plan["packets"]) != k or len(reals) != 1:
+        FAILURES.append(f"K-fold wrong: k={k} packets={len(plan['packets'])} decoys={plan['decoyCount']} reals={len(reals)}")
+    else:
+        CHECKS["kfold:one-real-k-minus-1-decoys"] = True
+
+    # 2. Jitter: every packet's jitter is inside the declared window.
+    lo, hi = profile["jitterMs"]["min"], profile["jitterMs"]["max"]
+    if all(lo <= p["jitter_ms"] <= hi for p in plan["packets"]):
+        CHECKS["jitter:within-window"] = True
+    else:
+        FAILURES.append("a packet's jitter fell outside the declared jitterMs window")
+
+    # 3. The emitted receipt is an owner-sealed SOC hop event.
+    err = owner_sealed_ok(event)
+    if err:
+        FAILURES.append(f"emitted receipt is not owner-sealed SOC-conformant: {err}")
+    else:
+        CHECKS["receipt:owner-sealed-soc-conformant"] = True
+
+    # 4. Fail-closed: an unsealed contract and a no-anonymity profile are REFUSED (no hop produced).
+    try:
+        soc_hop.execute_soc_hop(load("soc_relay_contract.unsealed.invalid.json"), profile, b"x")
+        FAILURES.append("an unsealed contract must be refused (no hop produced)")
+    except soc_hop.SocHopError:
+        CHECKS["fail-closed:unsealed-refused"] = True
+    try:
+        soc_hop.execute_soc_hop(contract, load("obfuscation_profile.no-anonymity.invalid.json"), b"x")
+        FAILURES.append("a no-anonymity (K=1) profile must be refused")
+    except soc_hop.SocHopError:
+        CHECKS["fail-closed:no-anonymity-refused"] = True
+
+    # 5. Determinism — identical inputs produce an identical plan (auditable/reproducible).
+    again = soc_hop.execute_soc_hop(contract, profile, b"real-soc-payload")
+    if again == out:
+        CHECKS["deterministic:reproducible"] = True
+    else:
+        FAILURES.append("executor is not deterministic — same inputs produced a different plan")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Make the SOC contracts live

`reference/soc_hop.py` consumes the `SocRelayContract` + `ObfuscationProfile` (#79) and deterministically produces what a real SOC hop emits:
- the **obfuscation plan** — a K-fold decoy set with one hidden real packet, per-packet timing jitter inside the declared window, a braid plan, and a padded size;
- the **owner-sealed `rpc.hop.sealed` receipt** (per the SOC/chain profile #78).

**Fail-closed:** an unsealed / non-tritrpc / ad-hoc-id contract, or a no-anonymity (K=1) profile, is REFUSED before any hop is produced. **Deterministic** (SHA-256 CTR seeded from `contract_id`+`envelope_hash`) so the plan is reproducible and auditable.

**FIPS:** SHA-256 only (FIPS 180-4), no non-FIPS primitive; the planner performs **no AEAD** — the owner-sealing AEAD belongs to the transport lane, which in FIPS mode MUST be AES-256-GCM (not XChaCha). Does **not** touch the tritrpc v4/vNext wire format.

## Teeth (`make`-style CI: `verify_soc_hop_reference.py`, 6 checks)
- K−1 decoys + exactly one hidden real packet
- every packet's jitter inside the declared `jitterMs` window
- the emitted receipt is an owner-sealed, URI-shaped SOC hop
- an unsealed contract → refused; a K=1 profile → refused (fail-closed)
- deterministic — identical inputs produce an identical plan

Completes the Obfuscation-Manifesto follow-through: the genuinely-new privacy layer is now a working, verifiable reference bound to TriTRPC (not a forked stack).