### PR TITLE
feat(orchestration): Mesh Work-Unit pack + reference coordinator (settlement, fail-closed)

### DIFF
--- a/.github/workflows/validate-mesh-coordinator.yml
+++ b/.github/workflows/validate-mesh-coordinator.yml
@@ -1,0 +1,37 @@
+name: validate-mesh-coordinator
+
+on:
+  pull_request:
+    paths:
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_mesh_coordinator.py"
+      - "schemas/jsonschema/work-unit-pack.v0.schema.json"
+      - "schemas/jsonschema/work-unit-result.v0.schema.json"
+      - "examples/mesh/**"
+      - "spec/orchestration/mesh_work_unit.md"
+      - ".github/workflows/validate-mesh-coordinator.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_mesh_coordinator.py"
+      - "schemas/jsonschema/work-unit-pack.v0.schema.json"
+      - "schemas/jsonschema/work-unit-result.v0.schema.json"
+      - "examples/mesh/**"
+      - "spec/orchestration/mesh_work_unit.md"
+      - ".github/workflows/validate-mesh-coordinator.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate reference Mesh Coordinator (WU settlement, fail-closed)
+        run: python tools/verify_mesh_coordinator.py

--- a/examples/mesh/trusted_nodes.example.json
+++ b/examples/mesh/trusted_nodes.example.json
@@ -1,0 +1,17 @@
+[
+  {
+    "node_ref": "node://eu-1",
+    "attestationRef": "att://tpm/eu-1#quote",
+    "region": "EU"
+  },
+  {
+    "node_ref": "node://eu-2",
+    "attestationRef": "att://tpm/eu-2#quote",
+    "region": "EU"
+  },
+  {
+    "node_ref": "node://eu-3",
+    "attestationRef": "att://tpm/eu-3#quote",
+    "region": "EU"
+  }
+]

--- a/examples/mesh/work_unit_pack.example.json
+++ b/examples/mesh/work_unit_pack.example.json
@@ -1,0 +1,15 @@
+{
+  "wu_id": "wu-2026-08-03-0001",
+  "schema_id": "sha3-256:1111111111111111111111111111111111111111111111111111111111111111",
+  "proof_mode": "redundant",
+  "sandbox": "wasm",
+  "policy": {
+    "residency": "EU",
+    "isolation": "strong",
+    "slo_ms": 30000
+  },
+  "body_cid": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "replication": 3,
+  "context": "https://ctx.socioprophet.dev/mesh/wu.jsonld",
+  "signature": "ed25519:deadbeef"
+}

--- a/examples/mesh/work_unit_results.example.json
+++ b/examples/mesh/work_unit_results.example.json
@@ -1,0 +1,32 @@
+[
+  {
+    "wu_id": "wu-2026-08-03-0001",
+    "node_ref": "node://eu-1",
+    "region": "EU",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "proof": {
+      "mode": "redundant"
+    },
+    "signature": "ed25519:11"
+  },
+  {
+    "wu_id": "wu-2026-08-03-0001",
+    "node_ref": "node://eu-2",
+    "region": "EU",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "proof": {
+      "mode": "redundant"
+    },
+    "signature": "ed25519:22"
+  },
+  {
+    "wu_id": "wu-2026-08-03-0001",
+    "node_ref": "node://eu-3",
+    "region": "EU",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "proof": {
+      "mode": "redundant"
+    },
+    "signature": "ed25519:33"
+  }
+]

--- a/reference/mesh_coordinator.py
+++ b/reference/mesh_coordinator.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Reference Mesh Coordinator — makes the Work-Unit contracts LIVE and fail-closed.
+
+Dual-Orchestration plane B: a coordinator dispatches a `WorkUnitPack` to volunteer nodes and
+collects `WorkUnitResult`s. This module implements the two steps a coordinator can decide
+*deterministically* from the artifacts alone — VERIFY (per-result admission) and REDUCE (settlement)
+— and emits an auditable settlement receipt. It is a reference settler, not a network stack: it does
+not schedule or transport; it produces the checkable artifact a conformant coordinator must.
+
+  * verify_result(pack, result, trusted): fail-closed admission of ONE result —
+      - the node must be TRUSTED and ATTESTED (unattested / unknown node -> refused);
+      - the node's region must satisfy pack.policy.residency (residency violation -> refused);
+      - result.wu_id must match; the proof.mode must equal pack.proof_mode; and the proof must
+        carry that mode's REQUIRED material (a mode mismatch or missing material -> refused).
+  * reduce(pack, results, trusted): settle admissible results by proof_mode and assign RLC credit —
+      - redundant: needs >= pack.replication admissible results; the accepted result is the CID held
+        by a STRICT MAJORITY. No majority (a split / sabotage) -> NOT settled, no credit.
+      - spot_check / tee / zk: the coordinator confirms the required proof material is present and
+        well-formed (structural), then accepts; cryptographic proof-checking of a TEE quote or a zk
+        proof is delegated to that mode's verifier (out of scope here, stated honestly). RLC credit
+        goes ONLY to nodes whose result matches the accepted CID.
+
+FIPS: content-addressing / agreement is over SHA-256 CIDs (FIPS 180-4) and SCHEMA-IDs over SHA3
+(FIPS 202) — no non-FIPS primitive is used or required. This module performs no AEAD; the transport
+AEAD is the CryptoProfile lane's job (AES-256-GCM in a FIPS deployment, never XChaCha20). It does not
+touch the tritrpc v4/vNext wire format.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+PROOF_MODES = {"redundant", "spot_check", "tee", "zk"}
+# The material each proof mode's result MUST carry to be admissible (beyond schema shape).
+REQUIRED_PROOF_FIELDS = {
+    "redundant": (),                                  # agreement is decided across replicas, not per-result
+    "spot_check": ("challenge_index", "revealed_cid"),
+    "tee": ("quote", "measurement"),
+    "zk": ("statement", "proof_blob"),
+}
+
+
+class MeshCoordinatorError(Exception):
+    pass
+
+
+def _fail(m: str) -> None:
+    raise MeshCoordinatorError(m)
+
+
+def _trusted_index(trusted: Any) -> dict:
+    """node_ref -> node record, admitting ONLY attested nodes (fail-closed: no attestationRef => not admitted)."""
+    idx = {}
+    for n in trusted or []:
+        if not isinstance(n, dict):
+            continue
+        ref = n.get("node_ref")
+        if str(ref or "").startswith("node://") and str(n.get("attestationRef") or "").strip():
+            idx[ref] = n
+    return idx
+
+
+def _residency_ok(policy_region: str, node_region: str) -> bool:
+    return policy_region == "any" or policy_region == node_region
+
+
+def verify_result(pack: dict, result: dict, trusted: list) -> None:
+    """Fail-closed admission of one result. Raises MeshCoordinatorError on any violation."""
+    mode = pack.get("proof_mode")
+    if mode not in PROOF_MODES:
+        _fail(f"pack.proof_mode invalid: {mode!r}")
+    if result.get("wu_id") != pack.get("wu_id"):
+        _fail("result.wu_id does not match pack.wu_id")
+
+    idx = _trusted_index(trusted)
+    node_ref = result.get("node_ref")
+    node = idx.get(node_ref)
+    if node is None:
+        _fail(f"node {node_ref!r} is not a trusted+attested mesh node (refused)")
+
+    policy = pack.get("policy") or {}
+    if not _residency_ok(policy.get("residency", "any"), result.get("region", "")):
+        _fail(f"residency violation: pack requires {policy.get('residency')!r}, node in {result.get('region')!r}")
+
+    proof = result.get("proof") or {}
+    if proof.get("mode") != mode:
+        _fail(f"proof.mode {proof.get('mode')!r} != pack.proof_mode {mode!r} (mode mismatch)")
+    for field in REQUIRED_PROOF_FIELDS[mode]:
+        if not str(proof.get(field) or "").strip() and proof.get(field) != 0:
+            _fail(f"proof for mode {mode!r} is missing required material: {field!r}")
+
+
+def reduce(pack: dict, results: list, trusted: list) -> dict:
+    """Settle a WU from its collected results. Deterministic + fail-closed. Returns a settlement receipt."""
+    mode = pack["proof_mode"]
+
+    admissible, rejected = [], []
+    for r in results or []:
+        try:
+            verify_result(pack, r, trusted)
+            admissible.append(r)
+        except MeshCoordinatorError as exc:
+            rejected.append({"node_ref": r.get("node_ref"), "reason": str(exc)})
+
+    settled = False
+    accepted_cid = None
+    method = mode
+    quorum = {"admissible": len(admissible), "rejected": len(rejected)}
+
+    if mode == "redundant":
+        need = int(pack.get("replication", 1))
+        quorum["required"] = need
+        if len(admissible) >= need:
+            tally: dict[str, int] = {}
+            for r in admissible:
+                tally[r["result_cid"]] = tally.get(r["result_cid"], 0) + 1
+            top_cid, top_n = max(tally.items(), key=lambda kv: kv[1])
+            quorum["agree"] = top_n
+            # STRICT majority of the admissible set — a tie/split is a possible sabotage, so no settlement.
+            if top_n * 2 > len(admissible):
+                settled, accepted_cid = True, top_cid
+    else:
+        # spot_check / tee / zk: verify_result already confirmed the required proof material is present.
+        if admissible:
+            accepted_cid = admissible[0]["result_cid"]
+            settled = True
+
+    # RLC credit: only nodes whose result matches the accepted CID (nothing is paid on a failed settle).
+    credited = [r["node_ref"] for r in admissible if settled and r["result_cid"] == accepted_cid]
+
+    return {
+        "wu_id": pack.get("wu_id"),
+        "settled": settled,
+        "method": method,
+        "accepted_result_cid": accepted_cid,
+        "quorum": quorum,
+        "rlc_credit": credited,
+        "rejected": rejected,
+    }
+
+
+if __name__ == "__main__":  # tiny demo on the shipped examples
+    import json
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    ex = root / "examples" / "mesh"
+    pack = json.loads((ex / "work_unit_pack.example.json").read_text())
+    results = json.loads((ex / "work_unit_results.example.json").read_text())
+    trusted = json.loads((ex / "trusted_nodes.example.json").read_text())
+    print(json.dumps(reduce(pack, results, trusted), indent=2))

--- a/schemas/jsonschema/work-unit-pack.v0.schema.json
+++ b/schemas/jsonschema/work-unit-pack.v0.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/work-unit-pack.v0.schema.json",
+  "title": "WorkUnitPack v0",
+  "description": "A federated-mesh Work-Unit pack (Dual-Orchestration plane B): the TriTRPC-enveloped descriptor a Mesh Coordinator hands to a volunteer node. Header carries the Avro SCHEMA-ID (SHA3), governance POLICY (residency/isolation/SLO), a PROOF_MODE, and a SANDBOX; the body is content-addressed (SHA-256 CID, per the FederationCryptoProfile). This is the request half; a WorkUnitResult is the returned half. Settlement is decided by reference/mesh_coordinator.py, fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["wu_id", "schema_id", "proof_mode", "sandbox", "policy", "body_cid", "replication", "context", "signature"],
+  "properties": {
+    "wu_id": { "type": "string", "minLength": 1 },
+    "schema_id": { "type": "string", "pattern": "^sha3-256:", "description": "SHA3-256 of the Avro canonical schema of the body (the SCHEMA-ID)." },
+    "proof_mode": { "type": "string", "enum": ["redundant", "spot_check", "tee", "zk"] },
+    "sandbox": { "type": "string", "enum": ["docker", "lightning", "wasm", "kata"] },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["residency", "isolation", "slo_ms"],
+      "properties": {
+        "residency": { "type": "string", "minLength": 1, "description": "required data-residency region, e.g. EU / US / any" },
+        "isolation": { "type": "string", "enum": ["strong", "standard"] },
+        "slo_ms": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "body_cid": { "type": "string", "pattern": "^sha256:", "description": "content-addressed body (SHA-256 CID; FederationCryptoProfile)." },
+    "replication": { "type": "integer", "minimum": 1, "description": "number of independent nodes the WU is dispatched to (redundant mode needs >= 3 for a majority)." },
+    "context": { "type": "string", "minLength": 1, "description": "JSON-LD @context reference for the body." },
+    "signature": { "type": "string", "minLength": 1 }
+  }
+}

--- a/schemas/jsonschema/work-unit-result.v0.schema.json
+++ b/schemas/jsonschema/work-unit-result.v0.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/work-unit-result.v0.schema.json",
+  "title": "WorkUnitResult v0",
+  "description": "A volunteer node's returned result for a WorkUnitPack. Carries the content-addressed result (SHA-256 CID), the executing node anchor, its region (checked against pack.policy.residency), and a proof block whose mode MUST match the pack's proof_mode and MUST carry that mode's required material. The Mesh Coordinator collects these and settles fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["wu_id", "node_ref", "region", "result_cid", "proof", "signature"],
+  "properties": {
+    "wu_id": { "type": "string", "minLength": 1 },
+    "node_ref": { "type": "string", "pattern": "^node://" },
+    "region": { "type": "string", "minLength": 1 },
+    "result_cid": { "type": "string", "pattern": "^sha256:" },
+    "proof": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["redundant", "spot_check", "tee", "zk"] },
+        "challenge_index": { "type": "integer", "minimum": 0 },
+        "revealed_cid": { "type": "string", "pattern": "^sha256:" },
+        "quote": { "type": "string" },
+        "measurement": { "type": "string", "pattern": "^sha256:" },
+        "statement": { "type": "string" },
+        "proof_blob": { "type": "string" }
+      }
+    },
+    "signature": { "type": "string", "minLength": 1 }
+  }
+}

--- a/spec/orchestration/mesh_work_unit.md
+++ b/spec/orchestration/mesh_work_unit.md
@@ -1,0 +1,61 @@
+# Mesh Work-Unit & Coordinator (Dual-Orchestration plane B)
+
+The Dual-Orchestration model has two planes: **(A)** governed cluster ETL (sp-orchestrator) and
+**(B)** a federated volunteer-compute mesh. This spec pins plane B's request/result contracts and the
+coordinator's **settlement** step — the part a coordinator can decide deterministically from the
+artifacts alone. The `ProjectComputeSetting` cockpit surface (socioprophet) *declares* a project's
+mesh + WU governance; this is the runtime that *settles* the units it dispatches.
+
+## Artifacts
+
+- **`WorkUnitPack`** (`schemas/jsonschema/work-unit-pack.v0.schema.json`) — the TriTRPC-enveloped
+  descriptor handed to a node. Header: `schema_id` (**SHA3-256** of the Avro canonical schema — the
+  SCHEMA-ID), `policy` (`residency` / `isolation` / `slo_ms`), `proof_mode`
+  (`redundant | spot_check | tee | zk`), `sandbox` (`docker | lightning | wasm | kata`). Body is
+  content-addressed by **SHA-256 CID** (`body_cid`), per the FederationCryptoProfile. `replication`
+  is the number of independent nodes the WU is dispatched to.
+- **`WorkUnitResult`** (`schemas/jsonschema/work-unit-result.v0.schema.json`) — a node's return:
+  `node_ref` (`node://`), `region`, `result_cid` (SHA-256 CID), and a `proof` block whose `mode`
+  MUST equal the pack's `proof_mode` and carry that mode's required material.
+
+## Coordinator lifecycle
+
+`registry → schedule → collect → **verify → reduce → settle**`. This reference implements the last
+three (`reference/mesh_coordinator.py`); registry/schedule/collect are transport/scheduling and are
+out of scope for the contract layer.
+
+### verify (per-result admission — fail-closed)
+A result is admissible only if **all** hold; any violation is refused:
+1. the node is **trusted AND attested** (no `attestationRef` ⇒ not admitted);
+2. the node's `region` satisfies `policy.residency` (`any` waives);
+3. `result.wu_id == pack.wu_id`;
+4. `proof.mode == pack.proof_mode` and the mode's required material is present
+   (`spot_check`: `challenge_index` + `revealed_cid`; `tee`: `quote` + `measurement`;
+   `zk`: `statement` + `proof_blob`; `redundant`: none — agreement is decided across replicas).
+
+### reduce / settle (deterministic)
+- **redundant** — needs ≥ `replication` admissible results; the accepted CID is the one held by a
+  **strict majority** of the admissible set. No majority (a split / suspected sabotage) ⇒ **NOT
+  settled**, no credit.
+- **spot_check / tee / zk** — `verify` has confirmed the required proof material is present and
+  well-formed; the coordinator accepts and records the result CID. Cryptographic proof-checking of a
+  TEE quote or a zk proof is **delegated to that mode's verifier** and is out of scope here (stated
+  honestly — this is a settler, not a TEE/zk verifier).
+- **RLC credit** is assigned ONLY to nodes whose `result_cid` equals the accepted CID; a failed
+  settlement pays nothing. (Redundant Labour Credit — the settlement ledger entry.)
+
+The settlement receipt is `{wu_id, settled, method, accepted_result_cid, quorum, rlc_credit, rejected}`
+and is a deterministic pure function of `(pack, results, trusted)` — reproducible and auditable.
+
+## FIPS
+
+Agreement / content-addressing is over **SHA-256 CIDs** (FIPS 180-4); SCHEMA-IDs over **SHA3**
+(FIPS 202). No non-FIPS primitive is used or required. The coordinator performs **no AEAD**; the
+owner-sealing / transport AEAD is the `CryptoProfile` lane's job — **AES-256-GCM** in a FIPS
+deployment, never XChaCha20-Poly1305. This module does not touch the tritrpc v4/vNext wire format.
+
+## Governance tie-in
+
+Every settled WU carries an attested node + a residency-checked region + a proof for its declared
+mode — the same fail-closed doctrine the `ProjectComputeSetting` validator enforces at declaration
+time ("no ungoverned compute"). No attestation, no residency match, or no majority ⇒ no settlement.

--- a/tools/verify_mesh_coordinator.py
+++ b/tools/verify_mesh_coordinator.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Verify the reference Mesh Coordinator settles Work-Units fail-closed (Dual-Orchestration plane B).
+
+Runs reference/mesh_coordinator.py on the shipped example WU pack + results + trusted nodes and asserts:
+a redundant WU whose replicas AGREE settles with all replicas credited; and then, fail-closed —
+an UNTRUSTED node, a PROOF-MODE MISMATCH, and a RESIDENCY VIOLATION are each refused; a redundant
+SPLIT (no strict majority) and INSUFFICIENT replicas do NOT settle and pay no credit; a tee result
+missing its measurement is refused. Plus determinism (identical inputs -> identical receipt). Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import mesh_coordinator as mc  # noqa: E402
+
+EX = ROOT / "examples" / "mesh"
+SCHEMAS = ROOT / "schemas" / "jsonschema"
+PACK_SCHEMA = SCHEMAS / "work-unit-pack.v0.schema.json"
+RESULT_SCHEMA = SCHEMAS / "work-unit-result.v0.schema.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(name: str):
+    return json.loads((EX / name).read_text())
+
+
+def _schema(p: Path):
+    return json.loads(p.read_text())
+
+
+def validate_schemas() -> None:
+    """Drift-guard (stdlib): the schemas and the coordinator constants must stay in lockstep."""
+    pack, res = _schema(PACK_SCHEMA), _schema(RESULT_SCHEMA)
+    for name, s in (("pack", pack), ("result", res)):
+        if s.get("additionalProperties") is not False:
+            raise mc.MeshCoordinatorError(f"{name} schema root must be strict (additionalProperties:false)")
+    pp = pack["properties"]
+    if set(pp["proof_mode"]["enum"]) != mc.PROOF_MODES:
+        raise mc.MeshCoordinatorError("pack.proof_mode enum drifted from mesh_coordinator.PROOF_MODES")
+    if set(res["properties"]["proof"]["properties"]["mode"]["enum"]) != mc.PROOF_MODES:
+        raise mc.MeshCoordinatorError("result.proof.mode enum drifted from mesh_coordinator.PROOF_MODES")
+    if pp["sandbox"]["enum"] != ["docker", "lightning", "wasm", "kata"]:
+        raise mc.MeshCoordinatorError("pack.sandbox enum drifted")
+    if pp["body_cid"].get("pattern") != "^sha256:" or pp["schema_id"].get("pattern") != "^sha3-256:":
+        raise mc.MeshCoordinatorError("pack CID/SCHEMA-ID hash prefixes drifted (SHA-256 CID / SHA3 SCHEMA-ID)")
+    if pp["policy"].get("additionalProperties") is not False:
+        raise mc.MeshCoordinatorError("pack.policy must be strict")
+    # example structural conformance — no keys outside the declared properties.
+    for rec, s in ((load("work_unit_pack.example.json"), pack),
+                   *[(r, res) for r in load("work_unit_results.example.json")]):
+        extra = set(rec) - set(s["properties"])
+        if extra:
+            raise mc.MeshCoordinatorError(f"example has keys not in schema: {sorted(extra)}")
+
+
+def refused(fn) -> bool:
+    try:
+        fn()
+        return False
+    except mc.MeshCoordinatorError:
+        return True
+
+
+def main() -> int:
+    try:
+        validate_schemas()
+        CHECKS["schema:no-drift-and-example-conformant"] = True
+    except mc.MeshCoordinatorError as exc:
+        FAILURES.append(f"schema drift-guard failed: {exc}")
+
+    pack = load("work_unit_pack.example.json")
+    results = load("work_unit_results.example.json")
+    trusted = load("trusted_nodes.example.json")
+
+    # 1. Happy path: 3 agreeing replicas settle, all 3 credited.
+    rec = mc.reduce(pack, results, trusted)
+    if rec["settled"] and rec["accepted_result_cid"] == results[0]["result_cid"] and len(rec["rlc_credit"]) == 3 and not rec["rejected"]:
+        CHECKS["redundant:agree-settles-credits-all"] = True
+    else:
+        FAILURES.append(f"agreeing redundant WU did not settle cleanly: {rec}")
+
+    # 2. Untrusted node refused.
+    r_untrusted = copy.deepcopy(results[0]); r_untrusted["node_ref"] = "node://evil-9"
+    CHECKS["fail-closed:untrusted-node-refused"] = refused(lambda: mc.verify_result(pack, r_untrusted, trusted))
+    if not CHECKS["fail-closed:untrusted-node-refused"]:
+        FAILURES.append("an untrusted node's result must be refused")
+
+    # 3. Proof-mode mismatch refused.
+    r_mode = copy.deepcopy(results[0]); r_mode["proof"] = {"mode": "zk", "statement": "s", "proof_blob": "p"}
+    CHECKS["fail-closed:proof-mode-mismatch-refused"] = refused(lambda: mc.verify_result(pack, r_mode, trusted))
+    if not CHECKS["fail-closed:proof-mode-mismatch-refused"]:
+        FAILURES.append("a proof.mode != pack.proof_mode must be refused")
+
+    # 4. Residency violation refused (pack requires EU; node reports US).
+    r_res = copy.deepcopy(results[0]); r_res["region"] = "US"
+    CHECKS["fail-closed:residency-violation-refused"] = refused(lambda: mc.verify_result(pack, r_res, trusted))
+    if not CHECKS["fail-closed:residency-violation-refused"]:
+        FAILURES.append("a residency violation must be refused")
+
+    # 5. Redundant split: 2 vs 1 => no strict majority is impossible; make a true split (1/1/1).
+    split = copy.deepcopy(results)
+    split[1]["result_cid"] = "sha256:" + "c" * 64
+    split[2]["result_cid"] = "sha256:" + "d" * 64
+    rec_split = mc.reduce(pack, split, trusted)
+    if not rec_split["settled"] and not rec_split["rlc_credit"]:
+        CHECKS["fail-closed:redundant-split-no-settle"] = True
+    else:
+        FAILURES.append(f"a redundant split must NOT settle: {rec_split}")
+
+    # 6. Insufficient replicas (only 2, replication=3) => no settle.
+    rec_few = mc.reduce(pack, results[:2], trusted)
+    if not rec_few["settled"] and not rec_few["rlc_credit"]:
+        CHECKS["fail-closed:insufficient-replicas-no-settle"] = True
+    else:
+        FAILURES.append(f"below-replication WU must NOT settle: {rec_few}")
+
+    # 7. tee mode: present quote+measurement settles; missing measurement refused.
+    tee_pack = copy.deepcopy(pack); tee_pack["proof_mode"] = "tee"; tee_pack["replication"] = 1
+    r_tee = copy.deepcopy(results[0]); r_tee["proof"] = {"mode": "tee", "quote": "q", "measurement": "sha256:" + "e" * 64}
+    rec_tee = mc.reduce(tee_pack, [r_tee], trusted)
+    r_tee_bad = copy.deepcopy(r_tee); r_tee_bad["proof"] = {"mode": "tee", "quote": "q"}
+    if rec_tee["settled"] and refused(lambda: mc.verify_result(tee_pack, r_tee_bad, trusted)):
+        CHECKS["tee:present-settles-missing-refused"] = True
+    else:
+        FAILURES.append("tee: a valid quote+measurement must settle and a missing measurement be refused")
+
+    # 8. Determinism.
+    if mc.reduce(pack, results, trusted) == rec:
+        CHECKS["deterministic:reproducible"] = True
+    else:
+        FAILURES.append("reduce is not deterministic")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Dual-Orchestration plane B — the settlement runtime

The `ProjectComputeSetting` cockpit surface (socioprophet #504) *declares* a project's mesh + WU governance. This is the runtime half that **settles** the units it dispatches — the genuinely-decidable part a coordinator can decide from the artifacts alone.

### Contracts
- **`WorkUnitPack`** — TriTRPC-enveloped descriptor: **SHA3 SCHEMA-ID**, `policy` (residency/isolation/SLO), `proof_mode` (`redundant|spot_check|tee|zk`), `sandbox` (`docker|lightning|wasm|kata`), **SHA-256** body CID, `replication`.
- **`WorkUnitResult`** — a node's return: `node://` anchor, `region`, SHA-256 result CID, and a `proof` block whose `mode` must match the pack and carry that mode's material.

### Reference coordinator (`reference/mesh_coordinator.py`) — **fail-closed**
- **verify** (per-result admission): untrusted/unattested node, residency violation, `wu_id`/proof-mode mismatch, or missing proof material ⇒ **refused**.
- **reduce/settle**: `redundant` settles only on a **strict majority** of ≥ `replication` admissible results — a split (suspected sabotage) settles nothing. **RLC credit** goes only to nodes matching the accepted CID; a failed settle pays nothing. Deterministic pure function ⇒ reproducible, auditable receipt.
- `tee`/`zk` cryptographic proof-checking is **delegated** to that mode's verifier (stated honestly — this is a settler, not a TEE/zk verifier).

### Teeth (`tools/verify_mesh_coordinator.py`, stdlib)
Agreeing redundant WU settles + credits all · untrusted / proof-mode-mismatch / residency-violation refused · split + below-replication don't settle · tee present-settles/missing-refused · determinism · **a schema drift-guard** pinning the schema enums to the coordinator constants (verified to bite when they diverge).

**FIPS:** agreement over SHA-256 CIDs (180-4), SCHEMA-ID over SHA3 (202); no non-FIPS primitive; no AEAD here (that is the `CryptoProfile` lane's AES-256-GCM). Additive — does **not** touch the v4/vNext wire.