### PR TITLE
spec(transport): FederationCryptoProfile — FIPS for the Merkle-log P2P layer

### DIFF
--- a/.github/workflows/validate-federation-crypto-profile.yml
+++ b/.github/workflows/validate-federation-crypto-profile.yml
@@ -1,0 +1,33 @@
+name: validate-federation-crypto-profile
+
+on:
+  pull_request:
+    paths:
+      - "schemas/jsonschema/federation-crypto-profile.v0.schema.json"
+      - "spec/transport/federation_crypto_profile.md"
+      - "examples/transport/federation_crypto_profile.*.json"
+      - "tools/verify_federation_crypto_profile.py"
+      - ".github/workflows/validate-federation-crypto-profile.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "schemas/jsonschema/federation-crypto-profile.v0.schema.json"
+      - "spec/transport/federation_crypto_profile.md"
+      - "examples/transport/federation_crypto_profile.*.json"
+      - "tools/verify_federation_crypto_profile.py"
+      - ".github/workflows/validate-federation-crypto-profile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate federation crypto profile (FIPS gate)
+        run: python tools/verify_federation_crypto_profile.py

--- a/examples/transport/federation_crypto_profile.fips-blake2b.invalid.json
+++ b/examples/transport/federation_crypto_profile.fips-blake2b.invalid.json
@@ -1,0 +1,6 @@
+{
+  "profileId": "fedcrypto://bad",
+  "mode": "fips",
+  "contentHash": "BLAKE2b",
+  "signature": "ECDSA-P256"
+}

--- a/examples/transport/federation_crypto_profile.fips-blake3.invalid.json
+++ b/examples/transport/federation_crypto_profile.fips-blake3.invalid.json
@@ -1,0 +1,6 @@
+{
+  "profileId": "fedcrypto://bad2",
+  "mode": "fips",
+  "contentHash": "BLAKE3",
+  "signature": "Ed25519"
+}

--- a/examples/transport/federation_crypto_profile.fips-ecdsa.example.json
+++ b/examples/transport/federation_crypto_profile.fips-ecdsa.example.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "fedcrypto://fips/ecdsa",
+  "mode": "fips",
+  "contentHash": "SHA-256",
+  "signature": "ECDSA-P256",
+  "contentAddressing": "merkle-dag"
+}

--- a/examples/transport/federation_crypto_profile.fips-eddsa.example.json
+++ b/examples/transport/federation_crypto_profile.fips-eddsa.example.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "fedcrypto://fips/eddsa",
+  "mode": "fips",
+  "contentHash": "SHA3-256",
+  "signature": "Ed25519",
+  "contentAddressing": "ipfs"
+}

--- a/examples/transport/federation_crypto_profile.standard.example.json
+++ b/examples/transport/federation_crypto_profile.standard.example.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "fedcrypto://standard",
+  "mode": "standard",
+  "contentHash": "BLAKE2b",
+  "signature": "Ed25519",
+  "contentAddressing": "ssb"
+}

--- a/schemas/jsonschema/federation-crypto-profile.v0.schema.json
+++ b/schemas/jsonschema/federation-crypto-profile.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/federation-crypto-profile.v0.schema.json",
+  "title": "FederationCryptoProfile v0",
+  "description": "Gates the crypto of the Merkle-log P2P federation layer (the Symbolic-AI/KG + Dual-Orchestration docs' SSB/Hypercore/IPFS-style signed append-only knowledge logs). Companion to the transport CryptoProfile. Two surfaces: the CONTENT HASH (Merkle content addressing / CIDs) and the feed SIGNATURE. mode:fips requires a FIPS-approved hash (SHA-2/SHA-3) and a FIPS 186-5 signature (ECDSA / RSA / EdDSA). The genuine non-FIPS default in those stacks is the HASH — BLAKE2b (SSB/Hypercore) and BLAKE3 (IPFS option) are refused in fips mode; Ed25519/Ed448 are OK under FIPS 186-5.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profileId", "mode", "contentHash", "signature"],
+  "properties": {
+    "profileId": { "type": "string", "minLength": 1 },
+    "mode": { "type": "string", "enum": ["fips", "standard"] },
+    "contentHash": { "type": "string", "enum": ["SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512", "BLAKE2b", "BLAKE3"] },
+    "signature": { "type": "string", "enum": ["ECDSA-P256", "ECDSA-P384", "ECDSA-P521", "RSA-3072", "RSA-4096", "Ed25519", "Ed448"] },
+    "contentAddressing": { "type": "string", "enum": ["merkle-dag", "ipfs", "hypercore", "ssb"], "description": "informational: the federation scheme this profile secures. The hash algorithm — not the scheme — is what FIPS gates." }
+  }
+}

--- a/spec/transport/federation_crypto_profile.md
+++ b/spec/transport/federation_crypto_profile.md
@@ -1,0 +1,21 @@
+# Federation Crypto Profile v0 — FIPS for the Merkle-log layer
+
+The platform docs' P2P federation (signed append-only knowledge logs a la SSB / Hypercore-Dat /
+IPFS, Merkle-DAG addressed) secures two surfaces: the **content hash** (Merkle addressing / CIDs)
+and the feed **signature**. Those stacks' *defaults* are the FIPS risk, and the risk is the HASH:
+
+- **`mode: fips`** — `contentHash` MUST be FIPS-approved (SHA-2 / SHA-3, FIPS 180-4 / 202); `signature`
+  MUST be a FIPS 186-5 algorithm (ECDSA, RSA, or **EdDSA — Ed25519/Ed448, approved in FIPS 186-5**).
+  **BLAKE2b (SSB/Hypercore default) and BLAKE3 (IPFS option) are refused.** IPFS CIDs must pin the
+  multihash to SHA-256.
+- **`mode: standard`** — BLAKE2b/BLAKE3 permitted.
+
+**Correction vs. the naive reading:** it is common to flag "SSB uses Ed25519, so it isn't FIPS" —
+but FIPS 186-5 (Feb 2023) approves EdDSA, so Ed25519/Ed448 are fine. The genuine non-FIPS primitive
+in these federation stacks is the **BLAKE hash**, not the signature.
+
+**CMVP caveat:** some FIPS-validated modules have not yet added EdDSA to their certificate; a
+deployment that must run only CMVP-certified algorithms may further restrict signatures to ECDSA/RSA.
+That is a deployment posture on top of 186-5, not a change to the standard.
+
+`tools/verify_federation_crypto_profile.py` is the gate; ties the transport `CryptoProfile`.

--- a/tools/verify_federation_crypto_profile.py
+++ b/tools/verify_federation_crypto_profile.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Verify Merkle-log federation crypto profiles — FIPS for the P2P knowledge-log layer.
+
+The federation stacks (SSB / Hypercore-Dat / IPFS, Merkle-DAG) secure a CONTENT HASH and a feed
+SIGNATURE. mode:fips requires a FIPS-approved hash (SHA-2/SHA-3) and a FIPS 186-5 signature (ECDSA /
+RSA / EdDSA). The genuine non-FIPS default is the HASH — BLAKE2b (SSB/Hypercore) and BLAKE3 (IPFS)
+are refused; Ed25519/Ed448 pass under 186-5. Self-testing (stdlib): fips-ecdsa + fips-eddsa +
+standard pass; fips-blake2b + fips-blake3 rejected. A validate_schema drift-guard keeps them in sync.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "jsonschema" / "federation-crypto-profile.v0.schema.json"
+EX = ROOT / "examples" / "transport"
+VALID = [EX / "federation_crypto_profile.fips-ecdsa.example.json",
+         EX / "federation_crypto_profile.fips-eddsa.example.json",
+         EX / "federation_crypto_profile.standard.example.json"]
+INVALID = [EX / "federation_crypto_profile.fips-blake2b.invalid.json",
+           EX / "federation_crypto_profile.fips-blake3.invalid.json"]
+
+FIPS_HASH = {"SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512"}          # FIPS 180-4 / 202
+FIPS_SIG = {"ECDSA-P256", "ECDSA-P384", "ECDSA-P521", "RSA-3072", "RSA-4096",  # FIPS 186-5
+            "Ed25519", "Ed448"}                                               # EdDSA, approved in 186-5
+KEYS = {"profileId", "mode", "contentHash", "signature", "contentAddressing"}
+
+
+class FedError(Exception):
+    pass
+
+
+def fail(m: str) -> None:
+    raise FedError(m)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def verify(rec: Any) -> None:
+    if not isinstance(rec, dict) or sorted(set(rec) - KEYS):
+        fail(f"unexpected/invalid fields: {sorted(set(rec) - KEYS)}")
+    if not isinstance(rec.get("profileId"), str) or not rec["profileId"]:
+        fail("profileId: expected non-empty string")
+    if rec.get("mode") not in ("fips", "standard"):
+        fail("mode must be 'fips' or 'standard'")
+    ch, sig = rec.get("contentHash"), rec.get("signature")
+    if not isinstance(ch, str) or not isinstance(sig, str):
+        fail("contentHash and signature are required strings")
+    if rec["mode"] == "fips":
+        if ch not in FIPS_HASH:
+            fail(f"FIPS mode requires a FIPS hash {sorted(FIPS_HASH)} — {ch!r} (BLAKE2b/BLAKE3) is refused")
+        if sig not in FIPS_SIG:
+            fail(f"FIPS mode requires a FIPS 186-5 signature {sorted(FIPS_SIG)} — {sig!r} refused")
+
+
+def validate_schema(schema: Any) -> None:
+    if not isinstance(schema, dict) or schema.get("additionalProperties") is not False:
+        fail("schema root must be strict")
+    props = schema.get("properties", {})
+    if props.get("mode", {}).get("enum") != ["fips", "standard"]:
+        fail("schema mode enum drifted")
+    if not FIPS_HASH <= set(props.get("contentHash", {}).get("enum", [])):
+        fail("schema contentHash enum missing a FIPS hash the validator accepts")
+    if not FIPS_SIG <= set(props.get("signature", {}).get("enum", [])):
+        fail("schema signature enum missing a FIPS 186-5 signature the validator accepts")
+    # the non-FIPS hashes MUST be offered (so standard mode can select them and fips can refuse them)
+    if not {"BLAKE2b", "BLAKE3"} <= set(props.get("contentHash", {}).get("enum", [])):
+        fail("schema must offer BLAKE2b/BLAKE3 (the non-FIPS defaults the gate refuses in fips mode)")
+
+
+def main() -> int:
+    try:
+        validate_schema(load(SCHEMA))
+        for p in VALID:
+            verify(load(p))
+        for p in INVALID:
+            try:
+                verify(load(p))
+            except FedError:
+                continue
+            fail(f"expected {p.name} to be rejected, but it passed")
+    except FedError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: federation crypto profile validated (3 examples, 2 non-FIPS-hash-in-fips rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The last FIPS-red flag from the doc batch, closed

The Symbolic-AI/KG (#20) and Dual-Orchestration (#19) docs both lean on SSB/Hypercore/IPFS-style signed append-only Merkle-log federation — and those stacks' *defaults* are the FIPS risk. Companion to the transport `CryptoProfile` (#81), this gates the federation's two crypto surfaces.

- **`contentHash`** (Merkle addressing / CIDs): `fips` requires **SHA-2 / SHA-3**; **BLAKE2b (SSB/Hypercore default) and BLAKE3 (IPFS option) are refused** — the genuine non-FIPS primitive. IPFS CIDs pin SHA-256.
- **`signature`**: `fips` requires a **FIPS 186-5** algorithm — ECDSA / RSA / **EdDSA**.

**Accuracy correction (don't-take-it-blindly):** the naive reading is "SSB uses Ed25519, so it isn't FIPS" — but **FIPS 186-5 (Feb 2023) approves EdDSA**, so Ed25519/Ed448 **pass**. The real violation is the **BLAKE hash**, not the signature. The spec notes the CMVP caveat (some validated modules lag on EdDSA; a deployment may further restrict to ECDSA/RSA — a posture on top of 186-5, not a change to it).

Self-testing validator + `validate_schema` drift-guard: `fips-ecdsa`/`fips-eddsa`/`standard` pass; `fips-blake2b` + `fips-blake3` refused; Ed25519 accepted under `fips`. CI workflow. Additive — no wire change.

With #81 (transport) this makes **both** crypto surfaces the docs use FIPS-gateable.