### PR TITLE
feat(orchestration): node reputation + admission gate — who may ENTER the mesh trusted set

### DIFF
--- a/.github/workflows/validate-node-admission.yml
+++ b/.github/workflows/validate-node-admission.yml
@@ -1,0 +1,41 @@
+name: validate-node-admission
+
+on:
+  pull_request:
+    paths:
+      - "reference/node_admission.py"
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_node_admission.py"
+      - "schemas/jsonschema/node-reputation.v0.schema.json"
+      - "schemas/jsonschema/admission-policy.v0.schema.json"
+      - "examples/mesh/node_reputation.example.json"
+      - "examples/mesh/admission_policy.example.json"
+      - "spec/orchestration/node_reputation.md"
+      - ".github/workflows/validate-node-admission.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/node_admission.py"
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_node_admission.py"
+      - "schemas/jsonschema/node-reputation.v0.schema.json"
+      - "schemas/jsonschema/admission-policy.v0.schema.json"
+      - "examples/mesh/node_reputation.example.json"
+      - "examples/mesh/admission_policy.example.json"
+      - "spec/orchestration/node_reputation.md"
+      - ".github/workflows/validate-node-admission.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate node-admission gate (mesh trust, fail-closed + loop-closure)
+        run: python tools/verify_node_admission.py

--- a/examples/mesh/admission_policy.example.json
+++ b/examples/mesh/admission_policy.example.json
@@ -1,0 +1,7 @@
+{
+  "minTrust": 0.5,
+  "maxSelfOrientation": 0.4,
+  "minObservations": 30,
+  "minCivility": 0.5,
+  "requireAttestation": true
+}

--- a/examples/mesh/node_reputation.example.json
+++ b/examples/mesh/node_reputation.example.json
@@ -1,0 +1,21 @@
+{
+  "node_ref": "node://eu-1",
+  "attestationRef": "att://tpm/eu-1#quote",
+  "region": "EU",
+  "trust": {
+    "credibility": 0.9,
+    "reliability": 0.85,
+    "intimacy": 0.7,
+    "selfOrientation": 0.2
+  },
+  "energy": {
+    "knowledge": 0.8,
+    "creativity": 0.6,
+    "civility": 0.8
+  },
+  "history": {
+    "observations": 40,
+    "decayHalfLifeDays": 30
+  },
+  "sentiment": 0.3
+}

--- a/reference/node_admission.py
+++ b/reference/node_admission.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Reference node-admission gate — decides which nodes ENTER the mesh trusted set (fail-closed).
+
+This is the loop-closer for the Mesh Coordinator: reference/mesh_coordinator.py refuses any result
+from a node that is not in its `trusted` set; this module decides who gets INTO that set. It scores a
+NodeReputation with a bounded rendering of the Trust Equation and applies an AdmissionPolicy whose
+every gate must pass. On admission it emits EXACTLY the trusted-node record shape the coordinator
+consumes ({node_ref, attestationRef, region}), so an admitted reputation plugs straight in.
+
+Trust score (bounded [0,1] rendering of the classic Trust Equation T=(C+R+I)/S):
+    trust = mean(credibility, reliability, intimacy) * (1 - selfOrientation)
+Monotone: raising any of C/R/I (or lowering self-orientation) never lowers trust. History with fewer
+than the policy's minimum observations is not statistically admissible (estate default >= 30).
+
+FIPS: no cryptographic primitive is used here (pure scoring); attestation VERIFICATION is delegated
+to the attestation lane — this gate only requires that an attestationRef is PRESENT when the policy
+demands it. Does not touch the tritrpc v4/vNext wire format.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class AdmissionError(Exception):
+    pass
+
+
+def trust_score(rep: dict) -> float:
+    """Bounded Trust-Equation score in [0,1]."""
+    t = rep["trust"]
+    mean_cri = (t["credibility"] + t["reliability"] + t["intimacy"]) / 3.0
+    return mean_cri * (1.0 - t["selfOrientation"])
+
+
+def admit(rep: dict, policy: dict) -> dict:
+    """Decide admission. Returns {admitted, node_ref, trustScore, reasons, trustedNode?}. Fail-closed:
+    a malformed reputation raises AdmissionError; a well-formed but under-qualified one is NOT admitted
+    (admitted:false) with the failing reasons. Only a fully-passing node yields a trustedNode record."""
+    for key in ("node_ref", "attestationRef", "region", "trust", "energy", "history"):
+        if key not in rep:
+            raise AdmissionError(f"reputation missing required field: {key!r}")
+    if not str(rep["node_ref"]).startswith("node://"):
+        raise AdmissionError("node_ref must use the node:// URI shape")
+
+    score = trust_score(rep)
+    reasons: list[str] = []
+
+    if policy.get("requireAttestation") and not str(rep.get("attestationRef") or "").strip():
+        reasons.append("no attestation presented (policy requires attestation)")
+    obs = rep["history"]["observations"]
+    if obs < policy["minObservations"]:
+        reasons.append(f"insufficient history: {obs} observations < minimum {policy['minObservations']}")
+    if rep["trust"]["selfOrientation"] > policy["maxSelfOrientation"]:
+        reasons.append(f"self-orientation {rep['trust']['selfOrientation']} exceeds max {policy['maxSelfOrientation']}")
+    if rep["energy"]["civility"] < policy["minCivility"]:
+        reasons.append(f"civility {rep['energy']['civility']} below floor {policy['minCivility']} (abuse guard)")
+    if score < policy["minTrust"]:
+        reasons.append(f"trust score {score:.4f} < minimum {policy['minTrust']}")
+
+    admitted = not reasons
+    out: dict[str, Any] = {
+        "admitted": admitted,
+        "node_ref": rep["node_ref"],
+        "trustScore": round(score, 4),
+        "reasons": reasons,
+    }
+    if admitted:
+        # the exact record shape reference/mesh_coordinator.py's trusted set consumes.
+        out["trustedNode"] = {
+            "node_ref": rep["node_ref"],
+            "attestationRef": rep["attestationRef"],
+            "region": rep["region"],
+        }
+    return out
+
+
+if __name__ == "__main__":  # demo: admit the shipped example, then feed the coordinator
+    import json
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    ex = root / "examples" / "mesh"
+    rep = json.loads((ex / "node_reputation.example.json").read_text())
+    policy = json.loads((ex / "admission_policy.example.json").read_text())
+    print(json.dumps(admit(rep, policy), indent=2))

--- a/schemas/jsonschema/admission-policy.v0.schema.json
+++ b/schemas/jsonschema/admission-policy.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/admission-policy.v0.schema.json",
+  "title": "AdmissionPolicy v0",
+  "description": "The fail-closed thresholds a NodeReputation must clear to be admitted to the mesh trusted set. Every gate must pass; any failure refuses admission.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["minTrust", "maxSelfOrientation", "minObservations", "minCivility", "requireAttestation"],
+  "properties": {
+    "minTrust": { "type": "number", "minimum": 0, "maximum": 1 },
+    "maxSelfOrientation": { "type": "number", "minimum": 0, "maximum": 1 },
+    "minObservations": { "type": "integer", "minimum": 1, "description": "statistical-significance floor (estate default >= 30)." },
+    "minCivility": { "type": "number", "minimum": 0, "maximum": 1, "description": "hard abuse floor — a low-civility node is refused regardless of trust." },
+    "requireAttestation": { "type": "boolean" }
+  }
+}

--- a/schemas/jsonschema/node-reputation.v0.schema.json
+++ b/schemas/jsonschema/node-reputation.v0.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/node-reputation.v0.schema.json",
+  "title": "NodeReputation v0",
+  "description": "Anonymous-but-transparent reputation for a mesh node — the admission gate that decides which nodes may ENTER the trusted set the Mesh Coordinator checks. Renders the Trust Equation (credibility/reliability/intimacy over self-orientation) plus an energy spectrum (knowledge/creativity/civility) and an observation history with time-decay. A pseudonymous node_ref carries reputation without identity. Admission is decided fail-closed by reference/node_admission.py.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["node_ref", "attestationRef", "region", "trust", "energy", "history"],
+  "properties": {
+    "node_ref": { "type": "string", "pattern": "^node://" },
+    "attestationRef": { "type": "string", "minLength": 1, "description": "attestation the node presented (TPM quote etc.)" },
+    "region": { "type": "string", "minLength": 1 },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["credibility", "reliability", "intimacy", "selfOrientation"],
+      "properties": {
+        "credibility": { "type": "number", "minimum": 0, "maximum": 1 },
+        "reliability": { "type": "number", "minimum": 0, "maximum": 1 },
+        "intimacy": { "type": "number", "minimum": 0, "maximum": 1 },
+        "selfOrientation": { "type": "number", "minimum": 0, "maximum": 1, "description": "Trust-Equation denominator — HIGH self-orientation lowers trust." }
+      }
+    },
+    "energy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["knowledge", "creativity", "civility"],
+      "properties": {
+        "knowledge": { "type": "number", "minimum": 0, "maximum": 1 },
+        "creativity": { "type": "number", "minimum": 0, "maximum": 1 },
+        "civility": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "history": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observations", "decayHalfLifeDays"],
+      "properties": {
+        "observations": { "type": "integer", "minimum": 0, "description": "settled/verified interactions backing the scores." },
+        "decayHalfLifeDays": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    },
+    "sentiment": { "type": "number", "minimum": -1, "maximum": 1, "description": "optional anonymized sentiment signal." }
+  }
+}

--- a/spec/orchestration/node_reputation.md
+++ b/spec/orchestration/node_reputation.md
@@ -1,0 +1,47 @@
+# Node Reputation & Admission (mesh trust gate)
+
+The Mesh Coordinator (`spec/orchestration/mesh_work_unit.md`) refuses any result from a node not in
+its `trusted` set. **This spec decides who gets INTO that set.** It is the admission gate for the
+federated volunteer mesh — anonymous but transparent: a pseudonymous `node_ref` carries reputation
+without identity.
+
+## Reputation (`schemas/jsonschema/node-reputation.v0.schema.json`)
+
+- **Trust** — the Trust Equation dimensions: `credibility`, `reliability`, `intimacy`, and
+  `selfOrientation` (the denominator — high self-orientation *lowers* trust). Each in `[0,1]`.
+- **Energy spectrum** — `knowledge`, `creativity`, `civility` (each `[0,1]`). `civility` is a hard
+  abuse floor at admission.
+- **History** — `observations` (settled/verified interactions backing the scores) and a
+  `decayHalfLifeDays` for time-decay. Optional anonymized `sentiment`.
+- `attestationRef` + `region` travel with the reputation so an admitted node is immediately a
+  coordinator-ready trusted-node record.
+
+## Trust score (bounded rendering of `T=(C+R+I)/S`)
+
+```
+trust = mean(credibility, reliability, intimacy) * (1 - selfOrientation)   # in [0,1]
+```
+
+Monotone: raising any of C/R/I — or lowering self-orientation — never lowers trust. A bounded form is
+used so scores compose and threshold cleanly; the ranking is the classic Trust Equation's.
+
+## Admission (`schemas/jsonschema/admission-policy.v0.schema.json`) — fail-closed
+
+`reference/node_admission.py:admit(rep, policy)` admits a node **only if every gate passes**:
+
+1. attestation present (when `requireAttestation`);
+2. `observations >= minObservations` (statistical-significance floor — estate default **>= 30**);
+3. `selfOrientation <= maxSelfOrientation`;
+4. `civility >= minCivility` (abuse guard — a low-civility node is refused **regardless** of trust);
+5. `trust >= minTrust`.
+
+Any failure ⇒ `admitted:false` with the failing reasons; only a fully-passing node yields a
+`trustedNode` record `{node_ref, attestationRef, region}` — **exactly** the shape
+`reference/mesh_coordinator.py` consumes. The verifier proves the loop: an admitted node's record
+plugs into the coordinator and its WU result settles.
+
+## FIPS / boundary
+
+No cryptographic primitive is used here (pure scoring). Attestation **verification** is delegated to
+the attestation lane; this gate only requires an `attestationRef` be present when the policy demands
+it. Does not touch the tritrpc v4/vNext wire format.

--- a/tools/verify_node_admission.py
+++ b/tools/verify_node_admission.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Verify the reference node-admission gate is fail-closed AND closes the loop into the coordinator.
+
+Runs reference/node_admission.py on the shipped example reputation + policy and asserts: a qualified
+node is admitted and yields a trustedNode record; that record plugs straight into
+reference/mesh_coordinator.py (an admitted node's WU result settles) — the loop-closure proof; and
+then, fail-closed — unattested, under-observed (n<min), self-oriented, low-civility, and below-trust
+reputations are each NOT admitted with the right reason. Plus trust monotonicity, determinism, and a
+schema drift-guard. Stdlib, repo convention.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import node_admission as na  # noqa: E402
+import mesh_coordinator as mc  # noqa: E402
+
+EX = ROOT / "examples" / "mesh"
+SCHEMAS = ROOT / "schemas" / "jsonschema"
+REP_SCHEMA = SCHEMAS / "node-reputation.v0.schema.json"
+POL_SCHEMA = SCHEMAS / "admission-policy.v0.schema.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(name: str):
+    return json.loads((EX / name).read_text())
+
+
+def not_admitted_for(rep, policy, needle: str) -> bool:
+    d = na.admit(rep, policy)
+    return (not d["admitted"]) and any(needle in r for r in d["reasons"])
+
+
+def validate_schemas() -> None:
+    rep = json.loads(REP_SCHEMA.read_text())
+    pol = json.loads(POL_SCHEMA.read_text())
+    for name, s in (("reputation", rep), ("policy", pol)):
+        if s.get("additionalProperties") is not False:
+            raise na.AdmissionError(f"{name} schema root must be strict")
+    if set(rep["properties"]["trust"]["required"]) != {"credibility", "reliability", "intimacy", "selfOrientation"}:
+        raise na.AdmissionError("reputation.trust.required drifted from the Trust-Equation dimensions")
+    if set(rep["properties"]["energy"]["required"]) != {"knowledge", "creativity", "civility"}:
+        raise na.AdmissionError("reputation.energy.required drifted")
+    need_pol = {"minTrust", "maxSelfOrientation", "minObservations", "minCivility", "requireAttestation"}
+    if set(pol["required"]) != need_pol:
+        raise na.AdmissionError("admission-policy.required drifted from the enforced gates")
+    # example conformance: no keys outside declared properties.
+    for rec, s in ((load("node_reputation.example.json"), rep), (load("admission_policy.example.json"), pol)):
+        extra = set(rec) - set(s["properties"])
+        if extra:
+            raise na.AdmissionError(f"example has keys not in schema: {sorted(extra)}")
+
+
+def main() -> int:
+    try:
+        validate_schemas()
+        CHECKS["schema:no-drift-and-example-conformant"] = True
+    except na.AdmissionError as exc:
+        FAILURES.append(f"schema drift-guard failed: {exc}")
+
+    rep = load("node_reputation.example.json")
+    policy = load("admission_policy.example.json")
+
+    # 1. Qualified node admitted + emits a trustedNode record.
+    d = na.admit(rep, policy)
+    if d["admitted"] and d.get("trustedNode", {}).get("node_ref") == rep["node_ref"] and not d["reasons"]:
+        CHECKS["admit:qualified-node-admitted"] = True
+    else:
+        FAILURES.append(f"qualified node was not admitted cleanly: {d}")
+
+    # 2. LOOP CLOSURE: the admitted trustedNode plugs into the coordinator and a result settles.
+    trusted = [d["trustedNode"]] if d["admitted"] else []
+    pack = {"wu_id": "wu-x", "proof_mode": "tee", "sandbox": "wasm",
+            "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 1000},
+            "replication": 1}
+    result = {"wu_id": "wu-x", "node_ref": rep["node_ref"], "region": rep["region"],
+              "result_cid": "sha256:" + "a" * 64,
+              "proof": {"mode": "tee", "quote": "q", "measurement": "sha256:" + "b" * 64}}
+    rec = mc.reduce(pack, [result], trusted)
+    if rec["settled"] and rec["rlc_credit"] == [rep["node_ref"]]:
+        CHECKS["loop:admitted-node-settles-in-coordinator"] = True
+    else:
+        FAILURES.append(f"admitted node did not settle in the coordinator: {rec}")
+
+    # 3-7. Fail-closed refusals (each mutates one dimension).
+    no_att = copy.deepcopy(rep); no_att["attestationRef"] = ""
+    CHECKS["fail-closed:unattested-refused"] = not_admitted_for(no_att, policy, "no attestation")
+    few = copy.deepcopy(rep); few["history"]["observations"] = 10
+    CHECKS["fail-closed:under-observed-refused"] = not_admitted_for(few, policy, "insufficient history")
+    selfish = copy.deepcopy(rep); selfish["trust"]["selfOrientation"] = 0.9
+    CHECKS["fail-closed:self-oriented-refused"] = not_admitted_for(selfish, policy, "self-orientation")
+    rude = copy.deepcopy(rep); rude["energy"]["civility"] = 0.1
+    CHECKS["fail-closed:low-civility-refused"] = not_admitted_for(rude, policy, "civility")
+    weak = copy.deepcopy(rep)
+    weak["trust"].update(credibility=0.2, reliability=0.2, intimacy=0.2)
+    CHECKS["fail-closed:below-trust-refused"] = not_admitted_for(weak, policy, "trust score")
+    for k in ("fail-closed:unattested-refused", "fail-closed:under-observed-refused",
+              "fail-closed:self-oriented-refused", "fail-closed:low-civility-refused", "fail-closed:below-trust-refused"):
+        if not CHECKS[k]:
+            FAILURES.append(f"{k} did not fire")
+
+    # 8. Monotonicity: raising credibility never lowers the trust score.
+    prev = -1.0
+    mono = True
+    for c in [i / 20 for i in range(21)]:
+        r = copy.deepcopy(rep); r["trust"]["credibility"] = c
+        s = na.trust_score(r)
+        if s + 1e-12 < prev:
+            mono = False
+            break
+        prev = s
+    CHECKS["monotone:credibility-nondecreasing"] = mono
+    if not mono:
+        FAILURES.append("trust score is not monotone non-decreasing in credibility")
+
+    # 9. Determinism.
+    if na.admit(rep, policy) == d:
+        CHECKS["deterministic:reproducible"] = True
+    else:
+        FAILURES.append("admit is not deterministic")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The admission gate that closes the coordinator loop

The Mesh Coordinator (#87) refuses any result from a node not in its `trusted` set. **This decides who gets INTO that set** — the missing gate on mesh node admission. Anonymous but transparent: a pseudonymous `node_ref` carries reputation without identity.

### Contracts
- **`NodeReputation`** — Trust-Equation dimensions (`credibility`/`reliability`/`intimacy` over `selfOrientation`), an energy spectrum (`knowledge`/`creativity`/`civility`), observation history with time-decay, + `attestationRef`/`region`.
- **`AdmissionPolicy`** — the fail-closed thresholds.

### Reference gate (`reference/node_admission.py`)
`trust = mean(C,R,I) * (1 - selfOrientation)` — a bounded `[0,1]` rendering of the classic `T=(C+R+I)/S`, **monotone**. `admit()` passes **only if every gate holds**: attestation present · `observations >= min` (estate default **≥ 30**) · self-orientation ≤ max · **civility ≥ floor** (abuse guard — refused regardless of trust) · trust ≥ min. On admission it emits **exactly** the `{node_ref, attestationRef, region}` record the coordinator consumes.

### Teeth (`tools/verify_node_admission.py`, stdlib) — 10 checks
Qualified node admitted · **loop closure** (the admitted record plugs into `mesh_coordinator` and a WU result settles) · unattested / under-observed / self-oriented / low-civility / below-trust each refused with the right reason · **trust monotonicity** · determinism · a **schema drift-guard** pinning the Trust-Equation + policy-gate fields.

**FIPS:** pure scoring, no primitive; attestation *verification* delegated to the attestation lane (this gate only requires an `attestationRef` be present). Additive — does **not** touch the v4/vNext wire. Renders mockup image 2 (the reputation trust graph) as an enforceable admission contract.