### PR TITLE
test(vectors): canonical TritPack243 test vectors via the real codec (owed by From Trits to Trust)

### DIFF
--- a/.github/workflows/validate-tritpack-vectors.yml
+++ b/.github/workflows/validate-tritpack-vectors.yml
@@ -1,0 +1,33 @@
+name: validate-tritpack-vectors
+
+on:
+  pull_request:
+    paths:
+      - "fixtures/tritpack243_vectors.json"
+      - "tools/verify_tritpack_vectors.py"
+      - "tools/generate_tritpack_vectors.py"
+      - "reference/tritrpc_v1.py"
+      - ".github/workflows/validate-tritpack-vectors.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "fixtures/tritpack243_vectors.json"
+      - "tools/verify_tritpack_vectors.py"
+      - "tools/generate_tritpack_vectors.py"
+      - "reference/tritrpc_v1.py"
+      - ".github/workflows/validate-tritpack-vectors.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify TritPack243 canonical vectors
+        run: python tools/verify_tritpack_vectors.py

--- a/fixtures/tritpack243_vectors.json
+++ b/fixtures/tritpack243_vectors.json
@@ -1,0 +1,162 @@
+{
+  "codec": "TritPack243",
+  "alphabet": "unbalanced-ternary {0,1,2}, 5 trits/byte (3^5=243)",
+  "digest": "SHA3-256 (FIPS 202) over the packed bytes",
+  "aeadNote": "AEAD suite is selected by the CryptoProfile; not baked into these primitive vectors",
+  "vectors": [
+    {
+      "name": "empty",
+      "trits": [],
+      "tritpack243_hex": "",
+      "sha3_256": "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+    },
+    {
+      "name": "single-zero",
+      "trits": [
+        0
+      ],
+      "tritpack243_hex": "f300",
+      "sha3_256": "2244146992720ffd1ef3fc80eb76ed130873a3180e9a36ae10e3fb801aadde81"
+    },
+    {
+      "name": "single-max",
+      "trits": [
+        2
+      ],
+      "tritpack243_hex": "f302",
+      "sha3_256": "834f1891cb544ce34545038dc7363c06627466c7368e3943a79dc488977e1e47"
+    },
+    {
+      "name": "one-byte-mixed",
+      "trits": [
+        0,
+        1,
+        2,
+        0,
+        1
+      ],
+      "tritpack243_hex": "2e",
+      "sha3_256": "6890427a1f51a3e7e1dfb1f57449c5f2a24a9bed6b5d82973df1d78e765ea227"
+    },
+    {
+      "name": "all-max-7",
+      "trits": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "tritpack243_hex": "f2f408",
+      "sha3_256": "a6de734cb6b02703bb6c59d9af6d249342c09d72916237bfaf969e7c38f30688"
+    },
+    {
+      "name": "ascending-9",
+      "trits": [
+        0,
+        1,
+        2,
+        0,
+        1,
+        2,
+        0,
+        1,
+        2
+      ],
+      "tritpack243_hex": "2ef63b",
+      "sha3_256": "9547b8f0f33fd263cce9f8e49f5e48ab67c7f5f80c628137da757b13726d9284"
+    },
+    {
+      "name": "boundary-5",
+      "trits": [
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "tritpack243_hex": "f2",
+      "sha3_256": "eb7b0f0e00f494f261fb79fae36dfb1ec0d2a5a1906bf394bfe6f1a52f97d707"
+    },
+    {
+      "name": "boundary-6",
+      "trits": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        0
+      ],
+      "tritpack243_hex": "f2f300",
+      "sha3_256": "d8af52e437c341e5bbb57d6fafaf32344b6e060cb3a3e7772013265f77cdba17"
+    },
+    {
+      "name": "long-zeros-20",
+      "trits": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "tritpack243_hex": "00000000",
+      "sha3_256": "8b0a2385d83c8bf7be27e59996f7d881d3bf1fc6606f81ce600b753ad94192a2"
+    },
+    {
+      "name": "pattern-31",
+      "trits": [
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1,
+        0,
+        2,
+        1
+      ],
+      "tritpack243_hex": "66c44166c441f301",
+      "sha3_256": "e059b49734b170a8715f59f6b6ed46e3d6a551bfcdd1b6b1fdaf6869204a2670"
+    }
+  ]
+}

--- a/tools/generate_tritpack_vectors.py
+++ b/tools/generate_tritpack_vectors.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate canonical TritPack243 test vectors with the REAL reference codec.
+
+Closes the 'ten canonical test frames' the whitepaper owes, at the primitive-codec level: for each
+named trit sequence, emit the canonical TritPack243 bytes and a SHA3-256 digest of them, with the
+pack->unpack round-trip asserted at generation. These are cross-language parity anchors — any port
+(Rust/Go/TS) MUST reproduce identical bytes + digests. FIPS-clean: SHA3-256 is FIPS 202; the AEAD
+suite is NOT baked in here — it is selected by the CryptoProfile (spec/transport/crypto_profile.md),
+so these primitive vectors carry no non-FIPS cipher. Does not touch the wire (uses tritpack243_pack).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import tritrpc_v1 as t  # noqa: E402
+
+OUT = ROOT / "fixtures" / "tritpack243_vectors.json"
+
+# 10 canonical trit sequences (unbalanced ternary {0,1,2}, 5 trits/byte).
+CASES = {
+    "empty": [],
+    "single-zero": [0],
+    "single-max": [2],
+    "one-byte-mixed": [0, 1, 2, 0, 1],
+    "all-max-7": [2, 2, 2, 2, 2, 2, 2],
+    "ascending-9": [0, 1, 2, 0, 1, 2, 0, 1, 2],
+    "boundary-5": [2, 2, 2, 2, 2],
+    "boundary-6": [2, 2, 2, 2, 2, 0],
+    "long-zeros-20": [0] * 20,
+    "pattern-31": ([1, 0, 2] * 11)[:31],
+}
+
+
+def build() -> dict:
+    vectors = []
+    for name, trits in CASES.items():
+        packed = t.tritpack243_pack(trits)
+        back = t.tritpack243_unpack(packed)[:len(trits)]
+        if back != trits:
+            raise SystemExit(f"round-trip FAILED for {name}: {trits} != {back}")
+        vectors.append({
+            "name": name,
+            "trits": trits,
+            "tritpack243_hex": packed.hex(),
+            "sha3_256": hashlib.sha3_256(packed).hexdigest(),
+        })
+    return {
+        "codec": "TritPack243",
+        "alphabet": "unbalanced-ternary {0,1,2}, 5 trits/byte (3^5=243)",
+        "digest": "SHA3-256 (FIPS 202) over the packed bytes",
+        "aeadNote": "AEAD suite is selected by the CryptoProfile; not baked into these primitive vectors",
+        "vectors": vectors,
+    }
+
+
+def main() -> int:
+    OUT.write_text(json.dumps(build(), indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {OUT} ({len(CASES)} vectors)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_tritpack_vectors.py
+++ b/tools/verify_tritpack_vectors.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Verify the canonical TritPack243 vectors against the reference codec (recompute, don't trust).
+
+For each vector: re-pack the trits with the reference codec and assert the bytes equal the recorded
+tritpack243_hex; unpack the bytes and assert they equal the recorded trits (round-trip); recompute
+SHA3-256 and assert it matches. This is the cross-language parity gate — a port that diverges on any
+byte or digest fails here. Also confirms the digest is SHA3-256 (FIPS 202).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import tritrpc_v1 as t  # noqa: E402
+
+VEC = ROOT / "fixtures" / "tritpack243_vectors.json"
+
+
+def main() -> int:
+    doc = json.loads(VEC.read_text(encoding="utf-8"))
+    fails = []
+    for v in doc["vectors"]:
+        trits = v["trits"]
+        packed = t.tritpack243_pack(trits)
+        if packed.hex() != v["tritpack243_hex"]:
+            fails.append(f"{v['name']}: pack bytes {packed.hex()} != recorded {v['tritpack243_hex']}")
+            continue
+        if t.tritpack243_unpack(packed)[:len(trits)] != trits:
+            fails.append(f"{v['name']}: unpack did not round-trip to the recorded trits")
+            continue
+        if hashlib.sha3_256(packed).hexdigest() != v["sha3_256"]:
+            fails.append(f"{v['name']}: SHA3-256 digest mismatch")
+    if "SHA3-256" not in doc.get("digest", ""):
+        fails.append("digest must be SHA3-256 (FIPS 202)")
+    for m in fails:
+        print(f"FAIL: {m}", file=sys.stderr)
+    if fails:
+        return 1
+    print(f"OK: {len(doc['vectors'])} TritPack243 vectors verified (pack/unpack/SHA3-256 parity)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The whitepaper's owed 'ten canonical test frames' — at the primitive-codec level

From the *From Trits to Trust* de-dup pass: most of the whitepaper already has estate homes; the genuinely-owed, safe, additive slice is **canonical TritRPC test vectors**. This ships them at the codec primitive level.

10 named trit sequences → canonical **TritPack243** bytes + **SHA3-256** digest, **generated by the real reference codec** (`reference/tritrpc_v1.py`) with the `pack→unpack` round-trip asserted at generation. These are **cross-language parity anchors** — any Rust/Go/TS port must reproduce identical bytes + digests.

- **FIPS-clean:** SHA3-256 (FIPS 202); **no AEAD baked in** — the cipher is selected by the `CryptoProfile` (#81), so these primitive vectors carry no non-FIPS cipher.
- **Non-regression:** uses the existing codec, does **not** change the wire — v1/v4/vNext unaffected.
- `verify_tritpack_vectors.py` recomputes bytes + digest (recompute-don't-trust); teeth-verified (a corrupted digest is refused). CI workflow.

**Finding filed separately:** the codec's **TLEB3 length decode is broken** (raises `trunc tail marker` for every value); it's a wire-sensitive primitive so I filed a careful isolated fix rather than touching it here. These vectors cover **TritPack243**, which round-trips cleanly.