### PR TITLE
feat(buildforge): run-lifecycle state machine v0.1 — authoring != merge authority, fail-closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures descriptor-manifest-refs aux-shape avro-lom-diagrams integration-audit
+.PHONY: verify fmt rust-fmt go-fmt rust-test go-test fixtures descriptor-manifest-refs aux-shape avro-lom-diagrams build-forge integration-audit
 
-verify: fmt rust-test go-test fixtures aux-shape avro-lom-diagrams
+verify: fmt rust-test go-test fixtures aux-shape avro-lom-diagrams build-forge
 
 fmt: rust-fmt go-fmt
 
@@ -27,6 +27,9 @@ aux-shape:
 
 avro-lom-diagrams:
 	python tools/check_avro_lom_diagrams.py
+
+build-forge:
+	python tools/verify_build_forge_state_machine.py
 
 integration-audit:
 	./tools/audit_branch_pr_integration.sh main HEAD

--- a/fixtures/buildforge/build_forge_tritrpc_v0_1.proto
+++ b/fixtures/buildforge/build_forge_tritrpc_v0_1.proto
@@ -1,0 +1,317 @@
+syntax = "proto3";
+
+package tritrpc.buildforge.v1;
+
+message Empty {}
+
+enum RunState {
+  RUN_STATE_UNSPECIFIED = 0;
+  CREATED = 1;
+  AUTHORIZED = 2;
+  MOUNTED = 3;
+  BRANCHED = 4;
+  PATCHED = 5;
+  PUSHED = 6;
+  PR_OPEN = 7;
+  CHECKS_PENDING = 8;
+  REVIEW_PENDING = 9;
+  READY_TO_MERGE = 10;
+  MERGED = 11;
+  REJECTED = 12;
+  ABORTED = 13;
+  EXPIRED = 14;
+  FAILED = 15;
+}
+
+enum ReviewState {
+  REVIEW_STATE_UNSPECIFIED = 0;
+  COMMENTED = 1;
+  APPROVED = 2;
+  CHANGES_REQUESTED = 3;
+  DISMISSED = 4;
+  PENDING = 5;
+}
+
+enum CheckState {
+  CHECK_STATE_UNSPECIFIED = 0;
+  QUEUED = 1;
+  IN_PROGRESS = 2;
+  SUCCESS = 3;
+  FAILURE = 4;
+  CANCELLED = 5;
+  NEUTRAL = 6;
+  SKIPPED = 7;
+  TIMED_OUT = 8;
+  ACTION_REQUIRED = 9;
+}
+
+message DelegationGrant {
+  string grant_id = 1;
+  string grantor_principal_id = 2;
+  string grantee_agent_id = 3;
+  string purpose = 4;
+  repeated string scope = 5;
+  repeated string context_mount_refs = 6;
+  string approval_mode = 7;
+  string valid_from = 8;
+  string valid_until = 9;
+  bool revocable = 10;
+  string signature = 11;
+}
+
+message ContextMount {
+  string context_mount_id = 1;
+  string subject_principal_id = 2;
+  string resource_uri = 3;
+  string access_mode = 4;
+  repeated string allow_paths = 5;
+  repeated string deny_paths = 6;
+  string redaction_policy = 7;
+  int32 ttl_seconds = 8;
+  string audit_tag = 9;
+  string status = 10;
+}
+
+message ForgeTask {
+  string forge_task_id = 1;
+  string principal_id = 2;
+  string agent_id = 3;
+  string repo_ref = 4;
+  string base_ref = 5;
+  string intent = 6;
+  repeated string issue_refs = 7;
+  repeated string constraints = 8;
+  string acceptance_policy_ref = 9;
+  string deadline = 10;
+  RunState status = 11;
+}
+
+message BranchLease {
+  string branch_lease_id = 1;
+  string repo_ref = 2;
+  string base_ref = 3;
+  string head_ref = 4;
+  string lease_owner = 5;
+  bool force_push_allowed = 6;
+  string created_at = 7;
+  string expires_at = 8;
+  string status = 9;
+}
+
+message PatchsetProposal {
+  string patchset_id = 1;
+  string forge_task_id = 2;
+  string branch_lease_id = 3;
+  repeated string changed_files = 4;
+  string diff_hash = 5;
+  double risk_score = 6;
+  repeated string policy_findings = 7;
+  repeated string generated_commit_shas = 8;
+  string status = 9;
+}
+
+message ForgeCheck {
+  string check_id = 1;
+  string provider_check_ref = 2;
+  string forge_task_id = 3;
+  string name = 4;
+  CheckState state = 5;
+  string details_url = 6;
+  int32 annotation_count = 7;
+}
+
+message ForgeReview {
+  string review_id = 1;
+  string provider_review_ref = 2;
+  string forge_task_id = 3;
+  string reviewer_ref = 4;
+  ReviewState review_state = 5;
+  string body = 6;
+  string submitted_at = 7;
+}
+
+message Proof {
+  string proof_id = 1;
+  string proof_type = 2;
+  string forge_task_id = 3;
+  repeated string artifact_refs = 4;
+  repeated string artifact_hashes = 5;
+  repeated string witness_refs = 6;
+  string outcome = 7;
+  string timestamp = 8;
+  string signature = 9;
+}
+
+message Cairn {
+  string cairn_id = 1;
+  string parent_cairn_id = 2;
+  repeated string event_refs = 3;
+  string state_root = 4;
+  repeated string signers = 5;
+  string replay_class = 6;
+  string timestamp = 7;
+}
+
+message NormalizedWebhook {
+  string envelope_id = 1;
+  string provider = 2;
+  string provider_delivery_id = 3;
+  string provider_event = 4;
+  string provider_action = 5;
+  string provider_instance = 6;
+  string received_at = 7;
+  bool verified = 8;
+  string verification_method = 9;
+  string installation_ref = 10;
+  string project_ref = 11;
+  string repository_ref = 12;
+  string actor_ref = 13;
+  string target_ref = 14;
+  string source_ref = 15;
+  string head_sha = 16;
+  string base_sha = 17;
+  string normalized_kind = 18;
+  string raw_body_sha256 = 19;
+  bytes raw_payload = 20;
+}
+
+message ProviderAuthRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string acting_principal_id = 3;
+  string auth_mode = 4;
+  repeated string requested_permissions = 5;
+}
+
+message ProviderCredential {
+  string credential_id = 1;
+  string provider = 2;
+  string auth_mode = 3;
+  string expires_at = 4;
+  repeated string project_refs = 5;
+}
+
+message RepoSnapshotRequest {
+  string provider = 1;
+  string project_ref = 2;
+}
+
+message RepoSnapshot {
+  string repo_ref = 1;
+  string default_branch = 2;
+  bool archived = 3;
+  bool fork = 4;
+  string visibility = 5;
+  string web_url = 6;
+}
+
+message PolicySnapshotRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string target_ref = 3;
+}
+
+message ProtectionSnapshot {
+  string project_ref = 1;
+  string target_ref = 2;
+  repeated string required_checks = 3;
+  int32 required_reviews = 4;
+  bool require_up_to_date = 5;
+  bool merge_queue_required = 6;
+  bool code_owner_required = 7;
+  repeated string bypass_actors = 8;
+  string captured_at = 9;
+  string raw_ref = 10;
+}
+
+message CreateBranchRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string base_ref = 3;
+  string head_ref = 4;
+}
+
+message ChangeRequestRef {
+  string provider = 1;
+  string project_ref = 2;
+  string number_or_iid = 3;
+  string url = 4;
+  string head_ref = 5;
+  string base_ref = 6;
+  string head_sha = 7;
+  string state = 8;
+  string mergeable_state = 9;
+  bool draft = 10;
+}
+
+message PushPatchsetRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string head_ref = 3;
+  string diff_hash = 4;
+}
+
+message PushResult {
+  string project_ref = 1;
+  string head_ref = 2;
+  string head_sha = 3;
+  string url = 4;
+}
+
+message CreateChangeRequestRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string base_ref = 3;
+  string head_ref = 4;
+  string title = 5;
+  string body = 6;
+}
+
+message RequestReviewersRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string number_or_iid = 3;
+  repeated string reviewer_refs = 4;
+}
+
+message MergeRequest {
+  string provider = 1;
+  string project_ref = 2;
+  string number_or_iid = 3;
+  string expected_head_sha = 4;
+  string merge_method = 5;
+}
+
+message MergeResult {
+  bool merged = 1;
+  string merge_commit_sha = 2;
+  string message = 3;
+  string provider_status = 4;
+  string merged_at = 5;
+}
+
+service ForgeProviderAdapter {
+  rpc MintContextCredential(ProviderAuthRequest) returns (ProviderCredential);
+  rpc GetRepoSnapshot(RepoSnapshotRequest) returns (RepoSnapshot);
+  rpc GetProtectionSnapshot(PolicySnapshotRequest) returns (ProtectionSnapshot);
+  rpc CreateBranch(CreateBranchRequest) returns (BranchLease);
+  rpc PushPatchset(PushPatchsetRequest) returns (PushResult);
+  rpc CreateChangeRequest(CreateChangeRequestRequest) returns (ChangeRequestRef);
+  rpc RequestReviewers(RequestReviewersRequest) returns (Empty);
+  rpc MergeChangeRequest(MergeRequest) returns (MergeResult);
+  rpc NormalizeWebhook(NormalizedWebhook) returns (NormalizedWebhook);
+}
+
+service BuildForge {
+  rpc CreateTask(ForgeTask) returns (ForgeTask);
+  rpc AuthorizeTask(DelegationGrant) returns (ForgeTask);
+  rpc MountRepoContext(ContextMount) returns (ContextMount);
+  rpc OpenBranchLease(CreateBranchRequest) returns (BranchLease);
+  rpc ProposePatchset(PatchsetProposal) returns (PatchsetProposal);
+  rpc PushPatchset(PushPatchsetRequest) returns (PushResult);
+  rpc OpenChangeRequest(CreateChangeRequestRequest) returns (ChangeRequestRef);
+  rpc RequestReviewers(RequestReviewersRequest) returns (Empty);
+  rpc AttachCheck(ForgeCheck) returns (ForgeCheck);
+  rpc EmitProof(Proof) returns (Proof);
+  rpc CloseCairn(Cairn) returns (Cairn);
+}

--- a/fixtures/buildforge/reject_created_to_merged.json
+++ b/fixtures/buildforge/reject_created_to_merged.json
@@ -1,0 +1,8 @@
+{
+  "forge_task_id": "ft-skip-merge-001",
+  "note": "Skipping the lifecycle straight to MERGED is an event-order violation.",
+  "expect": {"reject": {"code": "BF-INT-004", "at": 0}},
+  "transitions": [
+    {"from": "CREATED", "to": "MERGED", "ctx": {"merge_grant_present": true, "policy_gates_passed": true}}
+  ]
+}

--- a/fixtures/buildforge/reject_discontinuous_log.json
+++ b/fixtures/buildforge/reject_discontinuous_log.json
@@ -1,0 +1,9 @@
+{
+  "forge_task_id": "ft-discontinuous-001",
+  "note": "Edge 1 starts from a state that is not edge 0's target; the log is discontinuous.",
+  "expect": {"reject": {"code": "BF-INT-004", "at": 1}},
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "MOUNTED", "to": "BRANCHED"}
+  ]
+}

--- a/fixtures/buildforge/reject_merge_gates_red.json
+++ b/fixtures/buildforge/reject_merge_gates_red.json
@@ -1,0 +1,17 @@
+{
+  "forge_task_id": "ft-gates-red-001",
+  "note": "A merge grant without green gates is still refused (fail-closed on required checks).",
+  "expect": {"reject": {"code": "BF-POL-005", "at": 9}},
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED"},
+    {"from": "PATCHED", "to": "PUSHED"},
+    {"from": "PUSHED", "to": "PR_OPEN"},
+    {"from": "PR_OPEN", "to": "CHECKS_PENDING"},
+    {"from": "CHECKS_PENDING", "to": "REVIEW_PENDING"},
+    {"from": "REVIEW_PENDING", "to": "READY_TO_MERGE"},
+    {"from": "READY_TO_MERGE", "to": "MERGED", "ctx": {"merge_grant_present": true, "policy_gates_passed": false}}
+  ]
+}

--- a/fixtures/buildforge/reject_merge_without_grant.json
+++ b/fixtures/buildforge/reject_merge_without_grant.json
@@ -1,0 +1,17 @@
+{
+  "forge_task_id": "ft-no-merge-grant-001",
+  "note": "Reaching MERGED without a distinct merge grant violates authoring != merge authority.",
+  "expect": {"reject": {"code": "BF-AUTH-006", "at": 9}},
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED"},
+    {"from": "PATCHED", "to": "PUSHED"},
+    {"from": "PUSHED", "to": "PR_OPEN"},
+    {"from": "PR_OPEN", "to": "CHECKS_PENDING"},
+    {"from": "CHECKS_PENDING", "to": "REVIEW_PENDING"},
+    {"from": "REVIEW_PENDING", "to": "READY_TO_MERGE"},
+    {"from": "READY_TO_MERGE", "to": "MERGED", "ctx": {"policy_gates_passed": true}}
+  ]
+}

--- a/fixtures/buildforge/reject_terminal_reopen.json
+++ b/fixtures/buildforge/reject_terminal_reopen.json
@@ -1,0 +1,18 @@
+{
+  "forge_task_id": "ft-reopen-001",
+  "note": "Terminal states are absorbing; reopening a MERGED run is refused.",
+  "expect": {"reject": {"code": "BF-INT-004", "at": 10}},
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED"},
+    {"from": "PATCHED", "to": "PUSHED"},
+    {"from": "PUSHED", "to": "PR_OPEN"},
+    {"from": "PR_OPEN", "to": "CHECKS_PENDING"},
+    {"from": "CHECKS_PENDING", "to": "REVIEW_PENDING"},
+    {"from": "REVIEW_PENDING", "to": "READY_TO_MERGE"},
+    {"from": "READY_TO_MERGE", "to": "MERGED", "ctx": {"merge_grant_present": true, "policy_gates_passed": true}},
+    {"from": "MERGED", "to": "PR_OPEN"}
+  ]
+}

--- a/fixtures/buildforge/reject_workflow_mutation.json
+++ b/fixtures/buildforge/reject_workflow_mutation.json
@@ -1,0 +1,11 @@
+{
+  "forge_task_id": "ft-workflow-mutation-001",
+  "note": "Mutating workflow files during PATCHED under an ordinary authoring grant is refused.",
+  "expect": {"reject": {"code": "BF-POL-001", "at": 3}},
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED", "ctx": {"workflow_file_mutation": true, "workflow_mutation_capability": false}}
+  ]
+}

--- a/fixtures/buildforge/valid_interrupt_aborted.json
+++ b/fixtures/buildforge/valid_interrupt_aborted.json
@@ -1,0 +1,10 @@
+{
+  "forge_task_id": "ft-abort-001",
+  "note": "An active run may be interrupted to ABORTED from any active state.",
+  "expect": "accept",
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "ABORTED"}
+  ]
+}

--- a/fixtures/buildforge/valid_review_rejected.json
+++ b/fixtures/buildforge/valid_review_rejected.json
@@ -1,0 +1,16 @@
+{
+  "forge_task_id": "ft-review-reject-001",
+  "note": "Reviewer requests rejection; run terminates at REJECTED. A legal terminal path.",
+  "expect": "accept",
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED"},
+    {"from": "PATCHED", "to": "PUSHED"},
+    {"from": "PUSHED", "to": "PR_OPEN"},
+    {"from": "PR_OPEN", "to": "CHECKS_PENDING"},
+    {"from": "CHECKS_PENDING", "to": "REVIEW_PENDING"},
+    {"from": "REVIEW_PENDING", "to": "REJECTED"}
+  ]
+}

--- a/fixtures/buildforge/valid_run_lifecycle.json
+++ b/fixtures/buildforge/valid_run_lifecycle.json
@@ -1,0 +1,17 @@
+{
+  "forge_task_id": "ft-happy-001",
+  "note": "Full happy path CREATED..MERGED with a distinct merge grant and green gates.",
+  "expect": "accept",
+  "transitions": [
+    {"from": "CREATED", "to": "AUTHORIZED"},
+    {"from": "AUTHORIZED", "to": "MOUNTED"},
+    {"from": "MOUNTED", "to": "BRANCHED"},
+    {"from": "BRANCHED", "to": "PATCHED"},
+    {"from": "PATCHED", "to": "PUSHED"},
+    {"from": "PUSHED", "to": "PR_OPEN"},
+    {"from": "PR_OPEN", "to": "CHECKS_PENDING"},
+    {"from": "CHECKS_PENDING", "to": "REVIEW_PENDING"},
+    {"from": "REVIEW_PENDING", "to": "READY_TO_MERGE"},
+    {"from": "READY_TO_MERGE", "to": "MERGED", "ctx": {"merge_grant_present": true, "policy_gates_passed": true}}
+  ]
+}

--- a/reference/build_forge_state_machine.py
+++ b/reference/build_forge_state_machine.py
@@ -1,0 +1,145 @@
+"""Build Forge run-lifecycle state machine (reference).
+
+Enforces the normative RunState transition machine from the Build Forge Contract
+Pack v0.1 (`spec/drafts/build_forge_v0_1.md`, §"Normative state machine"), plus the
+two hard invariants that give the lifecycle teeth:
+
+  * merge-authority separation  — a run MUST NOT reach MERGED without a distinct
+    merge grant AND passing policy gates (invariant 4 / G8, error BF-AUTH-006).
+  * workflow-mutation isolation — a transition that mutates workflow files under an
+    ordinary authoring grant is refused (invariant 8 / G4, error BF-POL-001).
+
+Terminal states are absorbing. Any illegal edge is an event-order violation
+(BF-INT-004). Fail-closed: unknown states raise rather than pass.
+
+Pure stdlib, deterministic. Mirrors the `tritrpc.buildforge.v1` proto RunState enum
+in `fixtures/buildforge/build_forge_tritrpc_v0_1.proto`.
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, Optional, Set
+
+# Non-terminal (active) run states, in canonical lifecycle order.
+ACTIVE: tuple[str, ...] = (
+    "CREATED",
+    "AUTHORIZED",
+    "MOUNTED",
+    "BRANCHED",
+    "PATCHED",
+    "PUSHED",
+    "PR_OPEN",
+    "CHECKS_PENDING",
+    "REVIEW_PENDING",
+    "READY_TO_MERGE",
+)
+
+# Absorbing terminal states.
+TERMINAL: frozenset[str] = frozenset(
+    {"MERGED", "REJECTED", "ABORTED", "EXPIRED", "FAILED"}
+)
+
+ALL_STATES: frozenset[str] = frozenset(ACTIVE) | TERMINAL
+
+# Interrupt edges available from every active state.
+_INTERRUPT: frozenset[str] = frozenset({"FAILED", "ABORTED", "EXPIRED"})
+
+# Linear / branching happy-path edges (excludes the universal interrupt edges).
+_LINEAR: Dict[str, Set[str]] = {
+    "CREATED": {"AUTHORIZED"},
+    "AUTHORIZED": {"MOUNTED"},
+    "MOUNTED": {"BRANCHED"},
+    "BRANCHED": {"PATCHED"},
+    "PATCHED": {"PUSHED"},
+    "PUSHED": {"PR_OPEN"},
+    "PR_OPEN": {"CHECKS_PENDING"},
+    "CHECKS_PENDING": {"REVIEW_PENDING"},
+    "REVIEW_PENDING": {"READY_TO_MERGE", "REJECTED"},
+    "READY_TO_MERGE": {"MERGED"},
+}
+
+
+class RunStateError(Exception):
+    """A refused transition, carrying a machine-readable Build Forge error code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def allowed_targets(state: str) -> Set[str]:
+    """The set of states reachable from ``state`` by a single legal edge."""
+    if state not in ALL_STATES:
+        raise RunStateError("BF-INT-004", f"unknown state {state!r}")
+    if state in TERMINAL:
+        return set()
+    return set(_LINEAR.get(state, set())) | set(_INTERRUPT)
+
+
+def assert_transition(
+    frm: str, to: str, ctx: Optional[Mapping[str, object]] = None
+) -> str:
+    """Assert ``frm -> to`` is legal under ``ctx``; return ``to`` or raise.
+
+    ``ctx`` recognised keys:
+      merge_grant_present (bool)      — a distinct merge grant is present.
+      policy_gates_passed (bool)      — required checks green / gates satisfied.
+      workflow_file_mutation (bool)   — this transition mutates workflow files.
+      workflow_mutation_capability(bool) — grant carries the workflow-mutation class.
+    """
+    ctx = ctx or {}
+    if frm not in ALL_STATES:
+        raise RunStateError("BF-INT-004", f"unknown source state {frm!r}")
+    if to not in ALL_STATES:
+        raise RunStateError("BF-INT-004", f"unknown target state {to!r}")
+    if frm in TERMINAL:
+        raise RunStateError(
+            "BF-INT-004", f"terminal state {frm} is absorbing; refused edge to {to}"
+        )
+    if to not in allowed_targets(frm):
+        raise RunStateError(
+            "BF-INT-004", f"illegal transition {frm} -> {to} (not in allowed set)"
+        )
+    # Merge-authority separation: MERGED requires a distinct grant AND green gates.
+    if to == "MERGED":
+        if not ctx.get("merge_grant_present"):
+            raise RunStateError(
+                "BF-AUTH-006",
+                "merge to MERGED requires a distinct merge grant (authoring != merge authority)",
+            )
+        if not ctx.get("policy_gates_passed"):
+            raise RunStateError(
+                "BF-POL-005", "merge refused: required checks not green / gates unsatisfied"
+            )
+    # Workflow-mutation isolation: a distinct capability class from ordinary authoring.
+    if ctx.get("workflow_file_mutation") and not ctx.get("workflow_mutation_capability"):
+        raise RunStateError(
+            "BF-POL-001",
+            "workflow file mutation disallowed under ordinary authoring grant",
+        )
+    return to
+
+
+def replay(transitions: Iterable[Mapping[str, object]]) -> List[str]:
+    """Walk a transition log, asserting each edge and inter-edge continuity.
+
+    Each item: ``{"from": <state>, "to": <state>, "ctx": {...}?}``. The ``to`` of
+    edge *i* MUST equal the ``from`` of edge *i+1* (BF-INT-004). Returns the visited
+    state sequence, or raises ``RunStateError`` at the first violation.
+    """
+    seq: List[str] = []
+    prev_to: Optional[str] = None
+    for i, t in enumerate(transitions):
+        frm = str(t["from"])
+        to = str(t["to"])
+        if prev_to is not None and frm != prev_to:
+            raise RunStateError(
+                "BF-INT-004",
+                f"discontinuous log at edge {i}: expected from={prev_to}, got {frm}",
+            )
+        ctx = t.get("ctx") or {}
+        assert_transition(frm, to, ctx)  # type: ignore[arg-type]
+        if not seq:
+            seq.append(frm)
+        seq.append(to)
+        prev_to = to
+    return seq

--- a/schemas/jsonschema/build-forge-run-transition.v0.schema.json
+++ b/schemas/jsonschema/build-forge-run-transition.v0.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://socioprophet.ai/schemas/tritrpc/build-forge-run-transition.v0.schema.json",
+  "title": "Build Forge run-lifecycle transition log (v0)",
+  "description": "A replayable log of RunState transitions for one Build Forge run. Each edge is asserted against the normative state machine in spec/drafts/build_forge_v0_1.md; the to of edge i must equal the from of edge i+1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["forge_task_id", "expect", "transitions"],
+  "properties": {
+    "forge_task_id": {"type": "string", "minLength": 1},
+    "note": {"type": "string"},
+    "expect": {
+      "description": "accept => the whole log replays cleanly; otherwise the edge index and error code that MUST be raised.",
+      "oneOf": [
+        {"const": "accept"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reject"],
+          "properties": {
+            "reject": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["code"],
+              "properties": {
+                "code": {"type": "string", "pattern": "^BF-[A-Z]+-[0-9]{3}$"},
+                "at": {"type": "integer", "minimum": 0}
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to"],
+        "properties": {
+          "from": {"$ref": "#/$defs/run_state"},
+          "to": {"$ref": "#/$defs/run_state"},
+          "ctx": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "merge_grant_present": {"type": "boolean"},
+              "policy_gates_passed": {"type": "boolean"},
+              "workflow_file_mutation": {"type": "boolean"},
+              "workflow_mutation_capability": {"type": "boolean"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "run_state": {
+      "type": "string",
+      "enum": [
+        "CREATED",
+        "AUTHORIZED",
+        "MOUNTED",
+        "BRANCHED",
+        "PATCHED",
+        "PUSHED",
+        "PR_OPEN",
+        "CHECKS_PENDING",
+        "REVIEW_PENDING",
+        "READY_TO_MERGE",
+        "MERGED",
+        "REJECTED",
+        "ABORTED",
+        "EXPIRED",
+        "FAILED"
+      ]
+    }
+  }
+}

--- a/spec/drafts/build_forge_v0_1.md
+++ b/spec/drafts/build_forge_v0_1.md
@@ -1,0 +1,89 @@
+# Build Forge Contract v0.1 — run-lifecycle slice (draft)
+
+Status: Draft / normative seed
+Package: `tritrpc.buildforge.v1`
+
+Build Forge is a policy-bound pull-request authoring and proof system — the first
+executable vertical slice of the Agentic Commons lane. It exercises the TriTRPC
+substrate under real pressure: human-rooted delegation, scoped context mounts,
+typed capabilities, provider adapters, proof emission, and replay/cairn closure,
+with an explicit separation of **authoring** authority from **merge** authority.
+
+This draft lands the wire contract and the enforceable core of the lifecycle. The
+full contract pack (domain model, provider adapter contract, GitHub/GitLab
+bindings, offline replay verifier, error taxonomy) is upstream in the Agentic
+Forge intake; the beyond-slice items are tracked in the companion issue.
+
+## What is contracted here
+
+| Artifact | Path |
+|---|---|
+| Proto service + message contract | `fixtures/buildforge/build_forge_tritrpc_v0_1.proto` |
+| Run-transition log schema | `schemas/jsonschema/build-forge-run-transition.v0.schema.json` |
+| Reference state machine | `reference/build_forge_state_machine.py` |
+| Conformance verifier (teeth) | `tools/verify_build_forge_state_machine.py` |
+| Accept + reject fixtures | `fixtures/buildforge/*.json` |
+
+The proto declares two services — `BuildForge` (CreateTask, AuthorizeTask,
+MountRepoContext, OpenBranchLease, ProposePatchset, PushPatchset,
+OpenChangeRequest, RequestReviewers, AttachCheck, EmitProof, CloseCairn) and the
+provider-neutral `ForgeProviderAdapter` — plus the `RunState`, `ReviewState`, and
+`CheckState` enumerations.
+
+## Hard invariants (enforced by this slice)
+
+1. A run MUST NOT escalate from authoring authority to merge authority unless a
+   distinct merge grant exists (**BF-AUTH-006**).
+2. Workflow-file mutation MUST be a distinct capability class from ordinary PR
+   authoring (**BF-POL-001**).
+3. A merge MUST fail closed unless required checks are green / gates pass
+   (**BF-POL-005**).
+4. Event ordering MUST conform to the state machine below; terminal states are
+   absorbing (**BF-INT-004**).
+
+## Normative state machine
+
+Active states, in lifecycle order:
+`CREATED → AUTHORIZED → MOUNTED → BRANCHED → PATCHED → PUSHED → PR_OPEN →
+CHECKS_PENDING → REVIEW_PENDING → READY_TO_MERGE`.
+
+Terminal (absorbing) states: `MERGED`, `REJECTED`, `ABORTED`, `EXPIRED`, `FAILED`.
+
+Allowed edges:
+
+- the linear chain above, edge by edge;
+- `REVIEW_PENDING → REJECTED`;
+- `READY_TO_MERGE → MERGED` — **only** with `merge_grant_present` **and**
+  `policy_gates_passed` in the transition context;
+- any active state → `FAILED` | `ABORTED` | `EXPIRED` (interrupt edges).
+
+Forbidden (a sample, all refused with a machine-readable code):
+
+- any terminal → any state (absorbing);
+- `CREATED → MERGED` and every other skip of the chain;
+- `READY_TO_MERGE → MERGED` without a distinct merge grant, or with red gates;
+- a transition mutating workflow files under an ordinary authoring grant;
+- a discontinuous log (edge *i*'s target ≠ edge *i+1*'s source).
+
+## Teeth
+
+`tools/verify_build_forge_state_machine.py` replays every fixture in
+`fixtures/buildforge/*.json` and asserts each declared outcome — accept, or reject
+with an exact `BF-*` code. Two drift guards assert the JSON Schema `run_state`
+enum and the proto `RunState` enum both match the reference state set, so the
+three artifacts cannot silently diverge. Wired into `make build-forge` (and the
+top-level `make verify`).
+
+Integrity: `build_forge_tritrpc_v0_1.proto` SHA-256 (FIPS 180-4)
+`1e3c60f2cf7737c4146e883f9d22916cec7fbddb04ecb1999b72e9301a752472`.
+
+## Beyond this slice
+
+The offline replay verifier over full Cairn chains (signature verification,
+artifact-hash matching, provider protection snapshots, `VERIFIED_SUCCESS` /
+`TAMPER_DETECTED` verdicts), the provider adapters (`adapter-github`,
+`adapter-gitlab`, `adapter-generic-git`), the webhook normalization envelope, and
+the reputation-edge basis-proof rules are tracked in the companion issue.
+
+Provenance: distilled from the Agentic Forge intake `build_forge_contract_pack_v0.1`
+(2026-07-31 spec-intake corpus). MIT, consistent with this repository.

--- a/tools/verify_build_forge_state_machine.py
+++ b/tools/verify_build_forge_state_machine.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Verify the Build Forge run-lifecycle state machine (fail-closed, with teeth).
+
+For every fixture in ``fixtures/buildforge/*.json`` this replays the transition log
+through ``reference/build_forge_state_machine.py`` and asserts the declared
+expectation:
+
+  * ``"accept"``            — the whole log replays with no error.
+  * ``{"reject": {code, at}}`` — replay raises ``RunStateError`` with that exact
+    machine-readable code (and, when given, at that edge index).
+
+So valid runs are accepted and invalid ones are rejected *for the stated reason* —
+CREATED->MERGED skips, terminal reopen, merge without a distinct grant, red gates,
+workflow-file mutation under an ordinary grant, and discontinuous logs.
+
+Two drift guards keep the three artifacts in lockstep: the JSON Schema run_state
+enum and the proto RunState enum must both match the reference module's state set.
+
+Stdlib only. Prints ``{"ok": bool, "checks": {...}}``; exit 0 iff every check holds.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import build_forge_state_machine as sm  # noqa: E402
+
+FIXTURE_DIR = ROOT / "fixtures" / "buildforge"
+SCHEMA = ROOT / "schemas" / "jsonschema" / "build-forge-run-transition.v0.schema.json"
+PROTO = FIXTURE_DIR / "build_forge_tritrpc_v0_1.proto"
+
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def _run_fixture(path: Path) -> None:
+    spec = json.loads(path.read_text())
+    name = path.name
+    expect = spec["expect"]
+    try:
+        sm.replay(spec["transitions"])
+        raised = None
+    except sm.RunStateError as exc:
+        raised = exc
+
+    if expect == "accept":
+        CHECKS[f"accept:{name}"] = raised is None
+        if raised is not None:
+            FAILURES.append(f"{name}: expected accept, got {raised.code} ({raised})")
+        return
+
+    want = expect["reject"]
+    if raised is None:
+        CHECKS[f"reject:{name}"] = False
+        FAILURES.append(f"{name}: expected reject {want['code']}, but log was accepted")
+        return
+    code_ok = raised.code == want["code"]
+    CHECKS[f"reject:{name}:{want['code']}"] = code_ok
+    if not code_ok:
+        FAILURES.append(f"{name}: expected {want['code']}, got {raised.code} ({raised})")
+
+
+def _drift_guards() -> None:
+    ref_states = set(sm.ALL_STATES)
+
+    schema = json.loads(SCHEMA.read_text())
+    enum = set(schema["$defs"]["run_state"]["enum"])
+    CHECKS["drift:schema-enum-matches-reference"] = enum == ref_states
+    if enum != ref_states:
+        FAILURES.append(f"schema run_state enum drift: {enum ^ ref_states}")
+
+    proto_text = PROTO.read_text()
+    block = re.search(r"enum\s+RunState\s*\{(.*?)\}", proto_text, re.DOTALL)
+    if not block:
+        CHECKS["drift:proto-enum-present"] = False
+        FAILURES.append("proto RunState enum not found")
+        return
+    names = set(re.findall(r"\b([A-Z][A-Z0-9_]+)\s*=\s*\d+", block.group(1)))
+    names.discard("RUN_STATE_UNSPECIFIED")
+    CHECKS["drift:proto-enum-matches-reference"] = names == ref_states
+    if names != ref_states:
+        FAILURES.append(f"proto RunState enum drift: {names ^ ref_states}")
+
+
+def main() -> int:
+    fixtures = sorted(FIXTURE_DIR.glob("*.json"))
+    CHECKS["fixtures:present"] = len(fixtures) > 0
+    if not fixtures:
+        FAILURES.append("no fixtures found under fixtures/buildforge/")
+    for fx in fixtures:
+        _run_fixture(fx)
+    _drift_guards()
+
+    # Sanity: at least one accept and one reject fixture exercised.
+    CHECKS["coverage:has-accept"] = any(k.startswith("accept:") for k in CHECKS)
+    CHECKS["coverage:has-reject"] = any(k.startswith("reject:") for k in CHECKS)
+
+    for k, v in CHECKS.items():
+        if not v and f"{k}" not in {f for f in FAILURES}:
+            pass
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

First **Build Forge** vertical slice, landed as a spec-as-code contract in the `tritrpc.buildforge.v1` package. Build Forge is a policy-bound PR-authoring and proof system — the Agentic Commons lane's first executable slice. This PR contracts the wire shape and the enforceable core of the run lifecycle.

Distilled (consume-not-fork) from the Agentic Forge intake `build_forge_contract_pack_v0.1` (2026-07-31 spec-intake corpus). MIT, consistent with this repo.

## Artifacts

| Artifact | Path |
|---|---|
| Proto service + message contract | `fixtures/buildforge/build_forge_tritrpc_v0_1.proto` |
| Run-transition log schema | `schemas/jsonschema/build-forge-run-transition.v0.schema.json` |
| Reference state machine | `reference/build_forge_state_machine.py` |
| Conformance verifier | `tools/verify_build_forge_state_machine.py` |
| Accept + reject fixtures | `fixtures/buildforge/*.json` |
| Spec draft | `spec/drafts/build_forge_v0_1.md` |

## Teeth (`make build-forge`, wired into `make verify`)

Every fixture replays through the reference FSM and asserts its declared outcome — accept, or reject with an exact `BF-*` code:

- happy path `CREATED..MERGED` + review-reject + interrupt-to-ABORTED **accepted**;
- `CREATED -> MERGED` skip and terminal reopen **rejected `BF-INT-004`**;
- merge without a distinct merge grant **rejected `BF-AUTH-006`** (authoring != merge authority);
- merge with red gates **rejected `BF-POL-005`** (fail-closed);
- workflow-file mutation under an ordinary authoring grant **rejected `BF-POL-001`**;
- discontinuous transition log **rejected `BF-INT-004`**.

Two drift guards assert the JSON Schema `run_state` enum and the proto `RunState` enum both match the reference state set, so the three artifacts cannot silently diverge. Negative control confirmed: weakening the FSM to permit `CREATED -> MERGED` makes the verifier exit non-zero.

Integrity: proto SHA-256 (FIPS 180-4 algorithm) `1e3c60f2cf7737c4146e883f9d22916cec7fbddb04ecb1999b72e9301a752472`.

## Beyond this slice

Tracked in a companion issue: the offline replay verifier over full Cairn chains (signature + artifact-hash + protection-snapshot checks, `VERIFIED_SUCCESS`/`TAMPER_DETECTED` verdicts), the provider adapters (`adapter-github`/`adapter-gitlab`/`adapter-generic-git`), the webhook normalization envelope, and reputation-edge basis-proof rules.