### PR TITLE
feat(orchestration): required-suite gate — a workload meets-or-exceeds its node's crypto suite

### DIFF
--- a/.github/workflows/validate-suite-gate.yml
+++ b/.github/workflows/validate-suite-gate.yml
@@ -1,0 +1,29 @@
+name: validate-suite-gate
+on:
+  pull_request:
+    paths:
+      - "reference/suite_gate.py"
+      - "tools/verify_suite_gate.py"
+      - "schemas/jsonschema/work-unit-pack.v0.schema.json"
+      - "spec/orchestration/mesh_work_unit.md"
+      - ".github/workflows/validate-suite-gate.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "reference/suite_gate.py"
+      - "tools/verify_suite_gate.py"
+      - "schemas/jsonschema/work-unit-pack.v0.schema.json"
+      - "spec/orchestration/mesh_work_unit.md"
+      - ".github/workflows/validate-suite-gate.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate suite gate (workload meets-or-exceeds profile suite)
+        run: python tools/verify_suite_gate.py

--- a/reference/suite_gate.py
+++ b/reference/suite_gate.py
@@ -1,0 +1,38 @@
+"""Reference suite gate — a workload runs only on a crypto profile that MEETS OR EXCEEDS its suite.
+
+A WorkUnitPack may declare policy.requiredSuite (v4 §13.4: 0 research / 1 fips-classical / 2
+cnsa2-ready). The executing node's resolved crypto profile carries a suite (explicit, or derived
+standard->0 / fips->1). This gate refuses to run a workload on a profile whose suite is BELOW the
+required one — closing the break where a CNSA-required (suite 2) workload could settle on a merely
+FIPS (suite 1) node. Fail-closed, numeric monotone (suite 2 > 1 > 0).
+
+FIPS/boundary: pure comparison, no primitive. The profile's own approved-mode/CNSA correctness is
+checked by verify_crypto_profile; this gate only enforces meet-or-exceed. Does not touch the wire.
+"""
+from __future__ import annotations
+
+
+class SuiteError(Exception):
+    pass
+
+
+def profile_suite(profile: dict) -> int:
+    """Resolve a crypto profile's suite: explicit `suite`, else derived (fips->1, standard->0)."""
+    if "suite" in profile:
+        return int(profile["suite"])
+    return 1 if profile.get("mode") == "fips" else 0
+
+
+def required_suite(pack: dict) -> int:
+    return int((pack.get("policy") or {}).get("requiredSuite", 0))
+
+
+def require_suite(pack: dict, profile: dict) -> int:
+    """Refuse (fail-closed) if the profile's suite is below the pack's requiredSuite. Returns the suite."""
+    need = required_suite(pack)
+    have = profile_suite(profile)
+    if have < need:
+        raise SuiteError(
+            f"crypto profile suite {have} does not meet the workload's requiredSuite {need} "
+            f"(a suite-{need} workload cannot run on a suite-{have} profile)")
+    return have

--- a/schemas/jsonschema/work-unit-pack.v0.schema.json
+++ b/schemas/jsonschema/work-unit-pack.v0.schema.json
@@ -5,25 +5,100 @@
   "description": "A federated-mesh Work-Unit pack (Dual-Orchestration plane B): the TriTRPC-enveloped descriptor a Mesh Coordinator hands to a volunteer node. Header carries the Avro SCHEMA-ID (SHA3), governance POLICY (residency/isolation/SLO), a PROOF_MODE, and a SANDBOX; the body is content-addressed (SHA-256 CID, per the FederationCryptoProfile). This is the request half; a WorkUnitResult is the returned half. Settlement is decided by reference/mesh_coordinator.py, fail-closed.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["wu_id", "schema_id", "proof_mode", "sandbox", "policy", "body_cid", "replication", "context", "signature"],
+  "required": [
+    "wu_id",
+    "schema_id",
+    "proof_mode",
+    "sandbox",
+    "policy",
+    "body_cid",
+    "replication",
+    "context",
+    "signature"
+  ],
   "properties": {
-    "wu_id": { "type": "string", "minLength": 1 },
-    "schema_id": { "type": "string", "pattern": "^sha3-256:", "description": "SHA3-256 of the Avro canonical schema of the body (the SCHEMA-ID)." },
-    "proof_mode": { "type": "string", "enum": ["redundant", "spot_check", "tee", "zk"] },
-    "sandbox": { "type": "string", "enum": ["docker", "lightning", "wasm", "kata"] },
+    "wu_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema_id": {
+      "type": "string",
+      "pattern": "^sha3-256:",
+      "description": "SHA3-256 of the Avro canonical schema of the body (the SCHEMA-ID)."
+    },
+    "proof_mode": {
+      "type": "string",
+      "enum": [
+        "redundant",
+        "spot_check",
+        "tee",
+        "zk"
+      ]
+    },
+    "sandbox": {
+      "type": "string",
+      "enum": [
+        "docker",
+        "lightning",
+        "wasm",
+        "kata"
+      ]
+    },
     "policy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["residency", "isolation", "slo_ms"],
+      "required": [
+        "residency",
+        "isolation",
+        "slo_ms"
+      ],
       "properties": {
-        "residency": { "type": "string", "minLength": 1, "description": "required data-residency region, e.g. EU / US / any" },
-        "isolation": { "type": "string", "enum": ["strong", "standard"] },
-        "slo_ms": { "type": "integer", "minimum": 1 }
+        "residency": {
+          "type": "string",
+          "minLength": 1,
+          "description": "required data-residency region, e.g. EU / US / any"
+        },
+        "isolation": {
+          "type": "string",
+          "enum": [
+            "strong",
+            "standard"
+          ]
+        },
+        "slo_ms": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "requiredSuite": {
+          "type": "integer",
+          "enum": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "description": "v4 suite the executing node's crypto profile MUST meet or exceed (absent => 0). A suite-2 (CNSA) workload cannot settle on a merely suite-1 (FIPS) profile."
+        }
       }
     },
-    "body_cid": { "type": "string", "pattern": "^sha256:", "description": "content-addressed body (SHA-256 CID; FederationCryptoProfile)." },
-    "replication": { "type": "integer", "minimum": 1, "description": "number of independent nodes the WU is dispatched to (redundant mode needs >= 3 for a majority)." },
-    "context": { "type": "string", "minLength": 1, "description": "JSON-LD @context reference for the body." },
-    "signature": { "type": "string", "minLength": 1 }
+    "body_cid": {
+      "type": "string",
+      "pattern": "^sha256:",
+      "description": "content-addressed body (SHA-256 CID; FederationCryptoProfile)."
+    },
+    "replication": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "number of independent nodes the WU is dispatched to (redundant mode needs >= 3 for a majority)."
+    },
+    "context": {
+      "type": "string",
+      "minLength": 1,
+      "description": "JSON-LD @context reference for the body."
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 1
+    }
   }
 }

--- a/spec/orchestration/mesh_work_unit.md
+++ b/spec/orchestration/mesh_work_unit.md
@@ -59,3 +59,12 @@ deployment, never XChaCha20-Poly1305. This module does not touch the tritrpc v4/
 Every settled WU carries an attested node + a residency-checked region + a proof for its declared
 mode — the same fail-closed doctrine the `ProjectComputeSetting` validator enforces at declaration
 time ("no ungoverned compute"). No attestation, no residency match, or no majority ⇒ no settlement.
+
+## Required assurance suite (v4 §13.4)
+
+A `WorkUnitPack` may declare `policy.requiredSuite` (0 research / 1 fips-classical / 2 cnsa2-ready).
+The executing node's resolved crypto profile carries a suite (explicit, or derived `fips→1`/
+`standard→0`). `reference/suite_gate.py:require_suite` refuses, fail-closed, to place a workload on a
+profile whose suite is **below** the required one — a suite-2 (CNSA) workload cannot settle on a
+suite-1 (FIPS) node. This is the cross-consumer meet-or-exceed check that ties the mesh to the
+CryptoProfile suite selector; the profile's own correctness is checked by `verify_crypto_profile`.

--- a/tools/verify_suite_gate.py
+++ b/tools/verify_suite_gate.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Verify the suite gate refuses under-assured placement (fail-closed).
+
+A CNSA-required (suite 2) workload MUST NOT run on a merely-FIPS (suite 1) or research (suite 0)
+profile; a FIPS-required (suite 1) workload MUST NOT run on a research (suite 0) profile; a workload
+with no requiredSuite (=> 0) runs anywhere. Profile suites resolve explicitly or derive from mode.
+Stdlib self-test + a schema drift-guard that requiredSuite is an accepted policy field.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import suite_gate as sg  # noqa: E402
+
+SCHEMA = ROOT / "schemas" / "jsonschema" / "work-unit-pack.v0.schema.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def pack(req=None):
+    p = {"wu_id": "wu-x", "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 1000}}
+    if req is not None:
+        p["policy"]["requiredSuite"] = req
+    return p
+
+
+def refused(fn):
+    try:
+        fn(); return False
+    except sg.SuiteError:
+        return True
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    if schema["properties"]["policy"]["properties"].get("requiredSuite", {}).get("enum") == [0, 1, 2, 3]:
+        CHECKS["schema:requiredSuite-present"] = True
+    else:
+        FAILURES.append("schema policy.requiredSuite drift")
+
+    cnsa = {"suite": 2, "mode": "fips"}
+    fips = {"suite": 1, "mode": "fips"}
+    fips_derived = {"mode": "fips"}   # no explicit suite -> 1
+    research = {"mode": "standard"}   # -> 0
+
+    # 1. CNSA workload on CNSA profile -> ok.
+    CHECKS["ok:cnsa-workload-cnsa-profile"] = (sg.require_suite(pack(2), cnsa) == 2)
+    # 2. THE BREAK: CNSA workload on FIPS profile -> refused.
+    CHECKS["fail-closed:cnsa-workload-fips-profile-refused"] = refused(lambda: sg.require_suite(pack(2), fips))
+    # 3. CNSA workload on research profile -> refused.
+    CHECKS["fail-closed:cnsa-workload-research-refused"] = refused(lambda: sg.require_suite(pack(2), research))
+    # 4. FIPS workload on research profile -> refused.
+    CHECKS["fail-closed:fips-workload-research-refused"] = refused(lambda: sg.require_suite(pack(1), research))
+    # 5. FIPS workload on derived-fips profile (no explicit suite) -> ok.
+    CHECKS["ok:derived-suite-fips"] = (sg.require_suite(pack(1), fips_derived) == 1)
+    # 6. No requiredSuite (=>0) runs anywhere.
+    CHECKS["ok:no-requirement-runs-anywhere"] = (sg.require_suite(pack(), research) == 0)
+    # 7. Determinism.
+    CHECKS["deterministic"] = (sg.require_suite(pack(2), cnsa) == sg.require_suite(pack(2), cnsa))
+
+    for k, v in CHECKS.items():
+        if not v:
+            FAILURES.append(f"{k} failed")
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Closes the 'CNSA workload settles on a merely-FIPS node' break

The v4 gap analysis flagged that a `WorkUnitPack` couldn't say suite=1 vs suite=2, so a CNSA-required workload could settle on a FIPS-only node — nothing compared them. This adds the meet-or-exceed gate.

- **schema:** `WorkUnitPack.policy.requiredSuite` (0/1/2/3), optional/additive — existing fixtures unchanged.
- **`reference/suite_gate.py`:** `require_suite(pack, profile)` resolves the profile's suite (explicit or derived `fips→1`/`standard→0`) and **refuses when it's below `requiredSuite`** (numeric monotone).
- **Teeth (8):** CNSA-on-CNSA ok · **CNSA-on-FIPS / CNSA-on-research / FIPS-on-research each refused** · derived-suite + no-requirement paths · determinism · schema drift-guard. The `mesh_coordinator` and `mesh_scheduler` verifiers stay green (no regression).

FIPS: pure comparison, no primitive. Additive — wire untouched. Ties the mesh to the CryptoProfile suite selector (closes gap D + the cross-consumer half of F).