### PR TITLE
feat(orchestration): proof-envelope pre-check — bind + route tee/zk proofs (anti-replay, fail-closed)

### DIFF
--- a/.github/workflows/validate-proof-envelope.yml
+++ b/.github/workflows/validate-proof-envelope.yml
@@ -1,0 +1,31 @@
+name: validate-proof-envelope
+on:
+  pull_request:
+    paths:
+      - "reference/proof_envelope.py"
+      - "tools/verify_proof_envelope.py"
+      - "schemas/jsonschema/proof-envelope.v0.schema.json"
+      - "examples/mesh/proof_envelope.*.json"
+      - "spec/orchestration/proof_envelope.md"
+      - ".github/workflows/validate-proof-envelope.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/proof_envelope.py"
+      - "tools/verify_proof_envelope.py"
+      - "schemas/jsonschema/proof-envelope.v0.schema.json"
+      - "examples/mesh/proof_envelope.*.json"
+      - "spec/orchestration/proof_envelope.md"
+      - ".github/workflows/validate-proof-envelope.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate proof-envelope pre-check (tee/zk bind + route, fail-closed)
+        run: python tools/verify_proof_envelope.py

--- a/examples/mesh/proof_envelope.tee.example.json
+++ b/examples/mesh/proof_envelope.tee.example.json
@@ -1,0 +1,12 @@
+{
+  "mode": "tee",
+  "binding": {
+    "wu_id": "wu-x",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "material": {
+    "quote": "BASE64QUOTE",
+    "measurement": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "nonce": "n-2026-08-03"
+  }
+}

--- a/examples/mesh/proof_envelope.zk.example.json
+++ b/examples/mesh/proof_envelope.zk.example.json
@@ -1,0 +1,15 @@
+{
+  "mode": "zk",
+  "binding": {
+    "wu_id": "wu-x",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "material": {
+    "scheme": "groth16",
+    "statement": "result==f(inputs)",
+    "proof": "BASE64PROOF",
+    "publicInputs": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ]
+  }
+}

--- a/reference/proof_envelope.py
+++ b/reference/proof_envelope.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Reference proof-envelope pre-check — bind a tee/zk proof to its result and route it (fail-closed).
+
+The Mesh Coordinator delegates the CRYPTOGRAPHIC verification of tee/zk proofs to their verifiers.
+Before it can delegate, it must (a) confirm the envelope is well-formed for its mode, and (b) confirm
+the proof is BOUND to exactly the result it is settling — a proof carrying binding {wu_id, result_cid}
+for another result must be refused, or a node could replay a valid proof against a different result.
+This module is that boundary: it validates + binds and returns a delegation ticket naming the verifier
+the coordinator MUST call. It does NOT check the cryptography (stated honestly).
+
+FIPS: no primitive here (structural). measurement/result_cid are SHA-256 (FIPS 180-4). The delegated
+TEE-quote / zk verifier is responsible for the cryptographic check. Does not touch the v4/vNext wire.
+"""
+from __future__ import annotations
+
+ZK_SCHEMES = {"groth16", "plonk", "stark"}
+
+
+class ProofEnvelopeError(Exception):
+    pass
+
+
+def _fail(m: str) -> None:
+    raise ProofEnvelopeError(m)
+
+
+def precheck(envelope: dict, pack: dict, result: dict) -> dict:
+    """Validate + bind a proof envelope against the WU pack and the result it settles.
+    Returns a delegation ticket {mode, verifier, wu_id, result_cid}. Fail-closed."""
+    mode = envelope.get("mode")
+    if mode not in ("tee", "zk"):
+        _fail(f"proof mode must be tee|zk, got {mode!r}")
+    if mode != pack.get("proof_mode"):
+        _fail(f"envelope mode {mode!r} != pack.proof_mode {pack.get('proof_mode')!r}")
+
+    binding = envelope.get("binding") or {}
+    # Anti-replay: the proof must be bound to THIS wu + THIS result, not any other.
+    if binding.get("wu_id") != pack.get("wu_id"):
+        _fail("binding.wu_id does not match the pack (proof bound to a different WU — refused)")
+    if binding.get("result_cid") != result.get("result_cid"):
+        _fail("binding.result_cid does not match the result (replayed proof — refused)")
+
+    m = envelope.get("material") or {}
+    if mode == "tee":
+        for field in ("quote", "measurement", "nonce"):  # nonce = freshness (anti-replay of the quote itself)
+            if not str(m.get(field) or "").strip():
+                _fail(f"tee envelope missing required material: {field!r}")
+        verifier = "tee-quote-verifier"
+    else:
+        scheme = m.get("scheme")
+        if scheme not in ZK_SCHEMES:
+            _fail(f"zk scheme must be one of {sorted(ZK_SCHEMES)}, got {scheme!r}")
+        for field in ("statement", "proof"):
+            if not str(m.get(field) or "").strip():
+                _fail(f"zk envelope missing required material: {field!r}")
+        verifier = f"zk-{scheme}-verifier"
+
+    return {"mode": mode, "verifier": verifier,
+            "wu_id": binding["wu_id"], "result_cid": binding["result_cid"]}
+
+
+if __name__ == "__main__":
+    import json
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    ex = root / "examples" / "mesh"
+    env = json.loads((ex / "proof_envelope.tee.example.json").read_text())
+    pack = {"wu_id": env["binding"]["wu_id"], "proof_mode": "tee"}
+    result = {"result_cid": env["binding"]["result_cid"]}
+    print(json.dumps(precheck(env, pack, result), indent=2))

--- a/schemas/jsonschema/proof-envelope.v0.schema.json
+++ b/schemas/jsonschema/proof-envelope.v0.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/proof-envelope.v0.schema.json",
+  "title": "ProofEnvelope v0",
+  "description": "The envelope a tee/zk WorkUnitResult proof must satisfy so the Mesh Coordinator can BIND it to a specific result and ROUTE it to the right verifier. The coordinator does not verify the cryptography itself (delegated); it enforces the envelope shape and the anti-replay binding (a proof is bound to wu_id + result_cid, so it cannot be replayed against a different result), then hands the proof to the named verifier.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mode", "binding", "material"],
+  "properties": {
+    "mode": { "type": "string", "enum": ["tee", "zk"] },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wu_id", "result_cid"],
+      "properties": {
+        "wu_id": { "type": "string", "minLength": 1 },
+        "result_cid": { "type": "string", "pattern": "^sha256:" }
+      }
+    },
+    "material": {
+      "type": "object",
+      "properties": {
+        "quote": { "type": "string" },
+        "measurement": { "type": "string", "pattern": "^sha256:" },
+        "nonce": { "type": "string", "minLength": 1 },
+        "scheme": { "type": "string", "enum": ["groth16", "plonk", "stark"] },
+        "statement": { "type": "string" },
+        "proof": { "type": "string" },
+        "publicInputs": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/spec/orchestration/proof_envelope.md
+++ b/spec/orchestration/proof_envelope.md
@@ -1,0 +1,33 @@
+# Proof Envelope (tee/zk delegation boundary)
+
+The Mesh Coordinator settles `redundant` proofs itself (majority agreement) but **delegates** the
+cryptographic verification of `tee` and `zk` proofs to their verifiers. This spec pins the boundary:
+the envelope a `tee`/`zk` result proof must satisfy so the coordinator can **bind** it and **route**
+it — the parts a coordinator can and must decide before delegating.
+
+## `ProofEnvelope` (`schemas/jsonschema/proof-envelope.v0.schema.json`)
+
+- `mode` — `tee | zk`.
+- `binding` — `{wu_id, result_cid}`: the proof is bound to **exactly one** WU and result.
+- `material` — mode-specific: `tee` → `quote` + `measurement` (SHA-256) + `nonce`;
+  `zk` → `scheme` (`groth16|plonk|stark`) + `statement` + `proof` (+ optional `publicInputs`).
+
+## Pre-check (`reference/proof_envelope.py:precheck`) — fail-closed
+
+Before delegation the coordinator enforces:
+1. `mode == pack.proof_mode`;
+2. **anti-replay binding** — `binding.wu_id == pack.wu_id` **and** `binding.result_cid == result.result_cid`;
+   a valid proof carrying another result's binding is **refused** (it cannot be replayed against a
+   different result);
+3. the mode's required material is present (`tee` requires a `nonce` for freshness; `zk` requires a
+   known `scheme`).
+
+It then returns a **delegation ticket** — `{mode, verifier, wu_id, result_cid}` — naming the verifier
+the coordinator MUST call (`tee-quote-verifier` / `zk-<scheme>-verifier`). It does **not** check the
+cryptography; that is the named verifier's job (stated honestly).
+
+## FIPS / boundary
+
+No cryptographic primitive here (structural); `measurement`/`result_cid` are SHA-256 (FIPS 180-4).
+The delegated TEE-quote / zk verifier performs the cryptographic check. Does not touch the tritrpc
+v4/vNext wire format.

--- a/tools/verify_proof_envelope.py
+++ b/tools/verify_proof_envelope.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Verify the proof-envelope pre-check binds + routes tee/zk proofs fail-closed (delegation boundary).
+
+Runs reference/proof_envelope.py on the shipped tee + zk examples: a well-formed tee envelope routes
+to the tee-quote-verifier and a zk envelope to the zk-<scheme>-verifier, each bound to its wu/result.
+Then, fail-closed: a REPLAYED proof (binding.result_cid != the result), a mode mismatch, a tee missing
+its nonce, and an unknown zk scheme are each refused before any delegation. Stdlib, repo convention.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import proof_envelope as pe  # noqa: E402
+
+EX = ROOT / "examples" / "mesh"
+SCHEMA = ROOT / "schemas" / "jsonschema" / "proof-envelope.v0.schema.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(name: str):
+    return json.loads((EX / name).read_text())
+
+
+def refused(fn) -> bool:
+    try:
+        fn()
+        return False
+    except pe.ProofEnvelopeError:
+        return True
+
+
+def main() -> int:
+    # schema drift-guard: strict root, modes + zk schemes match the reference.
+    schema = json.loads(SCHEMA.read_text())
+    if schema.get("additionalProperties") is not False or set(schema["properties"]["mode"]["enum"]) != {"tee", "zk"} \
+       or set(schema["properties"]["material"]["properties"]["scheme"]["enum"]) != pe.ZK_SCHEMES:
+        FAILURES.append("schema drifted from reference (mode/zk-scheme enums)")
+    else:
+        CHECKS["schema:no-drift"] = True
+
+    tee = load("proof_envelope.tee.example.json")
+    zk = load("proof_envelope.zk.example.json")
+    tee_pack = {"wu_id": "wu-x", "proof_mode": "tee"}
+    zk_pack = {"wu_id": "wu-x", "proof_mode": "zk"}
+    result = {"result_cid": tee["binding"]["result_cid"]}
+
+    # 1. Valid tee -> routes to tee-quote-verifier, bound to wu/result.
+    t = pe.precheck(tee, tee_pack, result)
+    if t["verifier"] == "tee-quote-verifier" and t["result_cid"] == result["result_cid"]:
+        CHECKS["tee:valid-routes-bound"] = True
+    else:
+        FAILURES.append(f"valid tee envelope did not route/bind: {t}")
+
+    # 2. Valid zk -> routes to zk-groth16-verifier.
+    z = pe.precheck(zk, zk_pack, result)
+    if z["verifier"] == "zk-groth16-verifier":
+        CHECKS["zk:valid-routes-by-scheme"] = True
+    else:
+        FAILURES.append(f"valid zk envelope did not route by scheme: {z}")
+
+    # 3. Anti-replay: a proof bound to a different result_cid is refused.
+    other = {"result_cid": "sha256:" + "b" * 64}
+    CHECKS["fail-closed:replayed-proof-refused"] = refused(lambda: pe.precheck(tee, tee_pack, other))
+    if not CHECKS["fail-closed:replayed-proof-refused"]:
+        FAILURES.append("a proof bound to a different result must be refused (replay)")
+
+    # 4. Mode mismatch (tee envelope, zk pack).
+    CHECKS["fail-closed:mode-mismatch-refused"] = refused(lambda: pe.precheck(tee, zk_pack, result))
+    if not CHECKS["fail-closed:mode-mismatch-refused"]:
+        FAILURES.append("envelope mode != pack.proof_mode must be refused")
+
+    # 5. tee missing nonce (freshness) refused.
+    no_nonce = copy.deepcopy(tee); no_nonce["material"].pop("nonce")
+    CHECKS["fail-closed:tee-missing-nonce-refused"] = refused(lambda: pe.precheck(no_nonce, tee_pack, result))
+    if not CHECKS["fail-closed:tee-missing-nonce-refused"]:
+        FAILURES.append("a tee envelope without a nonce must be refused")
+
+    # 6. Unknown zk scheme refused.
+    bad_scheme = copy.deepcopy(zk); bad_scheme["material"]["scheme"] = "snark9000"
+    CHECKS["fail-closed:unknown-zk-scheme-refused"] = refused(lambda: pe.precheck(bad_scheme, zk_pack, result))
+    if not CHECKS["fail-closed:unknown-zk-scheme-refused"]:
+        FAILURES.append("an unknown zk scheme must be refused")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The coordinator's tee/zk delegation boundary

The Mesh Coordinator (#87) settles `redundant` proofs itself but **delegates** cryptographic verification of `tee`/`zk` proofs. This pins what it must decide **before** delegating: bind the proof to a specific result, and route it.

- **`ProofEnvelope`** — `mode` (tee|zk), `binding` {wu_id, result_cid}, mode-specific `material` (tee: quote+measurement+**nonce**; zk: **scheme**+statement+proof).
- **`reference/proof_envelope.py:precheck`** enforces `mode==pack.proof_mode`, the **anti-replay binding** (a valid proof carrying *another* result's binding is refused — it can't be replayed against a different result), and required material; then returns a **delegation ticket** naming the verifier to call. It does **not** check the cryptography — that's the named verifier's job (honest boundary).

**Teeth (7):** valid tee/zk route+bind · replayed proof / mode mismatch / missing nonce / unknown zk scheme refused · schema drift-guard.

**FIPS:** structural, no primitive; measurement/result_cid SHA-256 (180-4). Additive — v4/vNext untouched. This completes the mesh settlement family (admission → dispatch → settle → prove).