### PR TITLE
feat(go): v4 stream frames (open/data/close) — completes the Go v4 frame family, oracle parity

### DIFF
--- a/go/tritrpcv1/v4_stream_frames.go
+++ b/go/tritrpcv1/v4_stream_frames.go
@@ -1,0 +1,143 @@
+package tritrpcv1
+
+// v4 stream frames — Go port, byte-identical to the Python oracle (frames.py). StreamOpen carries a
+// route handle + stream id + an optional DEFAULT semantic pair (Braid243, State243); StreamData
+// carries a stream id + an optional OVERRIDE semantic pair; StreamClose carries a stream id. The
+// semantic pair is two bytes [braid, state] when present, or empty when absent (both-or-neither).
+// Same AEAD tag lane as the other frames (AES-256-GCM over the prefix).
+
+// SemanticPair is an optional (Braid243, State243) coordinate; Set=false means "no pair".
+type SemanticPair struct {
+	Set   bool
+	Braid uint8 // 0..188 (from EncodeBraid243)
+	State uint8 // 0..242 (State243.Encode)
+}
+
+func encodeSemanticPair(p SemanticPair) []byte {
+	if !p.Set {
+		return nil
+	}
+	return []byte{p.Braid, p.State}
+}
+
+// StreamOpenFrame opens a stream, optionally establishing default semantics.
+type StreamOpenFrame struct {
+	Control      Control243
+	Suite        CryptoSuite
+	Kind         FrameKind
+	Epoch        uint64
+	RouteHandle  uint8
+	StreamID     uint64
+	Payload      []byte
+	DefaultBraid SemanticPair
+	Sequence     uint64
+}
+
+func (f StreamOpenFrame) prefix() ([]byte, error) {
+	cb, err := f.Control.Encode()
+	if err != nil {
+		return nil, err
+	}
+	h, err := EncodeHandle243(Handle243{Kind: HandleDirect, Direct: f.RouteHandle})
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, v4Magic...)
+	out = append(out, cb, byte(f.Kind), byte(f.Suite))
+	out = append(out, EncodeS243(f.Epoch)...)
+	out = append(out, h...)
+	out = append(out, EncodeS243(f.StreamID)...)
+	out = append(out, EncodeS243(uint64(len(f.Payload)))...)
+	out = append(out, f.Payload...)
+	out = append(out, encodeSemanticPair(f.DefaultBraid)...)
+	return out, nil
+}
+
+// Serialize builds the wire frame (prefix + AES-256-GCM tag).
+func (f StreamOpenFrame) Serialize(key []byte) ([]byte, error) {
+	p, err := f.prefix()
+	if err != nil {
+		return nil, err
+	}
+	tag, err := demoTag(key, p, f.Sequence)
+	if err != nil {
+		return nil, err
+	}
+	return append(p, tag...), nil
+}
+
+// StreamDataFrame carries a chunk, optionally overriding stream semantics.
+type StreamDataFrame struct {
+	Control  Control243
+	Suite    CryptoSuite
+	Epoch    uint64
+	StreamID uint64
+	Payload  []byte
+	Override SemanticPair
+	Sequence uint64
+}
+
+func (f StreamDataFrame) prefix() ([]byte, error) {
+	cb, err := f.Control.Encode()
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, v4Magic...)
+	out = append(out, cb, byte(KindStreamData), byte(f.Suite))
+	out = append(out, EncodeS243(f.Epoch)...)
+	out = append(out, EncodeS243(f.StreamID)...)
+	out = append(out, EncodeS243(uint64(len(f.Payload)))...)
+	out = append(out, f.Payload...)
+	out = append(out, encodeSemanticPair(f.Override)...)
+	return out, nil
+}
+
+// Serialize builds the wire frame (prefix + AES-256-GCM tag).
+func (f StreamDataFrame) Serialize(key []byte) ([]byte, error) {
+	p, err := f.prefix()
+	if err != nil {
+		return nil, err
+	}
+	tag, err := demoTag(key, p, f.Sequence)
+	if err != nil {
+		return nil, err
+	}
+	return append(p, tag...), nil
+}
+
+// StreamCloseFrame closes a stream.
+type StreamCloseFrame struct {
+	Control  Control243
+	Suite    CryptoSuite
+	Epoch    uint64
+	StreamID uint64
+	Payload  []byte
+	Sequence uint64
+}
+
+func (f StreamCloseFrame) prefix() ([]byte, error) {
+	cb, err := f.Control.Encode()
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, v4Magic...)
+	out = append(out, cb, byte(KindStreamClose), byte(f.Suite))
+	out = append(out, EncodeS243(f.Epoch)...)
+	out = append(out, EncodeS243(f.StreamID)...)
+	out = append(out, EncodeS243(uint64(len(f.Payload)))...)
+	out = append(out, f.Payload...)
+	return out, nil
+}
+
+// Serialize builds the wire frame (prefix + AES-256-GCM tag).
+func (f StreamCloseFrame) Serialize(key []byte) ([]byte, error) {
+	p, err := f.prefix()
+	if err != nil {
+		return nil, err
+	}
+	tag, err := demoTag(key, p, f.Sequence)
+	if err != nil {
+		return nil, err
+	}
+	return append(p, tag...), nil
+}

--- a/go/tritrpcv1/v4_stream_frames_test.go
+++ b/go/tritrpcv1/v4_stream_frames_test.go
@@ -1,0 +1,52 @@
+package tritrpcv1
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// ctrlA is the shared control byte used by the CLI stream frames (path_a/classical/exact/none/handle).
+func ctrlA() Control243 { return Control243{Profile: 0, Lane: 0, Evidence: 0, Fallback: 0, RouteFmt: 1} }
+
+// TestStreamOpenInheritedMatchesOracle: default semantic pair (braid 101, state 136), seq 2.
+func TestStreamOpenInheritedMatchesOracle(t *testing.T) {
+	m := frameOracle(t)
+	f := StreamOpenFrame{
+		Control: ctrlA(), Suite: SuiteFIPSClassical, Kind: KindStreamOpen, Epoch: 18,
+		RouteHandle: 7, StreamID: 9, Payload: []byte(`{"cursor":"start"}`),
+		DefaultBraid: SemanticPair{Set: true, Braid: 101, State: 136}, Sequence: 2,
+	}
+	got, err := f.Serialize(DemoKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != oracleHex(t, m, "stream_open_inherited") {
+		t.Fatalf("stream_open parity:\n got %s\n want %s", hex.EncodeToString(got), oracleHex(t, m, "stream_open_inherited"))
+	}
+}
+
+// TestStreamDataInheritMatchesOracle: no override (empty semantic pair), seq 3.
+func TestStreamDataInheritMatchesOracle(t *testing.T) {
+	m := frameOracle(t)
+	f := StreamDataFrame{
+		Control: ctrlA(), Suite: SuiteFIPSClassical, Epoch: 18, StreamID: 9,
+		Payload: []byte(`{"chunk":1}`), Sequence: 3,
+	}
+	got, _ := f.Serialize(DemoKey())
+	if hex.EncodeToString(got) != oracleHex(t, m, "stream_data_inherit") {
+		t.Fatalf("stream_data_inherit parity:\n got %s\n want %s", hex.EncodeToString(got), oracleHex(t, m, "stream_data_inherit"))
+	}
+}
+
+// TestStreamDataOverrideMatchesOracle: override semantic pair (101,136), seq 30.
+func TestStreamDataOverrideMatchesOracle(t *testing.T) {
+	m := frameOracle(t)
+	f := StreamDataFrame{
+		Control: ctrlA(), Suite: SuiteFIPSClassical, Epoch: 18, StreamID: 9,
+		Payload: []byte(`{"chunk":1}`), Override: SemanticPair{Set: true, Braid: 101, State: 136}, Sequence: 30,
+	}
+	got, _ := f.Serialize(DemoKey())
+	if hex.EncodeToString(got) != oracleHex(t, m, "stream_data_override") {
+		t.Fatalf("stream_data_override parity:\n got %s\n want %s", hex.EncodeToString(got), oracleHex(t, m, "stream_data_override"))
+	}
+}

--- a/go/tritrpcv1/v4_stream_frames_test.go
+++ b/go/tritrpcv1/v4_stream_frames_test.go
@@ -6,7 +6,9 @@ import (
 )
 
 // ctrlA is the shared control byte used by the CLI stream frames (path_a/classical/exact/none/handle).
-func ctrlA() Control243 { return Control243{Profile: 0, Lane: 0, Evidence: 0, Fallback: 0, RouteFmt: 1} }
+func ctrlA() Control243 {
+	return Control243{Profile: 0, Lane: 0, Evidence: 0, Fallback: 0, RouteFmt: 1}
+}
 
 // TestStreamOpenInheritedMatchesOracle: default semantic pair (braid 101, state 136), seq 2.
 func TestStreamOpenInheritedMatchesOracle(t *testing.T) {


### PR DESCRIPTION
## Go v4 stream frames — completes the frame family, all oracle-verified

StreamOpen / StreamData / StreamClose, byte-identical to the Python oracle:

- **StreamOpen** — route handle + stream id + optional **default** semantic pair `(Braid243, State243)`.
- **StreamData** — stream id + optional **override** semantic pair.
- **StreamClose** — stream id.

The semantic pair is two bytes `[braid, state]` when present, empty when absent (both-or-neither), matching `_encode_semantic_pair`. Same AES-256-GCM tag lane as #103.

**Parity:** `stream_open_inherited` (default pair, seq 2), `stream_data_inherit` (no pair, seq 3), `stream_data_override` (override pair, seq 30) each serialize **byte-identical** to `sample_vectors_v4.json`, tags included.

With #98 / #102 / #103 the **Go v4 primitive + frame family is complete** — Control243, State243, S243, Handle243, Braid243, hot_unary, beacon_commit, stream_open, stream_data, stream_close — all oracle-verified and CI-enforced via `make verify` (`go test`). gofmt+vet clean, full suite green. Additive — v1 wire untouched.
