### PR TITLE
fix(codec): TLEB3 length decode — read the 2-byte tail marker (was broken for all values)

### DIFF
--- a/.github/workflows/validate-tleb3-roundtrip.yml
+++ b/.github/workflows/validate-tleb3-roundtrip.yml
@@ -1,0 +1,29 @@
+name: validate-tleb3-roundtrip
+
+on:
+  pull_request:
+    paths:
+      - "reference/tritrpc_v1.py"
+      - "tools/verify_tleb3_roundtrip.py"
+      - ".github/workflows/validate-tleb3-roundtrip.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/tritrpc_v1.py"
+      - "tools/verify_tleb3_roundtrip.py"
+      - ".github/workflows/validate-tleb3-roundtrip.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify TLEB3 round-trip
+        run: python tools/verify_tleb3_roundtrip.py

--- a/reference/tritrpc_v1.py
+++ b/reference/tritrpc_v1.py
@@ -76,42 +76,50 @@ def tleb3_len_encode(n: int) -> bytes:
     return tritpack243_pack(trits)
 
 def tleb3_len_decode(b: bytes, offset: int) -> Tuple[int, int]:
-    """Decode a TLEB3 length starting at offset; returns (value, new_offset)."""
-    # We need to parse packed trits out of the stream. We can consume bytes until we reach a trit with C=0.
-    # Because tritpack groups in 5-trit bundles, we decode incrementally.
-    # Simpler approach: decode progressively while buffering trits.
+    """Decode a TLEB3 length starting at offset; returns (value, new_offset).
+
+    Reads TritPack243 groups from the stream: a full group (byte 0..242) is 5 trits, and a TAIL
+    group (marker 243..246) is a TWO-BYTE sequence (marker + value byte). The previous
+    implementation unpacked one byte at a time, so a lone tail-marker byte always tripped
+    "trunc tail marker" and every length failed to decode. This reads the tail's value byte with
+    its marker so decode correctly inverts encode. `tleb3_len_encode` is UNCHANGED — the wire
+    format (TritPack243/TLEB3) is byte-identical; only the decoder is corrected.
+    """
     i = offset
     tritbuf: List[int] = []
-    # We don't know how many bytes; read at least 1 group
     while True:
-        if i >= len(b): raise ValueError("EOF in TLEB3")
-        chunk = b[i:i+1]
-        i += 1
-        ts = tritpack243_unpack(chunk)  # ok for single byte
-        tritbuf.extend(ts)
-        # scan tritlets
-        # tritlets = groups of 3
-        if len(tritbuf) < 3: 
-            continue
-        # Try to parse; continuation 2 except last 0
-        val = 0
-        ok = False
-        # parse all complete tritlets and stop at first C=0
-        for j in range(0, len(tritbuf)//3):
-            C,P1,P0 = tritbuf[3*j:3*j+3]
-            digit = P1*3 + P0
-            val += digit * (9**j)
+        if i >= len(b):
+            raise ValueError("EOF in TLEB3")
+        byte = b[i]
+        if byte <= 242:                       # full group: 5 trits, big-endian base-3
+            val = byte
+            group = [0, 0, 0, 0, 0]
+            for j in range(4, -1, -1):
+                group[j] = val % 3
+                val //= 3
+            tritbuf.extend(group)
+            i += 1
+        elif 243 <= byte <= 246:              # tail group: marker + value byte -> k trits
+            k = (byte - 243) + 1
+            if i + 1 >= len(b):
+                raise ValueError("trunc tail marker")
+            val = b[i + 1]
+            group = [0] * k
+            for j in range(k - 1, -1, -1):
+                group[j] = val % 3
+                val //= 3
+            tritbuf.extend(group)
+            i += 2
+        else:
+            raise ValueError("invalid byte in canonical output (247..255)")
+        # Parse tritlets (3 trits: continuation C, then digit P1*3+P0); stop at the final C=0.
+        value = 0
+        for j in range(len(tritbuf) // 3):
+            C, P1, P0 = tritbuf[3 * j:3 * j + 3]
+            value += (P1 * 3 + P0) * (9 ** j)
             if C == 0:
-                # we've consumed j+1 tritlets; but tritbuf may contain extra trits from the same packed byte.
-                # compute how many trits used:
-                trits_used = (j+1)*3
-                # compute how many bytes were actually needed for these trits:
-                # We can't easily reverse-pack; instead, re-encode just those trits and count bytes.
-                enc = tritpack243_pack(tritbuf[:trits_used])
-                used_bytes = len(enc)
-                # Step back to offset + used_bytes
-                return val, offset + used_bytes
-        # else need more bytes
+                return value, i
+        # else: need more bytes
 
 # ===== Avro subset encoders (Path-A) =====
 

--- a/tools/verify_tleb3_roundtrip.py
+++ b/tools/verify_tleb3_roundtrip.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Round-trip gate for TLEB3 length encode<->decode (wire primitive).
+
+tleb3_len_decode was broken (raised 'trunc tail marker' for every value) because it unpacked one
+byte at a time while TritPack243 tail markers are 2-byte sequences. This asserts encode->decode is
+identity across boundary and multi-byte lengths, that stream decode stops exactly at the value
+boundary (leaving trailing bytes intact), and that a truncated tail still fails closed. Encode (the
+wire format) is unchanged; this locks the decoder's correctness in CI.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "reference"))
+import tritrpc_v1 as t  # noqa: E402
+
+# boundaries around the base-9 digit rollovers and the 5-trit TritPack243 group boundary
+VALUES = [0, 1, 2, 8, 9, 10, 80, 81, 242, 243, 244, 300, 728, 729, 730,
+          1000, 6560, 6561, 100000, 531440, 531441, 1_000_000]
+TRAILER = b"\xAB\xCD\xEF"
+
+
+def main() -> int:
+    fails = []
+    for n in VALUES:
+        enc = t.tleb3_len_encode(n)
+        v, off = t.tleb3_len_decode(enc, 0)
+        if v != n or off != len(enc):
+            fails.append(f"round-trip {n}: got value={v} offset={off} (enc {enc.hex()}, len {len(enc)})")
+        # stream: decode must consume exactly enc and leave the trailer untouched
+        v2, off2 = t.tleb3_len_decode(enc + TRAILER, 0)
+        if v2 != n or (enc + TRAILER)[off2:] != TRAILER:
+            fails.append(f"stream {n}: value={v2} offset={off2} did not stop at the boundary")
+    # fail-closed: a truncated tail marker must raise, not silently mis-decode
+    try:
+        t.tleb3_len_decode(t.tleb3_len_encode(0)[:1], 0)
+        fails.append("a truncated tail marker must raise ValueError, not decode")
+    except ValueError:
+        pass
+
+    for m in fails:
+        print(f"FAIL: {m}", file=sys.stderr)
+    if fails:
+        return 1
+    print(f"OK: TLEB3 round-trip verified for {len(VALUES)} lengths (incl multi-byte) + stream + truncation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The wire primitive bug, fixed without touching the wire

`tleb3_len_decode(tleb3_len_encode(n), 0)` raised `ValueError('trunc tail marker')` for **every** `n`. Root cause: decode unpacked **one byte at a time**, but a TritPack243 **tail group** (marker `243..246`) is a **2-byte sequence** (marker + value byte) — so a lone marker byte always looked truncated, and short lengths are *entirely* a tail group.

Decode now reads full groups (5 trits) and tail groups (marker + value → k trits) correctly, stopping at the first `C=0` tritlet.

**Wire unchanged (your v4/vNext + FIPS guardrail):**
- `tleb3_len_encode` / `tritpack243_pack` / `tritpack243_unpack` are **byte-identical** — the diff is decode-only.
- The 10 canonical TritPack243 vectors still verify; **no `fixtures/vectors_hex_*` change**. v1/v4/vNext frames unaffected.
- FIPS-neutral (a length codec, no crypto).

**Round-trip test wired into CI** (`verify_tleb3_roundtrip.py`): encode→decode identity across boundary and **multi-byte** lengths (0…1e6, base-9 and 5-trit-group boundaries), **stream** decode stops exactly at the value boundary (trailer intact), and a **truncated tail fails closed**.

Resolves the TLEB3 bug found while building the canonical vectors (#83).