### PR TITLE
test(conformance): v4 §15.1 suite-separation matrix — separation is enforced end to end

### DIFF
--- a/.github/workflows/validate-suite-separation.yml
+++ b/.github/workflows/validate-suite-separation.yml
@@ -1,0 +1,37 @@
+name: validate-suite-separation
+on:
+  pull_request:
+    paths:
+      - "tools/verify_suite_separation.py"
+      - "reference/suite_gate.py"
+      - "tools/verify_crypto_profile.py"
+      - "tools/verify_federation_crypto_profile.py"
+      - "fixtures/conformance/suite_separation_matrix.json"
+      - "examples/transport/crypto_profile.*.json"
+      - "examples/transport/federation_crypto_profile.*.json"
+      - "spec/conformance/suite_separation.md"
+      - ".github/workflows/validate-suite-separation.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "tools/verify_suite_separation.py"
+      - "reference/suite_gate.py"
+      - "tools/verify_crypto_profile.py"
+      - "tools/verify_federation_crypto_profile.py"
+      - "fixtures/conformance/suite_separation_matrix.json"
+      - "examples/transport/crypto_profile.*.json"
+      - "examples/transport/federation_crypto_profile.*.json"
+      - "spec/conformance/suite_separation.md"
+      - ".github/workflows/validate-suite-separation.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate suite-separation conformance matrix
+        run: python tools/verify_suite_separation.py

--- a/fixtures/conformance/suite_separation_matrix.json
+++ b/fixtures/conformance/suite_separation_matrix.json
@@ -1,0 +1,59 @@
+{
+  "description": "v4 \u00a715.1 approved/non-approved suite-separation conformance matrix. A workload of requiredSuite r runs on a profile of suite p iff p>=r (monotone). Also anchors the canonical per-suite crypto-profile examples.",
+  "cryptoProfilesBySuite": {
+    "0": "examples/transport/crypto_profile.standard.example.json",
+    "1": "examples/transport/crypto_profile.fips.example.json",
+    "2": "examples/transport/crypto_profile.cnsa.example.json"
+  },
+  "federationProfilesBySuite": {
+    "1": "examples/transport/federation_crypto_profile.fips-eddsa.example.json",
+    "2": "examples/transport/federation_crypto_profile.cnsa.example.json"
+  },
+  "gateMatrix": [
+    {
+      "requiredSuite": 0,
+      "profileSuite": 0,
+      "accept": true
+    },
+    {
+      "requiredSuite": 0,
+      "profileSuite": 1,
+      "accept": true
+    },
+    {
+      "requiredSuite": 0,
+      "profileSuite": 2,
+      "accept": true
+    },
+    {
+      "requiredSuite": 1,
+      "profileSuite": 0,
+      "accept": false
+    },
+    {
+      "requiredSuite": 1,
+      "profileSuite": 1,
+      "accept": true
+    },
+    {
+      "requiredSuite": 1,
+      "profileSuite": 2,
+      "accept": true
+    },
+    {
+      "requiredSuite": 2,
+      "profileSuite": 0,
+      "accept": false
+    },
+    {
+      "requiredSuite": 2,
+      "profileSuite": 1,
+      "accept": false
+    },
+    {
+      "requiredSuite": 2,
+      "profileSuite": 2,
+      "accept": true
+    }
+  ]
+}

--- a/spec/conformance/suite_separation.md
+++ b/spec/conformance/suite_separation.md
@@ -1,0 +1,18 @@
+# Suite-separation conformance (v4 §15.1)
+
+v4 §15.1 requires a fixture class for **approved/non-approved suite separation**. This is it — a
+single conformance artifact proving the suite selector is *enforced*, not merely declared.
+
+`fixtures/conformance/suite_separation_matrix.json` records the monotone gate matrix (a workload of
+`requiredSuite r` runs on a profile of `suite p` **iff p ≥ r**) and anchors the canonical per-suite
+CryptoProfile / FederationCryptoProfile examples. `tools/verify_suite_separation.py`:
+
+1. **recomputes** the gate matrix with `reference/suite_gate.py` and compares it to the recorded
+   fixture (recompute-don't-trust) — every cell must match `p ≥ r`;
+2. confirms each anchored profile resolves to its claimed suite;
+3. runs the CryptoProfile and FederationCryptoProfile validators and requires both green — their
+   approved suites accepted, their under-assured / non-FIPS profiles refused.
+
+Together these show separation end to end: an under-assured profile is refused at the profile gate,
+and a higher-suite workload is refused on a lower-suite profile at the placement gate. FIPS: no
+primitive (comparison + validator composition); does not touch the wire.

--- a/tools/verify_suite_separation.py
+++ b/tools/verify_suite_separation.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Verify v4 §15.1 suite-separation conformance — the matrix + the per-suite profile classes.
+
+Three properties, all fail-closed:
+  1. the required-suite gate's accept/refuse matches the monotone law (accept iff profileSuite >=
+     requiredSuite) over the whole matrix — RECOMPUTED here and compared to the recorded fixture
+     (recompute-don't-trust);
+  2. each per-suite crypto profile the matrix anchors actually resolves to that suite;
+  3. the CryptoProfile and FederationCryptoProfile validators both still pass (their approved suites
+     accepted, their under-assured/non-FIPS profiles refused) — i.e. suite separation is enforced end
+     to end. Stdlib, repo convention.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+sys.path.insert(0, str(ROOT / "tools"))
+import suite_gate as sg  # noqa: E402
+import verify_crypto_profile as vcp  # noqa: E402
+import verify_federation_crypto_profile as vfp  # noqa: E402
+
+FIX = ROOT / "fixtures" / "conformance" / "suite_separation_matrix.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def main() -> int:
+    vec = json.loads(FIX.read_text())
+
+    # 1. Recompute the gate matrix and compare to the recorded fixture.
+    ok_matrix = True
+    for cell in vec["gateMatrix"]:
+        r, p = cell["requiredSuite"], cell["profileSuite"]
+        pack = {"policy": {"requiredSuite": r}}
+        profile = {"suite": p}
+        try:
+            sg.require_suite(pack, profile)
+            got = True
+        except sg.SuiteError:
+            got = False
+        if got != cell["accept"] or cell["accept"] != (p >= r):
+            ok_matrix = False
+            FAILURES.append(f"matrix cell r={r} p={p}: expected accept={p>=r}, fixture={cell['accept']}, gate={got}")
+    CHECKS["matrix:gate-matches-monotone-law"] = ok_matrix
+
+    # 2. Each anchored crypto profile resolves to its claimed suite.
+    ok_anchor = True
+    for suite_str, rel in vec["cryptoProfilesBySuite"].items():
+        prof = json.loads((ROOT / rel).read_text())
+        if sg.profile_suite(prof) != int(suite_str):
+            ok_anchor = False
+            FAILURES.append(f"{rel} does not resolve to suite {suite_str}")
+    CHECKS["anchors:profiles-resolve-to-suite"] = ok_anchor
+
+    # 3. Both crypto validators still enforce separation (approved accepted, under-assured refused).
+    CHECKS["separation:crypto-profile-validator-green"] = (vcp.main() == 0)
+    CHECKS["separation:federation-validator-green"] = (vfp.main() == 0)
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Proves the suite selector is *enforced*, not just declared (v4 §15.1)

The gap analysis noted no fixture proved suite separation. This is the §15.1 approved/non-approved separation fixture class.

- **`fixtures/conformance/suite_separation_matrix.json`** — the monotone gate matrix (accept iff `profileSuite ≥ requiredSuite`) + the canonical per-suite crypto/federation profile anchors.
- **`tools/verify_suite_separation.py`** — **recomputes** the matrix via `suite_gate` and compares to the fixture (recompute-don't-trust); confirms each anchored profile resolves to its suite; and runs the CryptoProfile + FederationCryptoProfile validators, requiring both green.

Separation shown end to end: under-assured profiles refused at the **profile** gate; higher-suite workloads refused on lower-suite profiles at the **placement** gate. FIPS: no primitive; wire untouched. Closes gap E — the last of the buildable v4-alignment remediation items.