### PR TITLE
fix(rust): correct v4 hot_unary conformance fixture to the Python oracle (was unverified seed)

### DIFF
--- a/conformance/fixtures/v4/frames/hot_unary.json
+++ b/conformance/fixtures/v4/frames/hot_unary.json
@@ -17,16 +17,16 @@
           "routefmt": 1
         },
         "kind": 0,
-        "suite": 0,
-        "epoch": 1,
+        "suite": 1,
+        "epoch": 18,
         "route_handle": {
           "type": "direct",
-          "value": 18
+          "value": 7
         },
         "payload_hex": "7b226f70223a226164642d766572746578222c226964223a2261227d",
         "tag_hex": "4bcf6e1b01f174e964b9d22dfc5195aa"
       },
-      "expected_frame_hex": "f32a01000001121c7b226f70223a226164642d766572746578222c226964223a2261227d4bcf6e1b01f174e964b9d22dfc5195aa",
+      "expected_frame_hex": "f32a01000112071c7b226f70223a226164642d766572746578222c226964223a2261227d4bcf6e1b01f174e964b9d22dfc5195aa",
       "expected_parse": {
         "control": {
           "profile": 0,
@@ -36,15 +36,16 @@
           "routefmt": 1
         },
         "kind": 0,
-        "suite": 0,
-        "epoch": 1,
+        "suite": 1,
+        "epoch": 18,
         "route_handle": {
           "type": "direct",
-          "value": 18
+          "value": 7
         },
         "payload_hex": "7b226f70223a226164642d766572746578222c226964223a2261227d",
         "tag_hex": "4bcf6e1b01f174e964b9d22dfc5195aa"
-      }
+      },
+      "oracle_ref": "reference/experimental/tritrpc_requirements_impl_v4/generated/sample_vectors_v4.json#hot_unary"
     },
     {
       "id": "hot-unary-unary-rsp-direct-handle-empty-payload",


### PR DESCRIPTION
## The Rust v4 scaffold's seed was wrong — now oracle-verified

The Rust v4 module header flagged its fixtures as *"seed values [that] may need correction once tests run against the Python oracle."* They did. The `hot_unary` sample-vector case pasted the oracle's real AES-GCM tag onto a prefix built from **wrong inputs** (suite=0 / epoch=1 / route=18 instead of the oracle's suite=1 / epoch=18 / route=7), so the Rust test was self-consistent but validated nothing against the shared oracle.

**Fix:** corrected the sample-vector case to the true oracle values; `expected_frame_hex` now equals `generated/sample_vectors_v4.json#hot_unary` exactly. `cargo test --test v4_frames` **passes** — which proves the Rust serializer's field order (MAGIC · control · kind · suite · epoch · route · len · payload) was correct all along; only the seed data was wrong. `hot_unary` is now genuinely oracle-verified in Rust, matching the Go port (#103).

JSON fixture only — no serializer change. Remaining: the `stream_open` fixture (still a placeholder) needs the semantic-pair encoding verified against the oracle.