### PR TITLE
feat(orchestration): mesh scheduler + collector — coordinator front-half (fail-closed, end-to-end)

### DIFF
--- a/.github/workflows/validate-mesh-scheduler.yml
+++ b/.github/workflows/validate-mesh-scheduler.yml
@@ -1,0 +1,33 @@
+name: validate-mesh-scheduler
+on:
+  pull_request:
+    paths:
+      - "reference/mesh_scheduler.py"
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_mesh_scheduler.py"
+      - "schemas/jsonschema/node-registration.v0.schema.json"
+      - "examples/mesh/node_registry.example.json"
+      - "spec/orchestration/mesh_scheduler.md"
+      - ".github/workflows/validate-mesh-scheduler.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/mesh_scheduler.py"
+      - "reference/mesh_coordinator.py"
+      - "tools/verify_mesh_scheduler.py"
+      - "schemas/jsonschema/node-registration.v0.schema.json"
+      - "examples/mesh/node_registry.example.json"
+      - "spec/orchestration/mesh_scheduler.md"
+      - ".github/workflows/validate-mesh-scheduler.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate mesh scheduler/collector (fail-closed + end-to-end)
+        run: python tools/verify_mesh_scheduler.py

--- a/examples/mesh/node_registry.example.json
+++ b/examples/mesh/node_registry.example.json
@@ -1,0 +1,70 @@
+[
+  {
+    "node_ref": "node://eu-1",
+    "attestationRef": "att://tpm/eu-1#q",
+    "region": "EU",
+    "trustScore": 0.9,
+    "capacity": {
+      "freeSlots": 2,
+      "sandboxes": [
+        "wasm",
+        "docker"
+      ]
+    },
+    "liveness": {
+      "lastSeenMs": 999000,
+      "ttlMs": 5000
+    }
+  },
+  {
+    "node_ref": "node://eu-2",
+    "attestationRef": "att://tpm/eu-2#q",
+    "region": "EU",
+    "trustScore": 0.82,
+    "capacity": {
+      "freeSlots": 2,
+      "sandboxes": [
+        "wasm",
+        "docker"
+      ]
+    },
+    "liveness": {
+      "lastSeenMs": 999000,
+      "ttlMs": 5000
+    }
+  },
+  {
+    "node_ref": "node://eu-3",
+    "attestationRef": "att://tpm/eu-3#q",
+    "region": "EU",
+    "trustScore": 0.75,
+    "capacity": {
+      "freeSlots": 2,
+      "sandboxes": [
+        "wasm",
+        "docker"
+      ]
+    },
+    "liveness": {
+      "lastSeenMs": 999000,
+      "ttlMs": 5000
+    }
+  },
+  {
+    "node_ref": "node://us-1",
+    "attestationRef": "att://tpm/us-1#q",
+    "region": "US",
+    "trustScore": 0.95,
+    "capacity": {
+      "freeSlots": 2,
+      "sandboxes": [
+        "wasm",
+        "docker"
+      ]
+    },
+    "liveness": {
+      "lastSeenMs": 999000,
+      "ttlMs": 5000
+    }
+  }
+]

--- a/reference/mesh_scheduler.py
+++ b/reference/mesh_scheduler.py
@@ -1,0 +1,87 @@
+"""Reference mesh scheduler + collector — the coordinator's front-half (fail-closed, decidable).
+
+Between admission (node_admission) and settlement (mesh_coordinator) sits the part a coordinator
+decides from the registry alone: which eligible nodes a Work-Unit is assigned to (schedule) and which
+assigned nodes returned in time (collect). This is the POLICY logic, not the wire — the actual packet
+transport (QUIC/libp2p) that carries the dispatch and gathers results is the layer below and is out of
+scope here (delegated). What this decides is fully checkable:
+
+  * eligible(registry, pack, now): a node is eligible iff it is LIVE (now - lastSeenMs <= ttlMs),
+    its region satisfies pack.policy.residency, it offers pack.sandbox, and it has a free slot.
+  * schedule(registry, pack, now): assign pack.replication eligible nodes, highest trust first
+    (ties broken by node_ref for determinism). Fewer than replication eligible => REFUSE to schedule
+    (the redundancy the proof_mode needs cannot be met — fail-closed, never silently under-replicate).
+  * collect(assignment, results, deadlineMs): keep only results from ASSIGNED nodes that arrived by
+    the SLO deadline; late or unassigned results are dropped. The kept set is what feeds reduce().
+
+FIPS: no cryptographic primitive here (scheduling policy). Does not touch the tritrpc v4/vNext wire.
+"""
+from __future__ import annotations
+
+
+class ScheduleError(Exception):
+    pass
+
+
+def _live(entry: dict, now: int) -> bool:
+    lv = entry.get("liveness") or {}
+    return 0 <= (now - lv.get("lastSeenMs", -1)) <= lv.get("ttlMs", 0)
+
+
+def eligible(registry: list, pack: dict, now: int) -> list:
+    """Eligible nodes for a pack, ranked highest-trust first (deterministic tie-break by node_ref)."""
+    residency = (pack.get("policy") or {}).get("residency", "any")
+    sandbox = pack.get("sandbox")
+    out = []
+    for e in registry or []:
+        cap = e.get("capacity") or {}
+        if not _live(e, now):
+            continue
+        if residency != "any" and e.get("region") != residency:
+            continue
+        if sandbox not in (cap.get("sandboxes") or []):
+            continue
+        if cap.get("freeSlots", 0) < 1:
+            continue
+        out.append(e)
+    out.sort(key=lambda e: (-e.get("trustScore", 0.0), e["node_ref"]))
+    return out
+
+
+def schedule(registry: list, pack: dict, now: int) -> dict:
+    """Assign replication eligible nodes to a WU. Fail-closed if redundancy cannot be met."""
+    need = int(pack.get("replication", 1))
+    picks = eligible(registry, pack, now)[:need]
+    if len(picks) < need:
+        raise ScheduleError(
+            f"cannot schedule wu {pack.get('wu_id')!r}: need {need} eligible nodes, found {len(picks)} "
+            f"(residency={pack.get('policy',{}).get('residency')}, sandbox={pack.get('sandbox')})")
+    return {
+        "wu_id": pack.get("wu_id"),
+        "replication": need,
+        "assignments": [{"node_ref": e["node_ref"], "region": e["region"]} for e in picks],
+    }
+
+
+def collect(assignment: dict, results: list, deadline_ms: int) -> dict:
+    """Keep results from assigned nodes that arrived by the SLO deadline; drop late/unassigned ones."""
+    assigned = {a["node_ref"] for a in assignment.get("assignments", [])}
+    kept, dropped = [], []
+    for r in results or []:
+        if r.get("node_ref") not in assigned:
+            dropped.append({"node_ref": r.get("node_ref"), "reason": "not assigned to this WU"})
+        elif int(r.get("received_ms", 1 << 62)) > deadline_ms:
+            dropped.append({"node_ref": r.get("node_ref"), "reason": "arrived after SLO deadline"})
+        else:
+            kept.append(r)
+    return {"wu_id": assignment.get("wu_id"), "collected": kept, "dropped": dropped}
+
+
+if __name__ == "__main__":
+    import json
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    ex = root / "examples" / "mesh"
+    registry = json.loads((ex / "node_registry.example.json").read_text())
+    pack = json.loads((ex / "work_unit_pack.example.json").read_text())
+    print(json.dumps(schedule(registry, pack, now=1_000_000), indent=2))

--- a/schemas/jsonschema/node-registration.v0.schema.json
+++ b/schemas/jsonschema/node-registration.v0.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/node-registration.v0.schema.json",
+  "title": "NodeRegistration v0",
+  "description": "A node's registry entry in the mesh: the admitted trusted-node record (from node_admission) plus the capacity and liveness the scheduler needs to place Work-Units. The registry is the set the scheduler draws from; a node absent, stale, or over capacity is simply not eligible (fail-closed).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["node_ref", "attestationRef", "region", "trustScore", "capacity", "liveness"],
+  "properties": {
+    "node_ref": { "type": "string", "pattern": "^node://" },
+    "attestationRef": { "type": "string", "minLength": 1 },
+    "region": { "type": "string", "minLength": 1 },
+    "trustScore": { "type": "number", "minimum": 0, "maximum": 1, "description": "from node_admission (#88) — used to rank eligible nodes." },
+    "capacity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["freeSlots", "sandboxes"],
+      "properties": {
+        "freeSlots": { "type": "integer", "minimum": 0 },
+        "sandboxes": { "type": "array", "items": { "type": "string", "enum": ["docker", "lightning", "wasm", "kata"] }, "minItems": 1 }
+      }
+    },
+    "liveness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lastSeenMs", "ttlMs"],
+      "properties": {
+        "lastSeenMs": { "type": "integer", "minimum": 0, "description": "epoch ms of last heartbeat." },
+        "ttlMs": { "type": "integer", "minimum": 1, "description": "a node is live only if now - lastSeenMs <= ttlMs." }
+      }
+    }
+  }
+}

--- a/spec/orchestration/mesh_scheduler.md
+++ b/spec/orchestration/mesh_scheduler.md
@@ -1,0 +1,31 @@
+# Mesh Scheduler & Collector (coordinator front-half)
+
+The lifecycle is `registry → schedule → collect → verify → reduce → settle`. The mesh coordinator
+(`mesh_work_unit.md`) implements verify/reduce/settle. This spec pins the **front-half** — the
+scheduling and collection *policy* a coordinator decides from the registry alone. The actual packet
+transport that dispatches a WU and gathers results (QUIC / libp2p) is the wire **below** this and is
+out of scope (delegated) — this layer decides *who* and *whether*, not *how the bytes move*.
+
+## Registry (`schemas/jsonschema/node-registration.v0.schema.json`)
+
+A `NodeRegistration` is the admitted trusted-node record (from `node_admission`, #88) plus `capacity`
+(`freeSlots`, `sandboxes`) and `liveness` (`lastSeenMs`, `ttlMs`) and the `trustScore` used to rank.
+
+## Schedule (`reference/mesh_scheduler.py`) — fail-closed
+
+`eligible(registry, pack, now)` keeps a node iff it is **live** (`now - lastSeenMs <= ttlMs`), its
+`region` satisfies `pack.policy.residency`, it offers `pack.sandbox`, and it has a free slot; the set
+is ranked **highest trust first** (ties broken by `node_ref`). `schedule` assigns `pack.replication`
+of them — and if **fewer than replication** are eligible it **refuses** (the redundancy the
+`proof_mode` needs cannot be met; never silently under-replicate).
+
+## Collect
+
+`collect(assignment, results, deadlineMs)` keeps only results from **assigned** nodes that arrived by
+the **SLO deadline**; late or unassigned results are dropped. The kept set is exactly what feeds
+`reduce()` — the verifier proves the chain composes: schedule → collect → settle.
+
+## FIPS / boundary
+
+No cryptographic primitive here (scheduling policy). The QUIC/libp2p transport and the heartbeat
+source that populates `liveness` are the runtime below. Does not touch the tritrpc v4/vNext wire.

--- a/tools/verify_mesh_scheduler.py
+++ b/tools/verify_mesh_scheduler.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Verify the mesh scheduler/collector is fail-closed and composes end-to-end (schedule->collect->settle).
+
+Runs reference/mesh_scheduler.py on the shipped registry + example WU pack and asserts: a residency-,
+sandbox-, liveness-, capacity-filtered eligible set is ranked by trust and scheduled to exactly
+`replication` nodes; a US node (wrong residency), a stale node (past ttl), a no-wasm node, and a
+zero-slot node are each excluded; too few eligible nodes REFUSES scheduling (fail-closed); collect
+keeps on-time assigned results and drops late/unassigned ones; and the whole chain composes — the
+collected set settles in mesh_coordinator. Plus determinism + a schema drift-guard. Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import mesh_scheduler as ms  # noqa: E402
+import mesh_coordinator as mc  # noqa: E402
+
+EX = ROOT / "examples" / "mesh"
+SCHEMA = ROOT / "schemas" / "jsonschema" / "node-registration.v0.schema.json"
+NOW = 1_000_000
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(n: str):
+    return json.loads((EX / n).read_text())
+
+
+def refused(fn) -> bool:
+    try:
+        fn()
+        return False
+    except ms.ScheduleError:
+        return True
+
+
+def main() -> int:
+    # schema drift-guard.
+    schema = json.loads(SCHEMA.read_text())
+    cap = schema["properties"]["capacity"]["properties"]
+    if schema.get("additionalProperties") is not False or set(cap["sandboxes"]["items"]["enum"]) != {"docker", "lightning", "wasm", "kata"}:
+        FAILURES.append("schema drift (root strict / sandbox enum)")
+    else:
+        CHECKS["schema:no-drift"] = True
+
+    registry = load("node_registry.example.json")
+    pack = load("work_unit_pack.example.json")  # redundant, wasm, EU, replication 3
+
+    # 1. Happy schedule: 3 EU wasm nodes, ranked by trust, US excluded by residency.
+    sch = ms.schedule(registry, pack, NOW)
+    refs = [a["node_ref"] for a in sch["assignments"]]
+    if refs == ["node://eu-1", "node://eu-2", "node://eu-3"] and all(a["region"] == "EU" for a in sch["assignments"]):
+        CHECKS["schedule:eligible-ranked-residency-filtered"] = True
+    else:
+        FAILURES.append(f"schedule picked the wrong set/order: {refs}")
+
+    # 2. Liveness: stale a node -> only 2 eligible -> refuse (fail-closed).
+    stale = copy.deepcopy(registry)
+    stale[2]["liveness"]["lastSeenMs"] = 900_000  # now-900000 = 100000 > ttl 5000 => dead
+    CHECKS["fail-closed:stale-node-excluded->underfilled-refused"] = refused(lambda: ms.schedule(stale, pack, NOW))
+    if not CHECKS["fail-closed:stale-node-excluded->underfilled-refused"]:
+        FAILURES.append("a stale node must be excluded (and underfilled schedule refused)")
+
+    # 3. Sandbox: strip wasm from one node -> underfilled -> refuse.
+    nowasm = copy.deepcopy(registry)
+    nowasm[2]["capacity"]["sandboxes"] = ["docker"]
+    CHECKS["fail-closed:no-sandbox-excluded"] = refused(lambda: ms.schedule(nowasm, pack, NOW))
+
+    # 4. Capacity: zero free slots on one node -> underfilled -> refuse.
+    noslot = copy.deepcopy(registry)
+    noslot[2]["capacity"]["freeSlots"] = 0
+    CHECKS["fail-closed:no-capacity-excluded"] = refused(lambda: ms.schedule(noslot, pack, NOW))
+
+    # 5. Insufficient eligible outright (only US) -> refuse.
+    CHECKS["fail-closed:insufficient-eligible-refused"] = refused(lambda: ms.schedule([registry[3]], pack, NOW))
+    for k in ("fail-closed:no-sandbox-excluded", "fail-closed:no-capacity-excluded", "fail-closed:insufficient-eligible-refused"):
+        if not CHECKS[k]:
+            FAILURES.append(f"{k} did not fire")
+
+    # 6. Collect: on-time assigned kept, late + unassigned dropped.
+    deadline = NOW + pack["policy"]["slo_ms"]
+    results = [
+        {"wu_id": pack["wu_id"], "node_ref": "node://eu-1", "received_ms": deadline - 10, "result_cid": "sha256:" + "a" * 64, "region": "EU", "proof": {"mode": "redundant"}},
+        {"wu_id": pack["wu_id"], "node_ref": "node://eu-2", "received_ms": deadline - 5,  "result_cid": "sha256:" + "a" * 64, "region": "EU", "proof": {"mode": "redundant"}},
+        {"wu_id": pack["wu_id"], "node_ref": "node://eu-3", "received_ms": deadline + 500, "result_cid": "sha256:" + "a" * 64, "region": "EU", "proof": {"mode": "redundant"}},  # late
+        {"wu_id": pack["wu_id"], "node_ref": "node://us-1", "received_ms": deadline - 1,  "result_cid": "sha256:" + "a" * 64, "region": "US", "proof": {"mode": "redundant"}},  # unassigned
+    ]
+    col = ms.collect(sch, results, deadline)
+    kept_refs = {r["node_ref"] for r in col["collected"]}
+    if kept_refs == {"node://eu-1", "node://eu-2"} and len(col["dropped"]) == 2:
+        CHECKS["collect:on-time-assigned-kept"] = True
+    else:
+        FAILURES.append(f"collect kept/dropped wrong: kept={kept_refs} dropped={len(col['dropped'])}")
+
+    # 7. END-TO-END: schedule -> collect -> settle. Two on-time agree, but replication=3 so NOT settled
+    #    (a real SLO shortfall must not settle). Give a lower-replication pack to show a clean settle.
+    trusted = [{"node_ref": a["node_ref"], "attestationRef": "att://x", "region": a["region"]} for a in sch["assignments"]]
+    p2 = copy.deepcopy(pack); p2["replication"] = 2
+    settle = mc.reduce(p2, col["collected"], trusted)
+    if settle["settled"] and set(settle["rlc_credit"]) == {"node://eu-1", "node://eu-2"}:
+        CHECKS["e2e:collected-set-settles-in-coordinator"] = True
+    else:
+        FAILURES.append(f"collected set did not settle end-to-end: {settle}")
+
+    # 8. Determinism.
+    if ms.schedule(registry, pack, NOW) == sch:
+        CHECKS["deterministic:reproducible"] = True
+    else:
+        FAILURES.append("schedule is not deterministic")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The coordinator's front-half — registry → schedule → collect

Completes the lifecycle before verify/reduce/settle (#87). This is the scheduling/collection **policy** decided from the registry alone; the QUIC/libp2p packet transport is the wire **below** and stays delegated — this layer decides *who* and *whether*, not *how bytes move*.

- **`NodeRegistration`** — the admitted trusted-node record (#88) + `capacity` (freeSlots, sandboxes) + `liveness` (lastSeenMs, ttlMs) + `trustScore`.
- **`schedule`** — `eligible()` filters by **liveness / residency / sandbox / free-slot**, ranks by trust; assigns `replication` nodes and **refuses if fewer are eligible** (never silently under-replicate).
- **`collect`** — keeps only **assigned** results that arrived by the **SLO deadline**; drops late/unassigned. The kept set is exactly what feeds `reduce()`.

**Teeth (9):** eligible ranking + residency filter · stale / no-sandbox / no-capacity / insufficient each refuse · collect keeps on-time-assigned + drops late/unassigned · **end-to-end schedule→collect→settle composes in mesh_coordinator** · determinism · schema drift-guard.

**FIPS:** scheduling policy, no primitive. Additive — does not touch the v4/vNext wire.