### PR TITLE
feat(orchestration): WU Avro body schema + reproducible SCHEMA-ID / body-CID

### DIFF
--- a/.github/workflows/validate-avro-schema-id.yml
+++ b/.github/workflows/validate-avro-schema-id.yml
@@ -1,0 +1,31 @@
+name: validate-avro-schema-id
+on:
+  pull_request:
+    paths:
+      - "reference/avro_canonical.py"
+      - "tools/verify_avro_schema_id.py"
+      - "schemas/avro/work_unit_body.v0.avsc"
+      - "fixtures/mesh/work_unit_schema_id.vector.json"
+      - "spec/orchestration/schema_id.md"
+      - ".github/workflows/validate-avro-schema-id.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/avro_canonical.py"
+      - "tools/verify_avro_schema_id.py"
+      - "schemas/avro/work_unit_body.v0.avsc"
+      - "fixtures/mesh/work_unit_schema_id.vector.json"
+      - "spec/orchestration/schema_id.md"
+      - ".github/workflows/validate-avro-schema-id.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Recompute + verify mesh SCHEMA-ID / body-CID
+        run: python tools/verify_avro_schema_id.py

--- a/fixtures/mesh/work_unit_schema_id.vector.json
+++ b/fixtures/mesh/work_unit_schema_id.vector.json
@@ -1,0 +1,19 @@
+{
+  "avro_schema": "schemas/avro/work_unit_body.v0.avsc",
+  "pcf": "{\"name\":\"socioprophet.mesh.v0.WorkUnitBody\",\"type\":\"record\",\"fields\":[{\"name\":\"wu_id\",\"type\":\"string\"},{\"name\":\"op\",\"type\":{\"name\":\"socioprophet.mesh.v0.WorkUnitOp\",\"type\":\"enum\",\"symbols\":[\"map\",\"reduce\",\"embed\",\"score\"]}},{\"name\":\"inputs\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},{\"name\":\"params\",\"type\":{\"type\":\"map\",\"values\":\"string\"}},{\"name\":\"deadline_ms\",\"type\":\"long\"},{\"name\":\"checksum\",\"type\":[\"null\",\"string\"]}]}",
+  "schema_id": "sha3-256:723a9cb044d097f4d6173938d119748039230ce0c52cbd9bc8ad98f6bce07a03",
+  "body": {
+    "wu_id": "wu-2026-08-03-0001",
+    "op": "embed",
+    "inputs": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ],
+    "params": {
+      "model": "bge-small",
+      "dim": "384"
+    },
+    "deadline_ms": 30000,
+    "checksum": null
+  },
+  "body_cid": "sha256:353d9f1b495af4525974eed6c3ae40c5bfb3170a9bd8724fc01a7cbf7705960b"
+}

--- a/reference/avro_canonical.py
+++ b/reference/avro_canonical.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Avro Parsing Canonical Form (PCF) + the mesh SCHEMA-ID / body-CID — recompute, don't trust.
+
+A WorkUnitPack's `schema_id` is defined as SHA3-256 of the Avro *Parsing Canonical Form* of its body
+schema (the SCHEMA-ID), and its `body_cid` as SHA-256 of the body's canonical serialization. Both must
+be REPRODUCIBLE by any node from the artifacts alone — otherwise two honest nodes could disagree on
+what they computed. This module implements PCF (the subset the mesh uses: records, enums, arrays,
+maps, unions, primitives) per the Avro spec transformations PRIMITIVES/FULLNAMES/STRIP/ORDER/STRINGS,
+then the two content hashes.
+
+FIPS: SCHEMA-ID over SHA3-256 (FIPS 202), body CID over SHA-256 (FIPS 180-4) — both approved. The
+body CID here is over the body's canonical JSON (JCS-style: sorted keys, no whitespace) as a
+dependency-free stand-in for Avro binary; the invariant that matters is that all honest nodes derive
+the SAME cid from the SAME body, which canonical JSON guarantees. Does not touch the v4/vNext wire.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+PRIMITIVES = {"null", "boolean", "int", "long", "float", "double", "bytes", "string"}
+# Per PCF [ORDER]: name, type, fields, symbols, items, values, size.
+_ORDER = ["name", "type", "fields", "symbols", "items", "values", "size"]
+
+
+def _fullname(node: dict, enclosing_ns: str | None) -> str:
+    name = node["name"]
+    if "." in name:
+        return name
+    ns = node.get("namespace", enclosing_ns)
+    return f"{ns}.{name}" if ns else name
+
+
+def canonical_form(schema: Any, enclosing_ns: str | None = None) -> str:
+    """Return the Avro Parsing Canonical Form string of a schema."""
+    if isinstance(schema, str):
+        return json.dumps(schema)  # a primitive or a named-type reference (already a fullname)
+    if isinstance(schema, list):  # union
+        return "[" + ",".join(canonical_form(s, enclosing_ns) for s in schema) + "]"
+    if not isinstance(schema, dict):
+        raise ValueError(f"not an Avro schema: {schema!r}")
+
+    t = schema.get("type")
+    if t in PRIMITIVES and set(schema) <= {"type"} | set(_ORDER) and "name" not in schema:
+        return json.dumps(t)
+
+    if t in ("record", "error", "enum", "fixed"):
+        ns = schema.get("namespace", enclosing_ns)
+        parts = [f'"name":{json.dumps(_fullname(schema, enclosing_ns))}', f'"type":{json.dumps(t)}']
+        if t in ("record", "error"):
+            fields = []
+            for f in schema["fields"]:
+                fields.append('{"name":' + json.dumps(f["name"]) + ',"type":' + canonical_form(f["type"], ns) + "}")
+            parts.append('"fields":[' + ",".join(fields) + "]")
+        elif t == "enum":
+            parts.append('"symbols":[' + ",".join(json.dumps(s) for s in schema["symbols"]) + "]")
+        elif t == "fixed":
+            parts.append(f'"size":{int(schema["size"])}')
+        return "{" + ",".join(parts) + "}"
+
+    if t == "array":
+        return '{"type":"array","items":' + canonical_form(schema["items"], enclosing_ns) + "}"
+    if t == "map":
+        return '{"type":"map","values":' + canonical_form(schema["values"], enclosing_ns) + "}"
+    # a wrapped primitive with extra attrs: {"type":"string", ...} -> "string"
+    if t in PRIMITIVES:
+        return json.dumps(t)
+    raise ValueError(f"unsupported Avro type: {t!r}")
+
+
+def schema_id(schema: Any) -> str:
+    """SCHEMA-ID = sha3-256: of the Parsing Canonical Form bytes."""
+    pcf = canonical_form(schema).encode("utf-8")
+    return "sha3-256:" + hashlib.sha3_256(pcf).hexdigest()
+
+
+def _canonical_json(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def body_cid(body: Any) -> str:
+    """body_cid = sha256: of the body's canonical JSON serialization."""
+    return "sha256:" + hashlib.sha256(_canonical_json(body)).hexdigest()
+
+
+if __name__ == "__main__":
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    schema = json.loads((root / "schemas/avro/work_unit_body.v0.avsc").read_text())
+    print("PCF:", canonical_form(schema))
+    print("schema_id:", schema_id(schema))

--- a/schemas/avro/work_unit_body.v0.avsc
+++ b/schemas/avro/work_unit_body.v0.avsc
@@ -1,0 +1,14 @@
+{
+  "type": "record",
+  "name": "WorkUnitBody",
+  "namespace": "socioprophet.mesh.v0",
+  "doc": "The Avro body a WorkUnitPack references by SCHEMA-ID (SHA3-256 of this schema's Parsing Canonical Form) and by body_cid (SHA-256 of the canonical body). A concrete map/compute unit dispatched to a volunteer node.",
+  "fields": [
+    { "name": "wu_id", "type": "string" },
+    { "name": "op", "type": { "type": "enum", "name": "WorkUnitOp", "symbols": ["map", "reduce", "embed", "score"] } },
+    { "name": "inputs", "type": { "type": "array", "items": "string" }, "doc": "input CIDs" },
+    { "name": "params", "type": { "type": "map", "values": "string" } },
+    { "name": "deadline_ms", "type": "long" },
+    { "name": "checksum", "type": ["null", "string"], "default": null }
+  ]
+}

--- a/spec/orchestration/schema_id.md
+++ b/spec/orchestration/schema_id.md
@@ -1,0 +1,27 @@
+# Mesh SCHEMA-ID & body-CID (reproducible content addresses)
+
+A `WorkUnitPack` carries a `schema_id` and a `body_cid`. For the mesh to work, both must be
+**reproducible** — two honest nodes must derive the same values from the same artifacts, or they
+could not agree on what they computed. This spec pins how they are derived and ships a recompute
+vector.
+
+## SCHEMA-ID = `sha3-256:` of the Avro Parsing Canonical Form
+
+The body's Avro schema (`schemas/avro/work_unit_body.v0.avsc`) is reduced to its **Parsing Canonical
+Form** (PCF) per the Avro spec — PRIMITIVES / FULLNAMES / STRIP / ORDER / STRINGS: names become
+fullnames, only `name/type/fields/symbols/items/values/size` are kept (doc, aliases, defaults,
+logical types stripped), object keys are ordered, and whitespace removed. The SCHEMA-ID is
+**SHA3-256** (FIPS 202) of the PCF bytes. Consequence, proven by the verifier: adding `doc`/`default`
+noise does **not** change the SCHEMA-ID, but reordering fields or changing an enum symbol **does** —
+the id tracks structure, not cosmetics.
+
+## body-CID = `sha256:` of the canonical body
+
+`body_cid` is **SHA-256** (FIPS 180-4) of the body's canonical JSON (sorted keys, no whitespace) — a
+dependency-free stand-in for Avro binary; the invariant that matters is that all honest nodes derive
+the same CID from the same body, so it is key-order invariant but content sensitive.
+
+`reference/avro_canonical.py` implements PCF + both hashes; `fixtures/mesh/work_unit_schema_id.vector.json`
+records `{pcf, schema_id, body, body_cid}` and `tools/verify_avro_schema_id.py` **recomputes** them
+(recompute-don't-trust) and proves the invariance/sensitivity properties. Both primitives are
+FIPS-approved; this does not touch the tritrpc v4/vNext wire format.

--- a/tools/verify_avro_schema_id.py
+++ b/tools/verify_avro_schema_id.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Verify the mesh SCHEMA-ID / body-CID are reproducible and PCF is correct (recompute, don't trust).
+
+Recomputes the WorkUnitBody's SCHEMA-ID (SHA3-256 of the Avro Parsing Canonical Form) and the example
+body's CID (SHA-256 of canonical JSON) from the schema/body alone and asserts they equal the recorded
+vector. Then proves PCF behaviour: adding doc/default/namespace noise does NOT change the SCHEMA-ID
+(STRIP), while reordering fields or changing an enum symbol DOES (structure is significant); and the
+body CID is invariant to JSON key order but changes with the body. Stdlib, repo convention.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import avro_canonical as ac  # noqa: E402
+
+AVSC = ROOT / "schemas" / "avro" / "work_unit_body.v0.avsc"
+VECTOR = ROOT / "fixtures" / "mesh" / "work_unit_schema_id.vector.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def main() -> int:
+    schema = json.loads(AVSC.read_text())
+    vec = json.loads(VECTOR.read_text())
+
+    # 1. Recompute-don't-trust: PCF, SCHEMA-ID, body CID all match the recorded vector.
+    if ac.canonical_form(schema) == vec["pcf"] and ac.schema_id(schema) == vec["schema_id"]:
+        CHECKS["recompute:schema-id-matches-vector"] = True
+    else:
+        FAILURES.append("recomputed SCHEMA-ID / PCF does not match the vector")
+    if ac.body_cid(vec["body"]) == vec["body_cid"]:
+        CHECKS["recompute:body-cid-matches-vector"] = True
+    else:
+        FAILURES.append("recomputed body CID does not match the vector")
+
+    # 2. FIPS prefixes.
+    if vec["schema_id"].startswith("sha3-256:") and vec["body_cid"].startswith("sha256:"):
+        CHECKS["fips:sha3-schema-id-sha256-cid"] = True
+    else:
+        FAILURES.append("SCHEMA-ID must be sha3-256: and body CID sha256:")
+
+    # 3. STRIP: doc/default/namespace-restated noise does NOT change the SCHEMA-ID.
+    noisy = copy.deepcopy(schema)
+    noisy["doc"] = "totally different doc"
+    noisy["fields"][0]["doc"] = "noise"
+    noisy["fields"][-1]["default"] = None  # already null; restating a default must be stripped
+    if ac.schema_id(noisy) == vec["schema_id"]:
+        CHECKS["pcf:strips-doc-default"] = True
+    else:
+        FAILURES.append("PCF did not strip doc/default — SCHEMA-ID changed under cosmetic noise")
+
+    # 4. SENSITIVITY: reordering fields changes the SCHEMA-ID (field order is significant in Avro).
+    reordered = copy.deepcopy(schema)
+    reordered["fields"] = list(reversed(reordered["fields"]))
+    changed_symbol = copy.deepcopy(schema)
+    changed_symbol["fields"][1]["type"]["symbols"] = ["map", "reduce", "embed", "rank"]
+    if ac.schema_id(reordered) != vec["schema_id"] and ac.schema_id(changed_symbol) != vec["schema_id"]:
+        CHECKS["pcf:sensitive-to-structure"] = True
+    else:
+        FAILURES.append("SCHEMA-ID must change when field order or an enum symbol changes")
+
+    # 5. body CID: invariant to JSON key order, sensitive to content.
+    rekeyed = {k: vec["body"][k] for k in reversed(list(vec["body"]))}
+    mutated = copy.deepcopy(vec["body"]); mutated["deadline_ms"] = 1
+    if ac.body_cid(rekeyed) == vec["body_cid"] and ac.body_cid(mutated) != vec["body_cid"]:
+        CHECKS["cid:key-order-invariant-content-sensitive"] = True
+    else:
+        FAILURES.append("body CID must be key-order invariant but content sensitive")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Concrete, reproducible content addresses for the mesh

A `WorkUnitPack` carries `schema_id` + `body_cid` — until now opaque placeholders. For the mesh to settle, two honest nodes must derive the **same** values from the same artifacts, so this pins how they're computed and ships a **recompute vector**.

- **`WorkUnitBody`** (`schemas/avro/work_unit_body.v0.avsc`) — a concrete map/reduce/embed/score unit.
- **`reference/avro_canonical.py`** — the Avro **Parsing Canonical Form** (PRIMITIVES/FULLNAMES/STRIP/ORDER/STRINGS) for the subset the mesh uses, then **SCHEMA-ID = SHA3-256(PCF)** and **body_cid = SHA-256(canonical body)**.
- **`tools/verify_avro_schema_id.py`** — **recomputes** everything (recompute-don't-trust) and proves: PCF is invariant to `doc`/`default` noise but **sensitive** to field order / enum symbols; the body CID is key-order invariant but content sensitive. 6 checks.

**FIPS:** SCHEMA-ID over SHA3-256 (202), body CID over SHA-256 (180-4) — both approved. Additive — does **not** touch the v4/vNext wire.