### PR TITLE
feat(go): v4 hot-path primitives Control243 + State243 — byte-parity with the Python oracle

### DIFF
--- a/go/tritrpcv1/v4_primitives.go
+++ b/go/tritrpcv1/v4_primitives.go
@@ -1,0 +1,81 @@
+package tritrpcv1
+
+// v4 hot-path primitives — Go port, byte-identical to the Python oracle
+// (reference/experimental/tritrpc_requirements_impl_v4). Control243 and State243 each pack five
+// trits (canonical fields in {0,1,2}) big-endian into a single value in 0..242 (243 = 3^5), the
+// compact control/state byte of the v4 hot frame. Parity is asserted against the shared oracle
+// vectors (generated/sample_vectors_v4.json) in v4_primitives_test.go.
+
+import "fmt"
+
+// Control243 fields (profile, lane, evidence, fallback, routefmt), each a trit 0..2.
+type Control243 struct {
+	Profile  uint8
+	Lane     uint8
+	Evidence uint8
+	Fallback uint8
+	RouteFmt uint8
+}
+
+// State243 fields (lifecycle, epistemic, novelty, friction, scope), each a trit 0..2.
+type State243 struct {
+	Lifecycle uint8
+	Epistemic uint8
+	Novelty   uint8
+	Friction  uint8
+	Scope     uint8
+}
+
+func packTrits5(name string, a, b, c, d, e uint8) (uint8, error) {
+	for _, t := range []uint8{a, b, c, d, e} {
+		if t > 2 {
+			return 0, fmt.Errorf("%s fields must be trits in canonical output", name)
+		}
+	}
+	return ((((a*3)+b)*3+c)*3+d)*3 + e, nil
+}
+
+func unpackTrits5(value uint8) (a, b, c, d, e uint8, err error) {
+	if value > 242 {
+		return 0, 0, 0, 0, 0, fmt.Errorf("byte must be in 0..242")
+	}
+	w := value
+	e = w % 3
+	w /= 3
+	d = w % 3
+	w /= 3
+	c = w % 3
+	w /= 3
+	b = w % 3
+	w /= 3
+	a = w % 3
+	return
+}
+
+// Encode packs the Control243 into its canonical 0..242 byte.
+func (c Control243) Encode() (uint8, error) {
+	return packTrits5("Control243", c.Profile, c.Lane, c.Evidence, c.Fallback, c.RouteFmt)
+}
+
+// DecodeControl243 inverts Encode.
+func DecodeControl243(value uint8) (Control243, error) {
+	a, b, cc, d, e, err := unpackTrits5(value)
+	if err != nil {
+		return Control243{}, fmt.Errorf("Control243 %w", err)
+	}
+	return Control243{Profile: a, Lane: b, Evidence: cc, Fallback: d, RouteFmt: e}, nil
+}
+
+// Encode packs the State243 into its canonical 0..242 byte.
+func (s State243) Encode() (uint8, error) {
+	return packTrits5("State243", s.Lifecycle, s.Epistemic, s.Novelty, s.Friction, s.Scope)
+}
+
+// DecodeState243 inverts Encode.
+func DecodeState243(value uint8) (State243, error) {
+	a, b, c, d, e, err := unpackTrits5(value)
+	if err != nil {
+		return State243{}, fmt.Errorf("State243 %w", err)
+	}
+	return State243{Lifecycle: a, Epistemic: b, Novelty: c, Friction: d, Scope: e}, nil
+}

--- a/go/tritrpcv1/v4_primitives_test.go
+++ b/go/tritrpcv1/v4_primitives_test.go
@@ -1,0 +1,72 @@
+package tritrpcv1
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// oraclePath locates the shared Python-generated parity vectors.
+func oraclePath() string {
+	return filepath.Join("..", "..", "reference", "experimental",
+		"tritrpc_requirements_impl_v4", "generated", "sample_vectors_v4.json")
+}
+
+// TestState243MatchesOracle: the canonical State243 (active/verified/routine/fluid/cohort) encodes
+// to the exact byte the Python oracle records (recompute-don't-trust against the shared vector).
+func TestState243MatchesOracle(t *testing.T) {
+	data, err := os.ReadFile(oraclePath())
+	if err != nil {
+		t.Fatalf("read oracle: %v", err)
+	}
+	var vec map[string]json.RawMessage
+	if err := json.Unmarshal(data, &vec); err != nil {
+		t.Fatalf("parse oracle: %v", err)
+	}
+	var want uint8
+	if err := json.Unmarshal(vec["state243"], &want); err != nil {
+		t.Fatalf("oracle state243: %v", err)
+	}
+	// active=1, verified=2, routine=0, fluid=0, cohort=1
+	got, err := State243{Lifecycle: 1, Epistemic: 2, Novelty: 0, Friction: 0, Scope: 1}.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("State243 parity: got %d, oracle %d", got, want)
+	}
+}
+
+// TestControlAndStateRoundtripAll: every value 0..242 round-trips through both primitives.
+func TestControlAndStateRoundtripAll(t *testing.T) {
+	for v := 0; v <= 242; v++ {
+		c, err := DecodeControl243(uint8(v))
+		if err != nil {
+			t.Fatalf("decode control %d: %v", v, err)
+		}
+		if enc, _ := c.Encode(); enc != uint8(v) {
+			t.Fatalf("control roundtrip %d -> %d", v, enc)
+		}
+		s, err := DecodeState243(uint8(v))
+		if err != nil {
+			t.Fatalf("decode state %d: %v", v, err)
+		}
+		if enc, _ := s.Encode(); enc != uint8(v) {
+			t.Fatalf("state roundtrip %d -> %d", v, enc)
+		}
+	}
+}
+
+// TestNonTritRejected: a non-canonical field (>2) is refused (fail-closed).
+func TestNonTritRejected(t *testing.T) {
+	if _, err := (State243{Lifecycle: 3}).Encode(); err == nil {
+		t.Fatal("expected non-trit State243 field to be rejected")
+	}
+	if _, err := (Control243{Profile: 5}).Encode(); err == nil {
+		t.Fatal("expected non-trit Control243 field to be rejected")
+	}
+	if _, err := DecodeState243(243); err == nil {
+		t.Fatal("expected out-of-range byte to be rejected")
+	}
+}


### PR DESCRIPTION
## First native Go v4 primitives — oracle-driven, byte-parity

The v4/vNext gap analysis's item 5 (native runtime lag) — corrected: **Rust has a WIP v4 scaffold, Go had nothing**. This starts the Go port, driven by the shared Python oracle so parity is *provable*, not asserted.

- **`Control243` / `State243`** — each packs five canonical trits (fields ∈ {0,1,2}) big-endian into a single `0..242` byte (the compact control/state byte of the v4 hot frame), byte-identical to `codec.py`.
- **Parity test** — `State243(active/verified/routine/fluid/cohort)` encodes to the exact byte the shared oracle (`generated/sample_vectors_v4.json`) records: **136** (recompute-don't-trust against the Python oracle). Full `0..242` round-trip for both; non-trit / out-of-range **refused** (fail-closed).

gofmt-clean, full Go suite green (no regression). Additive — does not touch the v1 wire. This is the honest first slice of the multi-primitive Go port (S243, Handle243, Braid243, StreamHot frames + the Rust-scaffold parity correction follow).