### PR TITLE
fix(rust): oracle-verify v4 stream_open frame (fixture was a zero-filled placeholder)

### DIFF
--- a/conformance/fixtures/v4/frames/stream_open.json
+++ b/conformance/fixtures/v4/frames/stream_open.json
@@ -16,17 +16,21 @@
           "fallback": 0,
           "routefmt": 1
         },
-        "suite": 0,
-        "epoch": 0,
+        "suite": 1,
+        "epoch": 18,
         "route_handle": {
           "type": "direct",
-          "value": 5
+          "value": 7
         },
-        "stream_id": 1,
-        "payload_hex": "",
-        "tag_hex": "00000000000000000000000000000000"
+        "stream_id": 9,
+        "payload_hex": "7b22637572736f72223a227374617274227d",
+        "tag_hex": "5dd481a66529abe7d508f921b15ea4d7",
+        "default_semantic": [
+          101,
+          136
+        ]
       },
-      "expected_frame_hex": "f32a0102000005010000000000000000000000000000000000",
+      "expected_frame_hex": "f32a010201120709127b22637572736f72223a227374617274227d65885dd481a66529abe7d508f921b15ea4d7",
       "expected_parse": {
         "control": {
           "profile": 0,
@@ -35,16 +39,21 @@
           "fallback": 0,
           "routefmt": 1
         },
-        "suite": 0,
-        "epoch": 0,
+        "suite": 1,
+        "epoch": 18,
         "route_handle": {
           "type": "direct",
-          "value": 5
+          "value": 7
         },
-        "stream_id": 1,
-        "payload_hex": "",
-        "tag_hex": "00000000000000000000000000000000"
-      }
+        "stream_id": 9,
+        "payload_hex": "7b22637572736f72223a227374617274227d",
+        "tag_hex": "5dd481a66529abe7d508f921b15ea4d7",
+        "default_semantic": [
+          101,
+          136
+        ]
+      },
+      "oracle_ref": "generated/sample_vectors_v4.json#stream_open_inherited"
     },
     {
       "id": "stream-open-utf8-handle-with-payload",

--- a/rust/tritrpc_v1/tests/v4_frames.rs
+++ b/rust/tritrpc_v1/tests/v4_frames.rs
@@ -260,6 +260,10 @@ fn v4_frames_stream_open_positive_cases_match_fixture() {
         let suite = CryptoSuite::from_byte(suite_byte)
             .unwrap_or_else(|e| panic!("case {}: bad suite: {e}", case.id));
 
+        let default_semantic = input
+            .get("default_semantic")
+            .and_then(|v| v.as_array())
+            .map(|a| (a[0].as_u64().unwrap() as u8, a[1].as_u64().unwrap() as u8));
         let frame = StreamOpenFrame {
             control,
             suite,
@@ -267,7 +271,7 @@ fn v4_frames_stream_open_positive_cases_match_fixture() {
             route_handle,
             stream_id,
             payload,
-            default_semantic: None,
+            default_semantic,
             tag,
         };
 


### PR DESCRIPTION
## Rust stream_open now genuinely oracle-verified

The Rust `stream_open` conformance fixture was a **placeholder** (all-zeros, null tag, no semantic pair) and the test **hardcoded `default_semantic: None`** — so it validated nothing against the shared oracle.

- Corrected the fixture to the true oracle: suite=1, epoch=18, route=7, stream_id=9, payload `{"cursor":"start"}`, **default_semantic=(braid 101, state 136)**, real AES-GCM tag; `expected_frame_hex` now equals `sample_vectors_v4.json#stream_open_inherited`.
- Taught the test to read `default_semantic` from the fixture (was hardcoded None).

`cargo test --test v4_frames` **passes** — proving the Rust `StreamOpenFrame` serializer, including the 2-byte semantic-pair tail, produces the oracle bytes exactly. With the hot_unary correction (#104), Rust's frame fixtures are now oracle-verified, matching the complete Go port. Fixture + test only; no serializer change.