### PR TITLE
feat(transport): CryptoProfile v4 suite selector + CNSA-2.0 + approved-mode gate

### DIFF
--- a/examples/transport/crypto_profile.cnsa-underassured.invalid.json
+++ b/examples/transport/crypto_profile.cnsa-underassured.invalid.json
@@ -1,15 +1,14 @@
 {
-  "profileId": "crypto://tritrpc/fips",
+  "profileId": "crypto://tritrpc/bad-cnsa",
   "mode": "fips",
-  "suite": 1,
-  "aead": "AES-256-GCM",
-  "hash": "SHA-384",
+  "suite": 2,
+  "aead": "AES-128-GCM",
+  "hash": "SHA-256",
   "approvedMode": {
     "encodeBeforeAuth": true,
     "canonicalOnly": true,
     "noncePolicy": "module-gcm",
     "rngSource": "module",
     "selfTests": true
-  },
-  "wireFormat": "tritrpc-v1"
+  }
 }

--- a/examples/transport/crypto_profile.cnsa.example.json
+++ b/examples/transport/crypto_profile.cnsa.example.json
@@ -1,9 +1,11 @@
 {
-  "profileId": "crypto://tritrpc/fips",
+  "profileId": "crypto://tritrpc/cnsa",
   "mode": "fips",
-  "suite": 1,
+  "suite": 2,
   "aead": "AES-256-GCM",
   "hash": "SHA-384",
+  "kem": "ML-KEM-1024",
+  "sig": "ML-DSA-87",
   "approvedMode": {
     "encodeBeforeAuth": true,
     "canonicalOnly": true,

--- a/examples/transport/crypto_profile.fips-no-approved-mode.invalid.json
+++ b/examples/transport/crypto_profile.fips-no-approved-mode.invalid.json
@@ -1,0 +1,7 @@
+{
+  "profileId": "crypto://tritrpc/bad-am",
+  "mode": "fips",
+  "suite": 1,
+  "aead": "AES-256-GCM",
+  "hash": "SHA-384"
+}

--- a/examples/transport/crypto_profile.suite-mode-mismatch.invalid.json
+++ b/examples/transport/crypto_profile.suite-mode-mismatch.invalid.json
@@ -1,6 +1,6 @@
 {
-  "profileId": "crypto://tritrpc/fips",
-  "mode": "fips",
+  "profileId": "crypto://tritrpc/bad-mm",
+  "mode": "standard",
   "suite": 1,
   "aead": "AES-256-GCM",
   "hash": "SHA-384",
@@ -10,6 +10,5 @@
     "noncePolicy": "module-gcm",
     "rngSource": "module",
     "selfTests": true
-  },
-  "wireFormat": "tritrpc-v1"
+  }
 }

--- a/examples/transport/crypto_profile.suite-reserved.invalid.json
+++ b/examples/transport/crypto_profile.suite-reserved.invalid.json
@@ -1,7 +1,7 @@
 {
-  "profileId": "crypto://tritrpc/fips",
+  "profileId": "crypto://tritrpc/bad-res",
   "mode": "fips",
-  "suite": 1,
+  "suite": 3,
   "aead": "AES-256-GCM",
   "hash": "SHA-384",
   "approvedMode": {
@@ -10,6 +10,5 @@
     "noncePolicy": "module-gcm",
     "rngSource": "module",
     "selfTests": true
-  },
-  "wireFormat": "tritrpc-v1"
+  }
 }

--- a/schemas/jsonschema/crypto-profile.v0.schema.json
+++ b/schemas/jsonschema/crypto-profile.v0.schema.json
@@ -2,15 +2,30 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.socioprophet.dev/tritrpc/crypto-profile.v0.schema.json",
   "title": "TriTRPC CryptoProfile v0",
-  "description": "Declares WHICH AEAD/hash a TriTRPC deployment uses, so 'AEAD-sealed canonical bytes' is a checkable, FIPS-gateable choice rather than a hardcoded cipher. mode:fips REQUIRES a FIPS-approved AEAD (AES-GCM/CCM, SP 800-38D) and hash (SHA-2/SHA-3, FIPS 180-4/202) and REFUSES XChaCha20/ChaCha20-Poly1305 and BLAKE. mode:standard permits the v1 XChaCha20-Poly1305 lane. Additive: it selects the cipher for the sealing lane; it does NOT change the v1/v4/vNext wire format (TritPack243/TLEB3 are unchanged).",
+  "description": "Declares WHICH AEAD/hash (and, for approved suites, KEM/signature + approved-mode assertions) a TriTRPC deployment uses, so 'AEAD-sealed canonical bytes' is a checkable, suite-gateable choice. Aligned to the v4 suite selector (§13.4): suite 0 research-nonapproved / 1 fips-classical / 2 cnsa2-ready / 3 reserved. `mode` stays for back-compat and is derived-consistent with `suite` (standard<->0, fips<->1|2). suite>=1 requires the §13.5/§5.3-5.6 approved-mode assertions; suite 2 (CNSA 2.0) additionally requires AES-256-GCM, SHA-384/512, and ML-KEM-1024 / ML-DSA-87 when a KEM/signature is declared. Additive: selects the sealing suite; does NOT change the v1/v4/vNext wire (TritPack243/TLEB3).",
   "type": "object",
   "additionalProperties": false,
   "required": ["profileId", "mode", "aead", "hash"],
   "properties": {
     "profileId": { "type": "string", "minLength": 1 },
     "mode": { "type": "string", "enum": ["fips", "standard"] },
+    "suite": { "type": "integer", "enum": [0, 1, 2, 3], "description": "v4 §13.4 suite selector. Absent => derived from mode (standard->0, fips->1)." },
     "aead": { "type": "string", "enum": ["AES-128-GCM", "AES-192-GCM", "AES-256-GCM", "AES-256-CCM", "ChaCha20-Poly1305", "XChaCha20-Poly1305"] },
     "hash": { "type": "string", "enum": ["SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512", "BLAKE3", "BLAKE2b"] },
+    "kem": { "type": "string", "enum": ["X25519", "ECDH-P256", "ECDH-P384", "ML-KEM-768", "ML-KEM-1024"] },
+    "sig": { "type": "string", "enum": ["Ed25519", "ECDSA-P256", "ECDSA-P384", "ML-DSA-65", "ML-DSA-87", "LMS", "XMSS"] },
+    "approvedMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["encodeBeforeAuth", "canonicalOnly", "noncePolicy", "rngSource", "selfTests"],
+      "properties": {
+        "encodeBeforeAuth": { "type": "boolean", "description": "§5.6: authenticate/sign the canonical byte string only." },
+        "canonicalOnly": { "type": "boolean", "description": "§5.6: one canonical encoding; reject non-canonical." },
+        "noncePolicy": { "type": "string", "enum": ["module-gcm", "context-sequence"], "description": "§5.4 IV construction." },
+        "rngSource": { "type": "string", "enum": ["module", "approved-bound"], "description": "§5.5: RNG from the validated module boundary." },
+        "selfTests": { "type": "boolean", "description": "§5.3: module self-tests complete." }
+      }
+    },
     "wireFormat": { "type": "string", "description": "informational: the wire this profile seals (e.g. tritrpc-v1). MUST NOT be altered by the crypto profile." }
   }
 }

--- a/spec/transport/crypto_profile.md
+++ b/spec/transport/crypto_profile.md
@@ -14,3 +14,22 @@ explicit, checkable, gateable choice instead of a hardcoded assumption.
 TriTRPC wire format — `TritPack243` byte canonical and `TLEB3` lengths are unchanged, so v1 / v4 /
 vNext frames still parse. Hashing was already FIPS-clean (`SCHEMA_ID = SHA3(...)`,
 `CONTEXT_ID = SHA3(...)`); this closes the AEAD gap. `tools/verify_crypto_profile.py` is the gate.
+
+## v4 suite selector alignment (§13.4 / §13.5 / addendum §5.3–5.6)
+
+The profile now carries the normative **suite selector** — `suite 0` research-nonapproved, `1`
+fips-classical, `2` cnsa2-ready, `3` reserved — and gates it fail-closed:
+
+- `mode` remains for back-compat; when `suite` is absent it is **derived** (`standard→0`, `fips→1`),
+  so existing profiles keep validating. When present, `suite` must be consistent with `mode`
+  (`0↔standard`, `1|2↔fips`); `suite 3` is refused.
+- **suite ≥ 1 (approved)** additionally requires an `approvedMode` block asserting the §13.5/§5.3–5.6
+  requirements: `encodeBeforeAuth` (authenticate the canonical bytes only), `canonicalOnly` (reject
+  non-canonical encodings), a `noncePolicy` (§5.4 IV construction), `rngSource` from the validated
+  module (§5.5), and `selfTests` complete (§5.3). A FIPS profile missing these is refused.
+- **suite 2 (CNSA 2.0)** is stricter than FIPS-classical: **AES-256-GCM only**, **SHA-384/512 only**,
+  and **ML-KEM-1024 / ML-DSA-87** when a KEM/signature is declared. A merely-FIPS profile
+  (AES-128 / SHA-256) that claims `suite 2` is **refused** — closing the silent-under-assurance gap
+  where a CNSA-required deployment could be handed a weaker FIPS profile.
+
+Still additive: the profile selects the sealing suite; it does not alter the v1/v4/vNext wire.

--- a/tools/verify_crypto_profile.py
+++ b/tools/verify_crypto_profile.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
-"""Verify TriTRPC crypto profiles — FIPS is the standard (fail-closed).
+"""Verify TriTRPC crypto profiles — FIPS is the standard, aligned to the v4 suite selector (fail-closed).
 
-'AEAD-sealed canonical bytes' recurs across the platform docs; the v1 lane is XChaCha20-Poly1305,
-which is NOT FIPS-approved. This gate makes the cipher a checkable, gateable CHOICE:
+The v1 lane is XChaCha20-Poly1305 (NOT FIPS). This gate makes the sealing suite a checkable choice
+aligned to v4 §13.4 (suite 0 research / 1 fips-classical / 2 cnsa2-ready / 3 reserved):
 
-  * mode:fips REQUIRES a FIPS-approved AEAD (AES-GCM/CCM, SP 800-38D) AND hash (SHA-2/SHA-3, FIPS
-    180-4/202), and REFUSES XChaCha20/ChaCha20-Poly1305 and BLAKE;
-  * mode:standard permits the v1 XChaCha20-Poly1305 lane.
+  * `mode` stays for back-compat; `suite` (absent => standard->0, fips->1) MUST be consistent with it.
+  * suite 0 (research): the v1 XChaCha20 lane is permitted.
+  * suite 1 (fips-classical): FIPS-approved AEAD (AES-GCM/CCM) + hash (SHA-2/3); XChaCha/BLAKE refused;
+    AND the approved-mode assertions (§13.5/§5.3-5.6): encode-before-authenticate, canonical-only,
+    nonce/IV policy, RNG from the module, self-tests complete.
+  * suite 2 (cnsa2-ready): STRICTER — AES-256-GCM only, SHA-384/512 only, and ML-KEM-1024 / ML-DSA-87
+    when a KEM/signature is declared. A merely-FIPS profile (AES-128 / SHA-256) claiming suite 2 is
+    REFUSED — this is the silent-under-assurance break, now closed.
+  * suite 3 (reserved): refused.
 
-The profile selects the sealing cipher only; it MUST NOT alter the v1/v4/vNext wire (TritPack243/
-TLEB3). Self-testing (stdlib): fips + standard examples pass; fips-with-chacha and fips-with-blake
-are rejected. A validate_schema drift-guard keeps schema and validator in lockstep.
+Selects the sealing suite only; MUST NOT alter the v1/v4/vNext wire. Self-testing (stdlib) + a
+validate_schema drift-guard.
 """
 from __future__ import annotations
 
@@ -22,12 +27,19 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "schemas" / "jsonschema" / "crypto-profile.v0.schema.json"
 EX = ROOT / "examples" / "transport"
-VALID = [EX / "crypto_profile.fips.example.json", EX / "crypto_profile.standard.example.json"]
-INVALID = [EX / "crypto_profile.fips-chacha.invalid.json", EX / "crypto_profile.fips-blake.invalid.json"]
+VALID = [EX / "crypto_profile.fips.example.json", EX / "crypto_profile.standard.example.json",
+         EX / "crypto_profile.cnsa.example.json"]
+INVALID = [EX / "crypto_profile.fips-chacha.invalid.json", EX / "crypto_profile.fips-blake.invalid.json",
+           EX / "crypto_profile.cnsa-underassured.invalid.json", EX / "crypto_profile.fips-no-approved-mode.invalid.json",
+           EX / "crypto_profile.suite-reserved.invalid.json", EX / "crypto_profile.suite-mode-mismatch.invalid.json"]
 
 FIPS_AEAD = {"AES-128-GCM", "AES-192-GCM", "AES-256-GCM", "AES-256-CCM"}   # SP 800-38D
 FIPS_HASH = {"SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-512"}      # FIPS 180-4 / 202
-KEYS = {"profileId", "mode", "aead", "hash", "wireFormat"}
+CNSA_AEAD = {"AES-256-GCM"}
+CNSA_HASH = {"SHA-384", "SHA-512"}
+CNSA_KEM = {"ML-KEM-1024"}
+CNSA_SIG = {"ML-DSA-87"}
+KEYS = {"profileId", "mode", "suite", "aead", "hash", "kem", "sig", "approvedMode", "wireFormat"}
 
 
 class CryptoError(Exception):
@@ -42,6 +54,12 @@ def load(p: Path) -> Any:
     return json.loads(p.read_text(encoding="utf-8"))
 
 
+def derived_suite(rec: dict) -> int:
+    if "suite" in rec:
+        return rec["suite"]
+    return 1 if rec.get("mode") == "fips" else 0
+
+
 def verify_profile(rec: Any) -> None:
     if not isinstance(rec, dict):
         fail("profile must be an object")
@@ -54,12 +72,45 @@ def verify_profile(rec: Any) -> None:
     aead, h = rec.get("aead"), rec.get("hash")
     if not isinstance(aead, str) or not isinstance(h, str):
         fail("aead and hash are required strings")
-    if rec["mode"] == "fips":
-        # FIPS is the standard: the AEAD and hash MUST be FIPS-approved.
+
+    suite = derived_suite(rec)
+    # suite <-> mode consistency.
+    if suite == 3:
+        fail("suite 3 is reserved and MUST NOT be used")
+    if suite == 0 and rec["mode"] != "standard":
+        fail("suite 0 (research-nonapproved) requires mode 'standard'")
+    if suite in (1, 2) and rec["mode"] != "fips":
+        fail(f"suite {suite} (approved) requires mode 'fips'")
+
+    if suite >= 1:
+        # FIPS classical floor.
         if aead not in FIPS_AEAD:
-            fail(f"FIPS mode requires a FIPS-approved AEAD {sorted(FIPS_AEAD)} — {aead!r} (e.g. XChaCha20) is refused")
+            fail(f"approved suite requires a FIPS-approved AEAD {sorted(FIPS_AEAD)} — {aead!r} refused")
         if h not in FIPS_HASH:
-            fail(f"FIPS mode requires a FIPS-approved hash {sorted(FIPS_HASH)} — {h!r} (e.g. BLAKE) is refused")
+            fail(f"approved suite requires a FIPS-approved hash {sorted(FIPS_HASH)} — {h!r} refused")
+        # Approved-mode assertions (§13.5 / §5.3-5.6).
+        am = rec.get("approvedMode")
+        if not isinstance(am, dict):
+            fail("approved suite (>=1) requires an approvedMode block (encode-before-auth, canonical-only, nonce, RNG, self-tests)")
+        if am.get("encodeBeforeAuth") is not True:
+            fail("approved mode requires encodeBeforeAuth=true (§5.6 authenticate canonical bytes only)")
+        if am.get("canonicalOnly") is not True:
+            fail("approved mode requires canonicalOnly=true (§5.6 reject non-canonical encodings)")
+        if am.get("rngSource") not in ("module", "approved-bound"):
+            fail("approved mode requires rngSource from the validated module (§5.5)")
+        if am.get("selfTests") is not True:
+            fail("approved mode requires selfTests=true (§5.3 module self-tests complete)")
+
+    if suite == 2:
+        # CNSA 2.0 — stricter than FIPS classical. Catches the silent-under-assurance break.
+        if aead not in CNSA_AEAD:
+            fail(f"CNSA suite 2 requires AES-256-GCM — {aead!r} is under-assured for CNSA")
+        if h not in CNSA_HASH:
+            fail(f"CNSA suite 2 requires SHA-384/512 — {h!r} is under-assured for CNSA")
+        if "kem" in rec and rec["kem"] not in CNSA_KEM:
+            fail(f"CNSA suite 2 requires ML-KEM-1024 — {rec['kem']!r} refused")
+        if "sig" in rec and rec["sig"] not in CNSA_SIG:
+            fail(f"CNSA suite 2 requires ML-DSA-87 — {rec['sig']!r} refused")
 
 
 def validate_schema(schema: Any) -> None:
@@ -68,12 +119,14 @@ def validate_schema(schema: Any) -> None:
     props = schema.get("properties", {})
     if props.get("mode", {}).get("enum") != ["fips", "standard"]:
         fail("schema mode enum drifted")
-    # Every FIPS-approved primitive the validator accepts MUST be offered by the schema enum,
-    # and the non-FIPS ones MUST be present too (so standard mode can select them).
+    if props.get("suite", {}).get("enum") != [0, 1, 2, 3]:
+        fail("schema suite enum drifted from the v4 selector (0/1/2/3)")
     if not FIPS_AEAD <= set(props.get("aead", {}).get("enum", [])):
         fail("schema aead enum missing a FIPS AEAD the validator accepts")
     if not FIPS_HASH <= set(props.get("hash", {}).get("enum", [])):
         fail("schema hash enum missing a FIPS hash the validator accepts")
+    if not (CNSA_KEM <= set(props.get("kem", {}).get("enum", [])) and CNSA_SIG <= set(props.get("sig", {}).get("enum", []))):
+        fail("schema kem/sig enum missing the CNSA PQC primitives the validator requires")
 
 
 def main() -> int:
@@ -90,7 +143,7 @@ def main() -> int:
     except CryptoError as exc:
         print(f"ERR: {exc}", file=sys.stderr)
         return 2
-    print("OK: crypto profile validated (2 examples, 2 non-FIPS-in-FIPS-mode rejected)")
+    print(f"OK: crypto profile validated ({len(VALID)} suites accepted, {len(INVALID)} under-assured/non-FIPS rejected)")
     return 0
 
 


### PR DESCRIPTION
## Closes the v4 suite-selector misalignment + the under-assurance break

The CryptoProfile (#81) only spoke `mode=fips|standard`. v4 §13.4 makes an explicit **suite selector** normative — `0` research / `1` fips-classical / `2` cnsa2-ready / `3` reserved — and §13.5/addendum §5.3–5.6 mandate approved-mode requirements this gate never checked.

**What's added (backward-compatible — `mode` stays, `suite` derives when absent):**
- `suite` (0/1/2/3) with **suite↔mode consistency**; `suite 3` refused.
- **suite ≥ 1** requires FIPS AEAD+hash **and** an `approvedMode` block: encode-before-authenticate, canonical-only, nonce/IV policy, RNG-from-module, self-tests (§13.5/§5.3–5.6).
- **suite 2 (CNSA 2.0)**: AES-256-GCM + SHA-384/512 only + ML-KEM-1024 / ML-DSA-87. **A merely-FIPS profile (AES-128 / SHA-256) claiming suite 2 is refused** — closing the silent-under-assurance gap where a CNSA-required deployment could be handed a weaker FIPS profile.

**Teeth:** fips (suite 1) / standard (suite 0) / CNSA (suite 2) accepted; fips-chacha, fips-blake, **cnsa-underassured**, fips-no-approved-mode, suite-reserved, suite-mode-mismatch all refused. Schema drift-guard extended.

Additive — selects the sealing suite only; does **not** change the v1/v4/vNext wire. First of the v4-alignment remediation series (gap A + B from the v4/vNext gap analysis).