### PR TITLE
spec(transport): TriTRPC CryptoProfile — FIPS is the standard (AEAD gate)

### DIFF
--- a/.github/workflows/validate-crypto-profile.yml
+++ b/.github/workflows/validate-crypto-profile.yml
@@ -1,0 +1,33 @@
+name: validate-crypto-profile
+
+on:
+  pull_request:
+    paths:
+      - "schemas/jsonschema/crypto-profile.v0.schema.json"
+      - "spec/transport/crypto_profile.md"
+      - "examples/transport/crypto_profile.*.json"
+      - "tools/verify_crypto_profile.py"
+      - ".github/workflows/validate-crypto-profile.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "schemas/jsonschema/crypto-profile.v0.schema.json"
+      - "spec/transport/crypto_profile.md"
+      - "examples/transport/crypto_profile.*.json"
+      - "tools/verify_crypto_profile.py"
+      - ".github/workflows/validate-crypto-profile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate crypto profile (FIPS gate)
+        run: python tools/verify_crypto_profile.py

--- a/examples/transport/crypto_profile.fips-blake.invalid.json
+++ b/examples/transport/crypto_profile.fips-blake.invalid.json
@@ -1,0 +1,6 @@
+{
+  "profileId": "crypto://tritrpc/bad2",
+  "mode": "fips",
+  "aead": "AES-256-GCM",
+  "hash": "BLAKE3"
+}

--- a/examples/transport/crypto_profile.fips-chacha.invalid.json
+++ b/examples/transport/crypto_profile.fips-chacha.invalid.json
@@ -1,0 +1,6 @@
+{
+  "profileId": "crypto://tritrpc/bad",
+  "mode": "fips",
+  "aead": "XChaCha20-Poly1305",
+  "hash": "SHA-256"
+}

--- a/examples/transport/crypto_profile.fips.example.json
+++ b/examples/transport/crypto_profile.fips.example.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "crypto://tritrpc/fips",
+  "mode": "fips",
+  "aead": "AES-256-GCM",
+  "hash": "SHA-384",
+  "wireFormat": "tritrpc-v1"
+}

--- a/examples/transport/crypto_profile.standard.example.json
+++ b/examples/transport/crypto_profile.standard.example.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "crypto://tritrpc/standard",
+  "mode": "standard",
+  "aead": "XChaCha20-Poly1305",
+  "hash": "BLAKE3",
+  "wireFormat": "tritrpc-v1"
+}

--- a/schemas/jsonschema/crypto-profile.v0.schema.json
+++ b/schemas/jsonschema/crypto-profile.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/crypto-profile.v0.schema.json",
+  "title": "TriTRPC CryptoProfile v0",
+  "description": "Declares WHICH AEAD/hash a TriTRPC deployment uses, so 'AEAD-sealed canonical bytes' is a checkable, FIPS-gateable choice rather than a hardcoded cipher. mode:fips REQUIRES a FIPS-approved AEAD (AES-GCM/CCM, SP 800-38D) and hash (SHA-2/SHA-3, FIPS 180-4/202) and REFUSES XChaCha20/ChaCha20-Poly1305 and BLAKE. mode:standard permits the v1 XChaCha20-Poly1305 lane. Additive: it selects the cipher for the sealing lane; it does NOT change the v1/v4/vNext wire format (TritPack243/TLEB3 are unchanged).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profileId", "mode", "aead", "hash"],
+  "properties": {
+    "profileId": { "type": "string", "minLength": 1 },
+    "mode": { "type": "string", "enum": ["fips", "standard"] },
+    "aead": { "type": "string", "enum": ["AES-128-GCM", "AES-192-GCM", "AES-256-GCM", "AES-256-CCM", "ChaCha20-Poly1305", "XChaCha20-Poly1305"] },
+    "hash": { "type": "string", "enum": ["SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512", "BLAKE3", "BLAKE2b"] },
+    "wireFormat": { "type": "string", "description": "informational: the wire this profile seals (e.g. tritrpc-v1). MUST NOT be altered by the crypto profile." }
+  }
+}

--- a/spec/transport/crypto_profile.md
+++ b/spec/transport/crypto_profile.md
@@ -1,0 +1,16 @@
+# TriTRPC Crypto Profile v0 — FIPS is the standard
+
+Across the platform ("From Trits to Trust", the agent threat model, and the SOC owner-sealing
+profile) the recurring primitive is **AEAD-sealed canonical bytes**. The v1 lane is
+XChaCha20-Poly1305 — fast and safe, but **not FIPS-approved**. A `CryptoProfile` makes the cipher an
+explicit, checkable, gateable choice instead of a hardcoded assumption.
+
+- **`mode: fips`** — the AEAD MUST be a FIPS-approved authenticated cipher (AES-GCM / AES-CCM,
+  SP 800-38D) and the hash MUST be FIPS-approved (SHA-2 / SHA-3, FIPS 180-4 / 202). XChaCha20 /
+  ChaCha20-Poly1305 and BLAKE are **refused** in this mode.
+- **`mode: standard`** — the v1 XChaCha20-Poly1305 lane is permitted.
+
+**Non-regression:** the crypto profile selects the *sealing cipher only*. It does **not** change the
+TriTRPC wire format — `TritPack243` byte canonical and `TLEB3` lengths are unchanged, so v1 / v4 /
+vNext frames still parse. Hashing was already FIPS-clean (`SCHEMA_ID = SHA3(...)`,
+`CONTEXT_ID = SHA3(...)`); this closes the AEAD gap. `tools/verify_crypto_profile.py` is the gate.

--- a/tools/verify_crypto_profile.py
+++ b/tools/verify_crypto_profile.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Verify TriTRPC crypto profiles — FIPS is the standard (fail-closed).
+
+'AEAD-sealed canonical bytes' recurs across the platform docs; the v1 lane is XChaCha20-Poly1305,
+which is NOT FIPS-approved. This gate makes the cipher a checkable, gateable CHOICE:
+
+  * mode:fips REQUIRES a FIPS-approved AEAD (AES-GCM/CCM, SP 800-38D) AND hash (SHA-2/SHA-3, FIPS
+    180-4/202), and REFUSES XChaCha20/ChaCha20-Poly1305 and BLAKE;
+  * mode:standard permits the v1 XChaCha20-Poly1305 lane.
+
+The profile selects the sealing cipher only; it MUST NOT alter the v1/v4/vNext wire (TritPack243/
+TLEB3). Self-testing (stdlib): fips + standard examples pass; fips-with-chacha and fips-with-blake
+are rejected. A validate_schema drift-guard keeps schema and validator in lockstep.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "jsonschema" / "crypto-profile.v0.schema.json"
+EX = ROOT / "examples" / "transport"
+VALID = [EX / "crypto_profile.fips.example.json", EX / "crypto_profile.standard.example.json"]
+INVALID = [EX / "crypto_profile.fips-chacha.invalid.json", EX / "crypto_profile.fips-blake.invalid.json"]
+
+FIPS_AEAD = {"AES-128-GCM", "AES-192-GCM", "AES-256-GCM", "AES-256-CCM"}   # SP 800-38D
+FIPS_HASH = {"SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512"}      # FIPS 180-4 / 202
+KEYS = {"profileId", "mode", "aead", "hash", "wireFormat"}
+
+
+class CryptoError(Exception):
+    pass
+
+
+def fail(m: str) -> None:
+    raise CryptoError(m)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def verify_profile(rec: Any) -> None:
+    if not isinstance(rec, dict):
+        fail("profile must be an object")
+    if sorted(set(rec) - KEYS):
+        fail(f"unexpected fields: {sorted(set(rec) - KEYS)}")
+    if not isinstance(rec.get("profileId"), str) or not rec["profileId"]:
+        fail("profileId: expected non-empty string")
+    if rec.get("mode") not in ("fips", "standard"):
+        fail("mode must be 'fips' or 'standard'")
+    aead, h = rec.get("aead"), rec.get("hash")
+    if not isinstance(aead, str) or not isinstance(h, str):
+        fail("aead and hash are required strings")
+    if rec["mode"] == "fips":
+        # FIPS is the standard: the AEAD and hash MUST be FIPS-approved.
+        if aead not in FIPS_AEAD:
+            fail(f"FIPS mode requires a FIPS-approved AEAD {sorted(FIPS_AEAD)} — {aead!r} (e.g. XChaCha20) is refused")
+        if h not in FIPS_HASH:
+            fail(f"FIPS mode requires a FIPS-approved hash {sorted(FIPS_HASH)} — {h!r} (e.g. BLAKE) is refused")
+
+
+def validate_schema(schema: Any) -> None:
+    if not isinstance(schema, dict) or schema.get("additionalProperties") is not False:
+        fail("schema root must be strict")
+    props = schema.get("properties", {})
+    if props.get("mode", {}).get("enum") != ["fips", "standard"]:
+        fail("schema mode enum drifted")
+    # Every FIPS-approved primitive the validator accepts MUST be offered by the schema enum,
+    # and the non-FIPS ones MUST be present too (so standard mode can select them).
+    if not FIPS_AEAD <= set(props.get("aead", {}).get("enum", [])):
+        fail("schema aead enum missing a FIPS AEAD the validator accepts")
+    if not FIPS_HASH <= set(props.get("hash", {}).get("enum", [])):
+        fail("schema hash enum missing a FIPS hash the validator accepts")
+
+
+def main() -> int:
+    try:
+        validate_schema(load(SCHEMA))
+        for path in VALID:
+            verify_profile(load(path))
+        for path in INVALID:
+            try:
+                verify_profile(load(path))
+            except CryptoError:
+                continue
+            fail(f"expected {path.name} to be rejected, but it passed")
+    except CryptoError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: crypto profile validated (2 examples, 2 non-FIPS-in-FIPS-mode rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Encode the FIPS guardrail as a contract, before building on the doc batch

Your flag — *FIPS is the standard; v4/vNext must keep working* — as a checkable gate. The recurring platform primitive is **AEAD-sealed canonical bytes**, and the v1 lane is XChaCha20-Poly1305 (**not** FIPS-approved). `CryptoProfile` makes the cipher explicit and gateable:

- **`mode: fips`** → AEAD MUST be FIPS-approved (AES-GCM/CCM, SP 800-38D) + hash FIPS-approved (SHA-2/SHA-3, FIPS 180-4/202); **XChaCha20 / ChaCha20-Poly1305 and BLAKE are refused** (teeth-verified).
- **`mode: standard`** → the v1 XChaCha20-Poly1305 lane is permitted.

**Non-regression (your v4/vNext constraint):** the profile selects the *sealing cipher only* — it does **not** change the wire. `TritPack243` / `TLEB3` are untouched, so v1/v4/vNext frames still parse. Hashing was already FIPS-clean (`SCHEMA_ID = SHA3(...)`); this closes the AEAD gap.

Self-testing validator + `validate_schema` drift-guard; `fips` + `standard` examples pass, `fips-with-chacha` and `fips-with-blake` refused. CI workflow.

This is the guardrail slice for the queued doc batch (From Trits to Trust, Objectives & threat model, …) — everything AEAD downstream references this profile, so nothing is 'taken blindly'.