### PR TITLE
feat(go): v4 hot-path frames (hot_unary + beacon_commit) with the real AES-256-GCM lane — oracle parity

### DIFF
--- a/go/tritrpcv1/v4_frames.go
+++ b/go/tritrpcv1/v4_frames.go
@@ -1,0 +1,162 @@
+package tritrpcv1
+
+// v4 hot-path frames — Go port, byte-identical to the Python oracle (frames.py). A frame is a
+// canonical prefix + a 16-byte AEAD tag. The prefix is MAGIC + control + kind + suite + S243(epoch)
+// + frame-specific fields + payload. The tag is AES-256-GCM over the prefix as AAD with empty
+// plaintext (the demo AesGcmDemoTagProvider): nonce = "TRPC" || seq(8B big-endian). This is the FIPS
+// AES-256-GCM sealing lane the CryptoProfile suite selects — a real tag, not a stub.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"errors"
+)
+
+var v4Magic = []byte{0xf3, 0x2a}
+
+const demoNoncePrefix = "TRPC" // the reference AesGcmDemoTagProvider nonce prefix
+
+type CryptoSuite uint8
+
+const (
+	SuiteResearch      CryptoSuite = 0
+	SuiteFIPSClassical CryptoSuite = 1
+	SuiteCNSA2Ready    CryptoSuite = 2
+	SuiteReserved      CryptoSuite = 3
+)
+
+type FrameKind uint8
+
+const (
+	KindUnaryReq     FrameKind = 0
+	KindUnaryRsp     FrameKind = 1
+	KindStreamOpen   FrameKind = 2
+	KindStreamData   FrameKind = 3
+	KindStreamClose  FrameKind = 4
+	KindBeaconCap    FrameKind = 5
+	KindBeaconIntent FrameKind = 6
+	KindBeaconCommit FrameKind = 7
+	KindError        FrameKind = 8
+)
+
+// demoTag computes the AES-256-GCM tag over `prefix` (AAD, empty plaintext) at `seq`.
+func demoTag(key, prefix []byte, seq uint64) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, errors.New("AES-256-GCM demo tag requires a 32-byte key")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, 0, 12)
+	nonce = append(nonce, demoNoncePrefix...)
+	var seqb [8]byte
+	binary.BigEndian.PutUint64(seqb[:], seq)
+	nonce = append(nonce, seqb[:]...)
+	return gcm.Seal(nil, nonce, nil, prefix), nil // empty plaintext -> 16-byte tag
+}
+
+// DemoKey returns the reference demo key bytes(range(32)) = 00 01 .. 1f.
+func DemoKey() []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i)
+	}
+	return k
+}
+
+// HotUnaryFrame is the aggressive v4 hot unary frame.
+type HotUnaryFrame struct {
+	Control     Control243
+	Suite       CryptoSuite
+	Kind        FrameKind
+	Epoch       uint64
+	RouteHandle uint8 // direct Handle243 (0..242)
+	Payload     []byte
+	Sequence    uint64
+}
+
+func (f HotUnaryFrame) prefix() ([]byte, error) {
+	cb, err := f.Control.Encode()
+	if err != nil {
+		return nil, err
+	}
+	h, err := EncodeHandle243(Handle243{Kind: HandleDirect, Direct: f.RouteHandle})
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, v4Magic...)
+	out = append(out, cb, byte(f.Kind), byte(f.Suite))
+	out = append(out, EncodeS243(f.Epoch)...)
+	out = append(out, h...)
+	out = append(out, EncodeS243(uint64(len(f.Payload)))...)
+	out = append(out, f.Payload...)
+	return out, nil
+}
+
+// Serialize builds the wire frame (prefix + AES-256-GCM tag).
+func (f HotUnaryFrame) Serialize(key []byte) ([]byte, error) {
+	p, err := f.prefix()
+	if err != nil {
+		return nil, err
+	}
+	tag, err := demoTag(key, p, f.Sequence)
+	if err != nil {
+		return nil, err
+	}
+	return append(p, tag...), nil
+}
+
+// BeaconFrame is a v4 beacon (capability / intent / commit).
+type BeaconFrame struct {
+	Control        Control243
+	Suite          CryptoSuite
+	Kind           FrameKind
+	Epoch          uint64
+	IdentityHandle uint8 // direct Handle243
+	Phase          uint8 // 1..7
+	Topic          uint8 // 1..23
+	Payload        []byte
+	Sequence       uint64
+}
+
+func (f BeaconFrame) prefix() ([]byte, error) {
+	cb, err := f.Control.Encode()
+	if err != nil {
+		return nil, err
+	}
+	h, err := EncodeHandle243(Handle243{Kind: HandleDirect, Direct: f.IdentityHandle})
+	if err != nil {
+		return nil, err
+	}
+	braid, err := EncodeBraid243(f.Phase, f.Topic)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, v4Magic...)
+	out = append(out, cb, byte(f.Kind), byte(f.Suite))
+	out = append(out, EncodeS243(f.Epoch)...)
+	out = append(out, h...)
+	out = append(out, braid)
+	out = append(out, EncodeS243(uint64(len(f.Payload)))...)
+	out = append(out, f.Payload...)
+	return out, nil
+}
+
+// Serialize builds the wire frame (prefix + AES-256-GCM tag).
+func (f BeaconFrame) Serialize(key []byte) ([]byte, error) {
+	p, err := f.prefix()
+	if err != nil {
+		return nil, err
+	}
+	tag, err := demoTag(key, p, f.Sequence)
+	if err != nil {
+		return nil, err
+	}
+	return append(p, tag...), nil
+}

--- a/go/tritrpcv1/v4_frames_test.go
+++ b/go/tritrpcv1/v4_frames_test.go
@@ -1,0 +1,80 @@
+package tritrpcv1
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func frameOracle(t *testing.T) map[string]json.RawMessage {
+	p := filepath.Join("..", "..", "reference", "experimental",
+		"tritrpc_requirements_impl_v4", "generated", "sample_vectors_v4.json")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read oracle: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse oracle: %v", err)
+	}
+	return m
+}
+
+func oracleHex(t *testing.T, m map[string]json.RawMessage, k string) string {
+	var s string
+	if err := json.Unmarshal(m[k], &s); err != nil {
+		t.Fatalf("oracle %s: %v", k, err)
+	}
+	return s
+}
+
+// TestHotUnaryFrameMatchesOracle: the CLI hot frame serializes byte-identical to the oracle vector
+// (control=1, kind=UNARY_REQ, suite=FIPS_CLASSICAL, epoch=18, route=7, payload, seq=1, demo key).
+func TestHotUnaryFrameMatchesOracle(t *testing.T) {
+	m := frameOracle(t)
+	f := HotUnaryFrame{
+		Control:     Control243{Profile: 0, Lane: 0, Evidence: 0, Fallback: 0, RouteFmt: 1},
+		Suite:       SuiteFIPSClassical,
+		Kind:        KindUnaryReq,
+		Epoch:       18,
+		RouteHandle: 7,
+		Payload:     []byte(`{"op":"add-vertex","id":"a"}`),
+		Sequence:    1,
+	}
+	got, err := f.Serialize(DemoKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != oracleHex(t, m, "hot_unary") {
+		t.Fatalf("hot_unary parity:\n got %s\n want %s", hex.EncodeToString(got), oracleHex(t, m, "hot_unary"))
+	}
+}
+
+// TestBeaconCommitFrameMatchesOracle: the CLI beacon commit serializes byte-identical to the oracle.
+// beacon payload = [State243.encode()==136] + beacon_identity string; control all-2s (=242),
+// suite=CNSA2, epoch=18, identity_handle=19, phase=4, topic=21, seq=4.
+func TestBeaconCommitFrameMatchesOracle(t *testing.T) {
+	m := frameOracle(t)
+	state243 := byte(136) // State243(active,verified,routine,fluid,cohort)
+	payload := append([]byte{state243}, []byte(oracleHex(t, m, "beacon_identity"))...)
+	f := BeaconFrame{
+		Control:        Control243{Profile: 2, Lane: 2, Evidence: 2, Fallback: 2, RouteFmt: 2},
+		Suite:          SuiteCNSA2Ready,
+		Kind:           KindBeaconCommit,
+		Epoch:          18,
+		IdentityHandle: 19,
+		Phase:          4,
+		Topic:          21,
+		Payload:        payload,
+		Sequence:       4,
+	}
+	got, err := f.Serialize(DemoKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != oracleHex(t, m, "beacon_commit") {
+		t.Fatalf("beacon_commit parity:\n got %s\n want %s", hex.EncodeToString(got), oracleHex(t, m, "beacon_commit"))
+	}
+}


### PR DESCRIPTION
## Go v4 frames with the real AES-256-GCM lane — byte-parity, not a stub

The hardest slice of the Go v4 port: **frames with a real AEAD tag**. A frame is a canonical prefix (`MAGIC + control + kind + suite + S243(epoch) + fields + payload`) + a 16-byte **AES-256-GCM** tag over the prefix as AAD with empty plaintext (nonce = `"TRPC" || seq` big-endian) — the FIPS AES-256-GCM sealing lane the CryptoProfile suite selects.

- **`v4_frames.go`** — `CryptoSuite` + `FrameKind` enums; `HotUnaryFrame` / `BeaconFrame` with `prefix()` + `Serialize(key)`; `demoTag()` via `crypto/aes` + `crypto/cipher` GCM.
- **`v4_frames_test.go`** — reconstructs the exact CLI frames and asserts each serializes **byte-identical** to the shared oracle (`generated/sample_vectors_v4.json`): `hot_unary` and `beacon_commit` (control=242 all-2s, CNSA2, braid phase4/topic21, payload = `[State243=136] + beacon_identity`).

This is genuine cross-language AES-256-GCM parity — the Go tag equals the Python `cryptography` tag byte-for-byte. Builds on #98/#102. gofmt-clean, full Go suite green. Additive — v1 wire untouched. Remaining: stream frames (need `_encode_semantic_pair` + BraidedId) + correcting the Rust scaffold against the oracle + wiring parity into CI.
