### PR TITLE
spec(qutrit): Q3 ECC default profile — RS over GF(9) + ternary stabilizer

### DIFF
--- a/.github/workflows/validate-q3-ecc-profile.yml
+++ b/.github/workflows/validate-q3-ecc-profile.yml
@@ -1,0 +1,19 @@
+name: validate-q3-ecc-profile
+on:
+  pull_request:
+    paths: ["schemas/jsonschema/q3-ecc-profile.v0.schema.json","spec/qutrit/q3_ecc_profile.md","examples/qutrit/q3_ecc_profile.*.json","tools/verify_q3_ecc_profile.py",".github/workflows/validate-q3-ecc-profile.yml"]
+  push:
+    branches: [ main ]
+    paths: ["schemas/jsonschema/q3-ecc-profile.v0.schema.json","spec/qutrit/q3_ecc_profile.md","examples/qutrit/q3_ecc_profile.*.json","tools/verify_q3_ecc_profile.py",".github/workflows/validate-q3-ecc-profile.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate Q3 ECC profile
+        run: python tools/verify_q3_ecc_profile.py

--- a/examples/qutrit/q3_ecc_profile.bad-blocklen.invalid.json
+++ b/examples/qutrit/q3_ecc_profile.bad-blocklen.invalid.json
@@ -1,0 +1,11 @@
+{
+  "profileId": "q3ecc://bad",
+  "rail": "classical-ternary",
+  "code": {
+    "kind": "RS-GF3m",
+    "m": 2,
+    "n": 9,
+    "k": 4,
+    "t": 2
+  }
+}

--- a/examples/qutrit/q3_ecc_profile.default.example.json
+++ b/examples/qutrit/q3_ecc_profile.default.example.json
@@ -1,0 +1,12 @@
+{
+  "profileId": "q3ecc://default/rs-gf9",
+  "default": true,
+  "rail": "classical-ternary",
+  "code": {
+    "kind": "RS-GF3m",
+    "m": 2,
+    "n": 8,
+    "k": 4,
+    "t": 2
+  }
+}

--- a/examples/qutrit/q3_ecc_profile.singleton-violation.invalid.json
+++ b/examples/qutrit/q3_ecc_profile.singleton-violation.invalid.json
@@ -1,0 +1,10 @@
+{
+  "profileId": "q3ecc://bad2",
+  "rail": "qutrit-quantum",
+  "code": {
+    "kind": "ternary-stabilizer",
+    "n": 5,
+    "k": 4,
+    "d": 3
+  }
+}

--- a/examples/qutrit/q3_ecc_profile.stabilizer.example.json
+++ b/examples/qutrit/q3_ecc_profile.stabilizer.example.json
@@ -1,0 +1,10 @@
+{
+  "profileId": "q3ecc://qutrit/perfect-5-1-3",
+  "rail": "qutrit-quantum",
+  "code": {
+    "kind": "ternary-stabilizer",
+    "n": 5,
+    "k": 1,
+    "d": 3
+  }
+}

--- a/schemas/jsonschema/q3-ecc-profile.v0.schema.json
+++ b/schemas/jsonschema/q3-ecc-profile.v0.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/q3-ecc-profile.v0.schema.json",
+  "title": "Q3ECCProfile v0",
+  "description": "Declares the Q3 (qutrit / ternary) error-correction profile so multi-vendor interop on the ternary rail is real day-one (the whitepaper's owed default). Two rails: classical-ternary uses Reed-Solomon over GF(3^m); qutrit-quantum uses a ternary [[n,k,d]]_3 stabilizer code. Parameters are self-consistency-checked so a declared code is a valid code. Additive: this selects the ECC for the ternary rail; it does NOT change the TritPack243/TLEB3 wire (v1/v4/vNext unaffected). FIPS-neutral (error-correction, not cryptography).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profileId", "rail", "code"],
+  "properties": {
+    "profileId": { "type": "string", "minLength": 1 },
+    "default": { "type": "boolean", "description": "true for the single canonical default profile" },
+    "rail": { "type": "string", "enum": ["classical-ternary", "qutrit-quantum"] },
+    "code": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["RS-GF3m", "ternary-stabilizer"] },
+        "m": { "type": "integer", "minimum": 1, "description": "RS: field is GF(3^m)" },
+        "n": { "type": "integer", "minimum": 1, "description": "code block length (symbols / qutrits)" },
+        "k": { "type": "integer", "minimum": 0, "description": "message symbols / logical qutrits" },
+        "t": { "type": "integer", "minimum": 0, "description": "RS: correctable symbol errors" },
+        "d": { "type": "integer", "minimum": 1, "description": "stabilizer: code distance" }
+      }
+    }
+  }
+}

--- a/spec/qutrit/q3_ecc_profile.md
+++ b/spec/qutrit/q3_ecc_profile.md
@@ -1,0 +1,17 @@
+# Q3 ECC Profile v0 — the default ternary/qutrit error-correction, for interop
+
+The whitepaper owes "a default Q3 ECC profile so multi-vendor interop is real from day one." Q3 is
+the qutrit / ternary rail. Two rails, one checkable profile:
+
+- **classical-ternary** — **Reed-Solomon over GF(3^m)**. Symbols are elements of GF(3^m); a primitive
+  RS code has block length `n = 3^m − 1`, `k` message symbols, and corrects `t = ⌊(n−k)/2⌋` symbol
+  errors. **Canonical default: RS over GF(9)** (`m=2`, `n=8`, `k=4`, `t=2`) — every vendor implements
+  this one day-one.
+- **qutrit-quantum** — a ternary `[[n,k,d]]_3` **stabilizer code**; must satisfy the quantum Singleton
+  bound `n − k ≥ 2(d−1)`. Example: the qutrit `[[5,1,3]]_3` perfect code.
+
+`tools/verify_q3_ecc_profile.py` checks each declared code is a VALID code (not just well-typed): RS
+requires `n = 3^m − 1`, `1 ≤ k < n`, and `t = ⌊(n−k)/2⌋ ≥ 1`; stabilizer requires `0 ≤ k < n`, `d ≥ 1`,
+and the quantum Singleton bound. So a multi-vendor profile that claims impossible parameters is
+refused. **Additive:** selects the rail's ECC; does NOT change the TritPack243/TLEB3 wire (v1/v4/vNext
+unaffected). **FIPS-neutral** (error-correction, not cryptography).

--- a/tools/verify_q3_ecc_profile.py
+++ b/tools/verify_q3_ecc_profile.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Verify Q3 (qutrit/ternary) ECC profiles are VALID codes — multi-vendor interop gate.
+
+Checks each declared code is a real code, not just well-typed:
+  * RS-GF3m (classical-ternary): n = 3^m - 1, 1 <= k < n, t = floor((n-k)/2) >= 1 (and t matches);
+  * ternary-stabilizer (qutrit-quantum): 0 <= k < n, d >= 1, quantum Singleton bound n-k >= 2(d-1).
+The canonical default (RS over GF(9), [8,4], t=2) must be present and marked default. Self-testing:
+the default + stabilizer examples pass; bad-blocklen + Singleton-violation are refused.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EX = ROOT / "examples" / "qutrit"
+VALID = [EX / "q3_ecc_profile.default.example.json", EX / "q3_ecc_profile.stabilizer.example.json"]
+INVALID = [EX / "q3_ecc_profile.bad-blocklen.invalid.json", EX / "q3_ecc_profile.singleton-violation.invalid.json"]
+
+
+class ECCError(Exception):
+    pass
+
+
+def fail(m: str) -> None:
+    raise ECCError(m)
+
+
+def load(p: Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def verify(p: Any) -> None:
+    code = (p or {}).get("code") or {}
+    kind = code.get("kind")
+    if kind == "RS-GF3m":
+        m, n, k = code.get("m"), code.get("n"), code.get("k")
+        if not all(isinstance(x, int) for x in (m, n, k)):
+            fail("RS-GF3m requires integer m, n, k")
+        if n != 3 ** m - 1:
+            fail(f"RS-GF3m block length must be 3^m-1 = {3 ** m - 1} over GF(3^{m}), got n={n}")
+        if not (1 <= k < n):
+            fail(f"RS-GF3m requires 1 <= k < n (k={k}, n={n})")
+        t_exp = (n - k) // 2
+        if t_exp < 1:
+            fail("RS-GF3m corrects no errors (t = floor((n-k)/2) < 1)")
+        if code.get("t") is not None and code["t"] != t_exp:
+            fail(f"RS-GF3m t must equal floor((n-k)/2) = {t_exp}, got {code['t']}")
+    elif kind == "ternary-stabilizer":
+        n, k, d = code.get("n"), code.get("k"), code.get("d")
+        if not all(isinstance(x, int) for x in (n, k, d)):
+            fail("ternary-stabilizer requires integer n, k, d")
+        if not (0 <= k < n):
+            fail(f"stabilizer requires 0 <= k < n (k={k}, n={n})")
+        if d < 1:
+            fail("stabilizer requires d >= 1")
+        if (n - k) < 2 * (d - 1):
+            fail(f"stabilizer violates the quantum Singleton bound n-k >= 2(d-1): {n - k} < {2 * (d - 1)}")
+    else:
+        fail(f"unknown code.kind {kind!r}")
+
+
+def main() -> int:
+    try:
+        defaults = 0
+        for path in VALID:
+            p = load(path)
+            verify(p)
+            if p.get("default"):
+                defaults += 1
+                if not (p["rail"] == "classical-ternary" and p["code"] == {"kind": "RS-GF3m", "m": 2, "n": 8, "k": 4, "t": 2}):
+                    fail("the default profile must be RS over GF(9): {m:2,n:8,k:4,t:2}")
+        if defaults != 1:
+            fail(f"exactly one canonical default profile required, found {defaults}")
+        for path in INVALID:
+            try:
+                verify(load(path))
+            except ECCError:
+                continue
+            fail(f"expected {path.name} to be rejected, but it passed")
+    except ECCError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: Q3 ECC profiles valid (default RS-GF9 + stabilizer; 2 invalid codes rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The whitepaper's owed default Q3 ECC profile

Ships a checkable default so multi-vendor interop on the ternary/qutrit rail is real day-one. Two rails, one profile:

- **classical-ternary** — **Reed-Solomon over GF(3^m)**; canonical **default = RS over GF(9)** (`m=2, n=8, k=4, t=2`), which every vendor implements day-one.
- **qutrit-quantum** — a ternary `[[n,k,d]]_3` **stabilizer code** (example: the `[[5,1,3]]_3` perfect code).

`verify_q3_ecc_profile.py` checks each declared code is a **valid code**, not just well-typed: RS requires `n = 3^m − 1`, `1 ≤ k < n`, `t = ⌊(n−k)/2⌋ ≥ 1`; the stabilizer must satisfy the **quantum Singleton bound** `n − k ≥ 2(d−1)`; exactly one canonical default. **Teeth:** a bad RS block-length (`n=9` for `m=2`) and a Singleton-violating stabilizer are refused.

**Additive & safe:** selects the rail's ECC; does **not** change the TritPack243/TLEB3 wire (v1/v4/vNext unaffected). **FIPS-neutral** (error-correction, not cryptography).