### PR TITLE
feat(orchestration): tee/zk attestation verifier — decidable checks + honest abstention

### DIFF
--- a/.github/workflows/validate-attestation-verifier.yml
+++ b/.github/workflows/validate-attestation-verifier.yml
@@ -1,0 +1,33 @@
+name: validate-attestation-verifier
+on:
+  pull_request:
+    paths:
+      - "reference/attestation_verifier.py"
+      - "tools/verify_attestation_verifier.py"
+      - "schemas/jsonschema/attestation-verdict.v0.schema.json"
+      - "examples/mesh/tee_quote.example.json"
+      - "examples/mesh/zk_proof.example.json"
+      - "spec/orchestration/attestation_verifier.md"
+      - ".github/workflows/validate-attestation-verifier.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/attestation_verifier.py"
+      - "tools/verify_attestation_verifier.py"
+      - "schemas/jsonschema/attestation-verdict.v0.schema.json"
+      - "examples/mesh/tee_quote.example.json"
+      - "examples/mesh/zk_proof.example.json"
+      - "spec/orchestration/attestation_verifier.md"
+      - ".github/workflows/validate-attestation-verifier.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate tee/zk attestation verifier (decidable checks + abstain)
+        run: python tools/verify_attestation_verifier.py

--- a/examples/mesh/tee_quote.example.json
+++ b/examples/mesh/tee_quote.example.json
@@ -1,0 +1,13 @@
+{
+  "binding": {
+    "wu_id": "wu-x",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "quote": {
+    "report_data": "sha256:14a1115838f39b9c61799c258e1b95fb32932fcf1b53ad5f8b472ae0b8f4941b",
+    "measurement": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "nonce": "n-2026-08-03",
+    "tcb": "up-to-date",
+    "quote_sig": "<delegated-to-dcap>"
+  }
+}

--- a/examples/mesh/zk_proof.example.json
+++ b/examples/mesh/zk_proof.example.json
@@ -1,0 +1,15 @@
+{
+  "binding": {
+    "wu_id": "wu-x",
+    "result_cid": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "proof": {
+    "scheme": "groth16",
+    "statement": "result==f(inputs)",
+    "proof": "<delegated>",
+    "publicInputs": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:fd9cf27c2a470b2731073e0eae75dc385a1f3e8b3ee5e48fa8f6c3613b993c01"
+    ]
+  }
+}

--- a/reference/attestation_verifier.py
+++ b/reference/attestation_verifier.py
@@ -1,0 +1,68 @@
+"""Reference tee/zk verifier — the decidable checks, then ABSTAIN on the crypto root (fail-closed).
+
+The ProofEnvelope (#90) routes a tee/zk proof here. A software verifier cannot check an Intel DCAP
+quote signature or a zk pairing without hardware collateral / a verifying key — but it CAN, and MUST,
+decide the parts that don't need them, and it must REFUSE to rubber-stamp what it can't verify:
+
+  tee: the quote's report_data MUST equal SHA-256(nonce || result_cid) — this is the binding that ties
+       the quote to THIS result; a wrong/absent binding is a reject. The measurement (MRENCLAVE) must
+       be in the allow-list; the nonce must be fresh (not seen before — anti-replay).
+  zk:  the public inputs MUST include the result_cid and SHA-256(statement) — the binding that ties
+       the proof to THIS result/statement; the scheme must be supported.
+
+If every decidable check passes, the verdict is REFER (not accept): the hardware/crypto root is
+delegated to the named root verifier. A bare 'accept' is never emitted for tee/zk — abstain, don't
+fake a pass (descend-abstain = gate).
+
+FIPS: the result-binding is SHA-256 (FIPS 180-4). The delegated quote-signature / zk-pairing check is
+the root verifier's job. Does not touch the tritrpc v4/vNext wire format.
+"""
+from __future__ import annotations
+
+import hashlib
+
+TEE_MEASUREMENT_ALLOWLIST = {"sha256:" + "e" * 64}  # known-good MRENCLAVE set (deployment-configured)
+ZK_SUPPORTED = {"groth16", "plonk", "stark"}
+
+
+def _sha256_hex(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def verify_tee(quote: dict, binding: dict, measurement_allow: set | None = None, seen_nonces: set | None = None) -> dict:
+    """Decide a TEE quote's binding/measurement/freshness; refer the DCAP signature. Fail-closed."""
+    allow = measurement_allow if measurement_allow is not None else TEE_MEASUREMENT_ALLOWLIST
+    seen = seen_nonces if seen_nonces is not None else set()
+    checks: dict[str, bool] = {}
+
+    nonce = str(quote.get("nonce") or "")
+    result_cid = str(binding.get("result_cid") or "")
+    expected = _sha256_hex((nonce + "|" + result_cid).encode())
+    checks["report_data_binds_result"] = (str(quote.get("report_data") or "") == expected)
+    checks["measurement_allowlisted"] = (quote.get("measurement") in allow)
+    checks["nonce_fresh"] = bool(nonce) and nonce not in seen
+
+    if not all(checks.values()):
+        reason = "; ".join(k for k, v in checks.items() if not v)
+        return {"mode": "tee", "verdict": "reject", "checks": checks, "reason": f"failed: {reason}"}
+    return {"mode": "tee", "verdict": "refer", "checks": checks,
+            "referTo": "dcap-quote-verifier", "reason": "binding/measurement/freshness ok; quote signature delegated"}
+
+
+def verify_zk(proof: dict, binding: dict, supported: set | None = None) -> dict:
+    """Decide a zk proof's public-input binding + scheme; refer the pairing check. Fail-closed."""
+    sup = supported if supported is not None else ZK_SUPPORTED
+    checks: dict[str, bool] = {}
+
+    scheme = proof.get("scheme")
+    public_inputs = proof.get("publicInputs") or []
+    stmt_hash = _sha256_hex(str(proof.get("statement") or "").encode())
+    checks["scheme_supported"] = scheme in sup
+    checks["public_inputs_bind_result"] = str(binding.get("result_cid") or "") in public_inputs
+    checks["public_inputs_bind_statement"] = stmt_hash in public_inputs
+
+    if not all(checks.values()):
+        reason = "; ".join(k for k, v in checks.items() if not v)
+        return {"mode": "zk", "verdict": "reject", "checks": checks, "reason": f"failed: {reason}"}
+    return {"mode": "zk", "verdict": "refer", "checks": checks,
+            "referTo": f"zk-{scheme}-vk-verifier", "reason": "public-input binding + scheme ok; pairing delegated"}

--- a/schemas/jsonschema/attestation-verdict.v0.schema.json
+++ b/schemas/jsonschema/attestation-verdict.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/attestation-verdict.v0.schema.json",
+  "title": "AttestationVerdict v0",
+  "description": "The verdict the tee/zk verifier emits for a proof the coordinator delegated to it (via the ProofEnvelope delegation ticket). It records the DECIDABLE checks a software verifier can make — the SHA-256 result-binding, measurement allow-list, nonce freshness (tee); public-input binding + supported scheme (zk) — and then either REJECTs (a decidable check failed, fail-closed) or REFERs (decidable checks pass; the hardware/cryptographic root — Intel DCAP quote signature / zk pairing — is delegated to the named root verifier). It never emits a bare 'accept' for tee/zk: the crypto root is always deferred, never rubber-stamped.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mode", "verdict", "checks"],
+  "properties": {
+    "mode": { "type": "string", "enum": ["tee", "zk"] },
+    "verdict": { "type": "string", "enum": ["reject", "refer"] },
+    "checks": { "type": "object", "additionalProperties": { "type": "boolean" } },
+    "reason": { "type": "string" },
+    "referTo": { "type": "string", "description": "the hardware/crypto root verifier the coordinator must still call (e.g. dcap-quote-verifier / zk-groth16-vk-verifier)." }
+  }
+}

--- a/spec/orchestration/attestation_verifier.md
+++ b/spec/orchestration/attestation_verifier.md
@@ -1,0 +1,29 @@
+# tee/zk Attestation Verifier (decidable checks + honest abstention)
+
+The ProofEnvelope (#90) routes a `tee`/`zk` proof to a named verifier. This spec pins what that
+verifier does in software — and, crucially, what it refuses to pretend to do.
+
+## What it decides (fail-closed)
+
+- **tee**: the quote's `report_data` MUST equal `SHA-256(nonce || result_cid)` — the binding that
+  ties the quote to **this** result. Wrong/absent ⇒ **reject**. The `measurement` (MRENCLAVE) must be
+  in the allow-list; the `nonce` must be fresh (anti-replay).
+- **zk**: the `publicInputs` MUST include the `result_cid` and `SHA-256(statement)` — the binding to
+  this result/statement; the `scheme` must be supported.
+
+## What it refuses to fake
+
+If every decidable check passes, the verdict is **`refer`**, not `accept`: the hardware/cryptographic
+root — the Intel DCAP quote **signature**, the zk **pairing** check — needs collateral / a verifying
+key this layer does not have, so it is **delegated** to the named root verifier (`dcap-quote-verifier`
+/ `zk-<scheme>-vk-verifier`). A bare `accept` is **never** emitted for tee/zk. The verdict enum is
+`{reject, refer}` by construction — abstain, don't rubber-stamp (descend-abstain = gate).
+
+This catches exactly the attacks a coordinator *can* catch deterministically — an unbound quote, a
+replayed nonce, the wrong enclave, wrong public inputs — and hands the rest to the root verifier with
+an explicit, auditable `referTo`.
+
+## FIPS / boundary
+
+The result-binding is SHA-256 (FIPS 180-4). The delegated quote-signature / zk-pairing check is the
+root verifier's job (out of scope). Does not touch the tritrpc v4/vNext wire format.

--- a/tools/verify_attestation_verifier.py
+++ b/tools/verify_attestation_verifier.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify the tee/zk verifier decides bindings fail-closed and ABSTAINS (never fake-passes) the root.
+
+Runs reference/attestation_verifier.py on the shipped tee quote + zk proof and asserts: a well-formed
+tee quote (report_data binds nonce|result_cid, measurement allow-listed, fresh nonce) yields REFER —
+not accept — routing to the dcap-quote-verifier; a well-formed zk proof (public inputs bind result +
+statement, supported scheme) yields REFER to the zk vk verifier. Then, fail-closed: a wrong binding,
+an unknown measurement, a replayed nonce, a missing public input, and an unsupported scheme are each
+REJECTED. The core invariant: tee/zk NEVER produce a bare 'accept' — the crypto root is always
+deferred. Plus determinism + a schema drift-guard. Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import attestation_verifier as av  # noqa: E402
+
+EX = ROOT / "examples" / "mesh"
+SCHEMA = ROOT / "schemas" / "jsonschema" / "attestation-verdict.v0.schema.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def load(n: str):
+    return json.loads((EX / n).read_text())
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    if schema.get("additionalProperties") is not False or set(schema["properties"]["verdict"]["enum"]) != {"reject", "refer"}:
+        FAILURES.append("schema drift: verdict enum must be exactly {reject, refer} (no 'accept')")
+    else:
+        CHECKS["schema:verdict-has-no-accept"] = True
+
+    tee = load("tee_quote.example.json")
+    zk = load("zk_proof.example.json")
+
+    # 1. well-formed tee -> refer (not accept), routed to dcap.
+    v = av.verify_tee(tee["quote"], tee["binding"], seen_nonces=set())
+    if v["verdict"] == "refer" and v.get("referTo") == "dcap-quote-verifier" and all(v["checks"].values()):
+        CHECKS["tee:wellformed-refers-not-accepts"] = True
+    else:
+        FAILURES.append(f"well-formed tee should refer: {v}")
+
+    # 2. wrong binding -> reject.
+    bad = copy.deepcopy(tee); bad["quote"]["report_data"] = "sha256:" + "0" * 64
+    CHECKS["fail-closed:tee-unbound-rejected"] = av.verify_tee(bad["quote"], bad["binding"], seen_nonces=set())["verdict"] == "reject"
+
+    # 3. unknown measurement -> reject.
+    m = copy.deepcopy(tee); m["quote"]["measurement"] = "sha256:" + "f" * 64
+    CHECKS["fail-closed:tee-unknown-enclave-rejected"] = av.verify_tee(m["quote"], m["binding"], seen_nonces=set())["verdict"] == "reject"
+
+    # 4. replayed nonce -> reject.
+    seen = {tee["quote"]["nonce"]}
+    CHECKS["fail-closed:tee-replayed-nonce-rejected"] = av.verify_tee(tee["quote"], tee["binding"], seen_nonces=seen)["verdict"] == "reject"
+
+    # 5. well-formed zk -> refer.
+    z = av.verify_zk(zk["proof"], zk["binding"])
+    if z["verdict"] == "refer" and z.get("referTo") == "zk-groth16-vk-verifier":
+        CHECKS["zk:wellformed-refers"] = True
+    else:
+        FAILURES.append(f"well-formed zk should refer: {z}")
+
+    # 6. zk missing result_cid in public inputs -> reject.
+    zbad = copy.deepcopy(zk); zbad["proof"]["publicInputs"] = [zbad["proof"]["publicInputs"][1]]
+    CHECKS["fail-closed:zk-unbound-rejected"] = av.verify_zk(zbad["proof"], zbad["binding"])["verdict"] == "reject"
+
+    # 7. zk unsupported scheme -> reject.
+    zs = copy.deepcopy(zk); zs["proof"]["scheme"] = "snark9000"
+    CHECKS["fail-closed:zk-unsupported-scheme-rejected"] = av.verify_zk(zs["proof"], zs["binding"])["verdict"] == "reject"
+
+    # 8. INVARIANT: neither verifier ever returns 'accept'.
+    verdicts = {av.verify_tee(tee["quote"], tee["binding"], seen_nonces=set())["verdict"],
+                av.verify_zk(zk["proof"], zk["binding"])["verdict"],
+                av.verify_tee(bad["quote"], bad["binding"], seen_nonces=set())["verdict"]}
+    CHECKS["invariant:never-bare-accept"] = "accept" not in verdicts
+
+    # 9. determinism.
+    CHECKS["deterministic:reproducible"] = av.verify_tee(tee["quote"], tee["binding"], seen_nonces=set()) == v
+
+    for k in ("fail-closed:tee-unbound-rejected", "fail-closed:tee-unknown-enclave-rejected",
+              "fail-closed:tee-replayed-nonce-rejected", "fail-closed:zk-unbound-rejected",
+              "fail-closed:zk-unsupported-scheme-rejected"):
+        if not CHECKS.get(k):
+            FAILURES.append(f"{k} did not fire")
+
+    for m2 in FAILURES:
+        print(f"FAIL: {m2}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The verifier the proof-envelope routes to — and what it refuses to fake

#90 routes a `tee`/`zk` proof to a named verifier. This is that verifier. It decides in software what it **can**, and **abstains** on what it can't.

**Decides (fail-closed):**
- **tee** — `report_data` MUST equal `SHA-256(nonce || result_cid)` (binds the quote to *this* result); `measurement` in an MRENCLAVE allow-list; `nonce` fresh (anti-replay).
- **zk** — `publicInputs` MUST include `result_cid` + `SHA-256(statement)`; `scheme` supported.

**Refuses to fake:** all decidable checks passing ⇒ verdict **`refer`**, never `accept`. The Intel DCAP quote **signature** / zk **pairing** needs collateral / a verifying key this layer lacks, so it's **delegated** with an explicit `referTo`. The verdict enum is `{reject, refer}` *by construction* — abstain, don't rubber-stamp (descend-abstain = gate).

**Teeth (10):** well-formed tee/zk refer (not accept) · unbound / unknown-enclave / replayed-nonce / missing-public-input / unsupported-scheme each rejected · **never-bare-accept invariant** · determinism · schema drift-guard.

**FIPS:** result-binding SHA-256 (180-4); delegated signature/pairing is the root verifier's job. Additive — v4/vNext untouched. This is the honest floor for the delegated proof modes; the real DCAP/zk root verifier is the remaining hardware/crypto runtime.