### PR TITLE
feat(go): v4 codec primitives S243 + Handle243 + Braid243 — byte-parity with the Python oracle

### DIFF
--- a/fixtures/v4/codec_primitive_vectors.json
+++ b/fixtures/v4/codec_primitive_vectors.json
@@ -1,0 +1,109 @@
+{
+  "s243": [
+    {
+      "v": 0,
+      "hex": "00"
+    },
+    {
+      "v": 1,
+      "hex": "01"
+    },
+    {
+      "v": 242,
+      "hex": "f2"
+    },
+    {
+      "v": 243,
+      "hex": "f3f500"
+    },
+    {
+      "v": 244,
+      "hex": "f3f501"
+    },
+    {
+      "v": 486,
+      "hex": "f3a8f603"
+    },
+    {
+      "v": 1000,
+      "hex": "f3b236f401"
+    },
+    {
+      "v": 65535,
+      "hex": "f3de47eaf501"
+    },
+    {
+      "v": 1000000,
+      "hex": "f3b3416be1f301"
+    }
+  ],
+  "handle243": [
+    {
+      "kind": "int",
+      "v": 0,
+      "hex": "00"
+    },
+    {
+      "kind": "int",
+      "v": 242,
+      "hex": "f2"
+    },
+    {
+      "kind": "ext",
+      "v": 5,
+      "hex": "f305"
+    },
+    {
+      "kind": "ext",
+      "v": 1000,
+      "hex": "f3f3b236f401"
+    },
+    {
+      "kind": "str",
+      "v": "agent.exec",
+      "hex": "f40a6167656e742e65786563"
+    },
+    {
+      "kind": "hash",
+      "v": "abababababababababababababababababababababababababababababababab",
+      "hex": "f5abababababababababababababababababababababababababababababababab"
+    },
+    {
+      "kind": "tombstone",
+      "v": null,
+      "hex": "f6"
+    }
+  ],
+  "braid243": [
+    {
+      "phase": 1,
+      "topic": 1,
+      "byte": 0
+    },
+    {
+      "phase": 1,
+      "topic": 23,
+      "byte": 22
+    },
+    {
+      "phase": 7,
+      "topic": 1,
+      "byte": 162
+    },
+    {
+      "phase": 7,
+      "topic": 23,
+      "byte": 184
+    },
+    {
+      "phase": 4,
+      "topic": 12,
+      "byte": 92
+    },
+    {
+      "phase": 3,
+      "topic": 7,
+      "byte": 60
+    }
+  ]
+}

--- a/go/tritrpcv1/v4_codec.go
+++ b/go/tritrpcv1/v4_codec.go
@@ -1,0 +1,146 @@
+package tritrpcv1
+
+// v4 codec primitives — Go port, byte-identical to the Python oracle
+// (reference/experimental/.../codec.py, naming.py). No crypto: pure canonical encodings.
+//   S243     : a value in 0..242 is one byte; larger values are [243] + TLEB3(value-243).
+//   Handle243: 0..242 direct; [243]+S243(ext_id); [244]+S243(len)+utf8; [245]+32B hash; [246] tombstone.
+//   Braid243 : (phase 1..7, topic 1..23) -> (phase-1)*27 + (topic-1), a single byte in 0..188.
+
+import (
+	"errors"
+	"fmt"
+)
+
+// EncodeS243 encodes a non-negative integer per the canonical S243 form.
+func EncodeS243(value uint64) []byte {
+	if value <= 242 {
+		return []byte{byte(value)}
+	}
+	return append([]byte{243}, TLEB3EncodeLen(value-243)...)
+}
+
+// DecodeS243 inverts EncodeS243, returning the value and the new offset.
+func DecodeS243(data []byte, offset int) (uint64, int, error) {
+	if offset >= len(data) {
+		return 0, 0, errors.New("EOF in S243")
+	}
+	prefix := data[offset]
+	if prefix <= 242 {
+		return uint64(prefix), offset + 1, nil
+	}
+	if prefix != 243 {
+		return 0, 0, errors.New("invalid leading byte for canonical S243")
+	}
+	v, newOff, err := TLEB3DecodeLen(data, offset+1)
+	if err != nil {
+		return 0, 0, err
+	}
+	return 243 + v, newOff, nil
+}
+
+// EncodeBraid243 packs a (phase 1..7, topic 1..23) braided coordinate into one byte.
+func EncodeBraid243(phase, topic uint8) (uint8, error) {
+	if phase < 1 || phase > 7 {
+		return 0, errors.New("phase must be in 1..7 for Braid243")
+	}
+	if topic < 1 || topic > 23 {
+		return 0, errors.New("topic must be in 1..23 for Braid243")
+	}
+	return (phase-1)*27 + (topic - 1), nil
+}
+
+// DecodeBraid243 inverts EncodeBraid243.
+func DecodeBraid243(value uint8) (phase, topic uint8, err error) {
+	if value > 242 {
+		return 0, 0, errors.New("Braid243 byte must be in 0..242")
+	}
+	phaseCode := value / 27
+	topicCode := value % 27
+	if phaseCode > 6 || topicCode > 22 {
+		return 0, 0, errors.New("reserved Braid243 coordinate")
+	}
+	return phaseCode + 1, topicCode + 1, nil
+}
+
+// HandleKind tags a Handle243 variant.
+type HandleKind int
+
+const (
+	HandleDirect HandleKind = iota
+	HandleExt
+	HandleStr
+	HandleHash
+	HandleTombstone
+)
+
+// Handle243 is a route-handle value (one of five canonical variants).
+type Handle243 struct {
+	Kind   HandleKind
+	Direct uint8    // HandleDirect: 0..242
+	Ext    uint64   // HandleExt
+	Str    string   // HandleStr
+	Hash   [32]byte // HandleHash
+}
+
+// EncodeHandle243 serializes a Handle243, byte-identical to the oracle.
+func EncodeHandle243(h Handle243) ([]byte, error) {
+	switch h.Kind {
+	case HandleDirect:
+		if h.Direct > 242 {
+			return nil, errors.New("direct Handle243 values must be in 0..242")
+		}
+		return []byte{h.Direct}, nil
+	case HandleExt:
+		return append([]byte{243}, EncodeS243(h.Ext)...), nil
+	case HandleStr:
+		raw := []byte(h.Str)
+		out := append([]byte{244}, EncodeS243(uint64(len(raw)))...)
+		return append(out, raw...), nil
+	case HandleHash:
+		return append([]byte{245}, h.Hash[:]...), nil
+	case HandleTombstone:
+		return []byte{246}, nil
+	default:
+		return nil, fmt.Errorf("unsupported Handle243 kind: %d", h.Kind)
+	}
+}
+
+// DecodeHandle243 inverts EncodeHandle243.
+func DecodeHandle243(data []byte, offset int) (Handle243, int, error) {
+	if offset >= len(data) {
+		return Handle243{}, 0, errors.New("EOF in Handle243")
+	}
+	prefix := data[offset]
+	switch {
+	case prefix <= 242:
+		return Handle243{Kind: HandleDirect, Direct: prefix}, offset + 1, nil
+	case prefix == 243:
+		v, newOff, err := DecodeS243(data, offset+1)
+		if err != nil {
+			return Handle243{}, 0, err
+		}
+		return Handle243{Kind: HandleExt, Ext: v}, newOff, nil
+	case prefix == 244:
+		n, newOff, err := DecodeS243(data, offset+1)
+		if err != nil {
+			return Handle243{}, 0, err
+		}
+		end := newOff + int(n)
+		if end > len(data) {
+			return Handle243{}, 0, errors.New("truncated inline UTF-8 handle")
+		}
+		return Handle243{Kind: HandleStr, Str: string(data[newOff:end])}, end, nil
+	case prefix == 245:
+		end := offset + 1 + 32
+		if end > len(data) {
+			return Handle243{}, 0, errors.New("truncated hash handle")
+		}
+		var h [32]byte
+		copy(h[:], data[offset+1:end])
+		return Handle243{Kind: HandleHash, Hash: h}, end, nil
+	case prefix == 246:
+		return Handle243{Kind: HandleTombstone}, offset + 1, nil
+	default:
+		return Handle243{}, 0, errors.New("invalid Handle243 prefix")
+	}
+}

--- a/go/tritrpcv1/v4_codec_test.go
+++ b/go/tritrpcv1/v4_codec_test.go
@@ -1,0 +1,109 @@
+package tritrpcv1
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func codecVectorsPath() string {
+	return filepath.Join("..", "..", "fixtures", "v4", "codec_primitive_vectors.json")
+}
+
+type codecVectors struct {
+	S243 []struct {
+		V   uint64 `json:"v"`
+		Hex string `json:"hex"`
+	} `json:"s243"`
+	Handle243 []struct {
+		Kind string `json:"kind"`
+		V    any    `json:"v"`
+		Hex  string `json:"hex"`
+	} `json:"handle243"`
+	Braid243 []struct {
+		Phase uint8 `json:"phase"`
+		Topic uint8 `json:"topic"`
+		Byte  uint8 `json:"byte"`
+	} `json:"braid243"`
+}
+
+func loadCodecVectors(t *testing.T) codecVectors {
+	data, err := os.ReadFile(codecVectorsPath())
+	if err != nil {
+		t.Fatalf("read oracle vectors: %v", err)
+	}
+	var v codecVectors
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("parse oracle vectors: %v", err)
+	}
+	return v
+}
+
+// TestS243MatchesOracle: encode + round-trip against the Python oracle bytes.
+func TestS243MatchesOracle(t *testing.T) {
+	for _, c := range loadCodecVectors(t).S243 {
+		got := hex.EncodeToString(EncodeS243(c.V))
+		if got != c.Hex {
+			t.Fatalf("S243(%d): got %s, oracle %s", c.V, got, c.Hex)
+		}
+		v, off, err := DecodeS243(EncodeS243(c.V), 0)
+		if err != nil || v != c.V || off != len(EncodeS243(c.V)) {
+			t.Fatalf("S243 roundtrip %d: v=%d off=%d err=%v", c.V, v, off, err)
+		}
+	}
+}
+
+// TestBraid243MatchesOracle: encode == oracle byte, round-trip, and reserved-coordinate rejection.
+func TestBraid243MatchesOracle(t *testing.T) {
+	for _, c := range loadCodecVectors(t).Braid243 {
+		got, err := EncodeBraid243(c.Phase, c.Topic)
+		if err != nil || got != c.Byte {
+			t.Fatalf("Braid243(%d,%d): got %d oracle %d err=%v", c.Phase, c.Topic, got, c.Byte, err)
+		}
+		p, tp, err := DecodeBraid243(got)
+		if err != nil || p != c.Phase || tp != c.Topic {
+			t.Fatalf("Braid243 roundtrip: %d,%d -> %d,%d", c.Phase, c.Topic, p, tp)
+		}
+	}
+	if _, _, err := DecodeBraid243(242); err == nil { // reserved (phaseCode=8)
+		t.Fatal("expected reserved Braid243 coordinate to be rejected")
+	}
+	if _, err := EncodeBraid243(8, 1); err == nil {
+		t.Fatal("expected out-of-range phase to be rejected")
+	}
+}
+
+// TestHandle243MatchesOracle: each variant encodes to the exact oracle bytes and round-trips.
+func TestHandle243MatchesOracle(t *testing.T) {
+	for _, c := range loadCodecVectors(t).Handle243 {
+		var h Handle243
+		switch c.Kind {
+		case "int":
+			h = Handle243{Kind: HandleDirect, Direct: uint8(c.V.(float64))}
+		case "ext":
+			h = Handle243{Kind: HandleExt, Ext: uint64(c.V.(float64))}
+		case "str":
+			h = Handle243{Kind: HandleStr, Str: c.V.(string)}
+		case "hash":
+			var b [32]byte
+			raw, _ := hex.DecodeString(c.V.(string))
+			copy(b[:], raw)
+			h = Handle243{Kind: HandleHash, Hash: b}
+		case "tombstone":
+			h = Handle243{Kind: HandleTombstone}
+		}
+		enc, err := EncodeHandle243(h)
+		if err != nil {
+			t.Fatalf("encode handle %s: %v", c.Kind, err)
+		}
+		if hex.EncodeToString(enc) != c.Hex {
+			t.Fatalf("Handle243 %s: got %s oracle %s", c.Kind, hex.EncodeToString(enc), c.Hex)
+		}
+		dec, off, err := DecodeHandle243(enc, 0)
+		if err != nil || off != len(enc) || dec.Kind != h.Kind {
+			t.Fatalf("Handle243 %s roundtrip: off=%d kind=%d err=%v", c.Kind, off, dec.Kind, err)
+		}
+	}
+}


### PR DESCRIPTION
## Next Go v4 primitives — S243, Handle243, Braid243 (pure codec, oracle-verified)

Continues the Go port after Control243/State243 (#98). All three are pure canonical encodings (no crypto), byte-identical to the Python oracle (`codec.py` / `naming.py`):

- **S243** — 0..242 is one byte; larger values are `[243] + TLEB3(value-243)`, reusing the existing Go TLEB3 lane.
- **Braid243** — `(phase 1..7, topic 1..23) -> (phase-1)*27 + (topic-1)`; reserved coordinates refused.
- **Handle243** — direct / extended / inline-utf8 / 32-byte hash / tombstone variants.

**Parity:** `fixtures/v4/codec_primitive_vectors.json` is generated by running the Python oracle; the Go test asserts each encoding is **byte-equal** to the oracle hex and round-trips, plus fail-closed rejections. `S243(243)=f3f500` confirms the Go TLEB3 lane matches Python `tleb3_encode` exactly.

gofmt-clean, full Go suite green (no regression). Additive — v1 wire untouched. Remaining Go v4: the hot_unary/beacon/stream **frames** (need the AES-256-GCM lane) + correcting the Rust scaffold against the oracle.
