### PR TITLE
feat(rust): v4 Beacon / StreamData / StreamClose frames — completes Rust frame parity with the oracle

### DIFF
--- a/rust/tritrpc_v1/src/v4/frames.rs
+++ b/rust/tritrpc_v1/src/v4/frames.rs
@@ -400,3 +400,108 @@ mod tests {
         assert_eq!(parsed, frame);
     }
 }
+
+/// Encode a (phase 1..7, topic 1..23) braided coordinate to one byte (Braid243).
+fn encode_braid243(phase: u8, topic: u8) -> Result<u8, V4Error> {
+    if !(1..=7).contains(&phase) {
+        return Err(V4Error::new("phase must be in 1..7 for Braid243"));
+    }
+    if !(1..=23).contains(&topic) {
+        return Err(V4Error::new("topic must be in 1..23 for Braid243"));
+    }
+    Ok((phase - 1) * 27 + (topic - 1))
+}
+
+/// A v4 Beacon frame (capability / intent / commit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeaconFrame {
+    pub control: Control243,
+    pub suite: CryptoSuite,
+    pub kind: FrameKind,
+    pub epoch: u64,
+    pub identity_handle: HandleValue,
+    pub phase: u8,
+    pub topic: u8,
+    pub payload: Vec<u8>,
+    pub tag: [u8; 16],
+}
+
+impl BeaconFrame {
+    /// Serialize this beacon frame to canonical wire bytes.
+    pub fn serialize(&self) -> Result<Vec<u8>, V4Error> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&MAGIC);
+        out.push(self.control.encode()?);
+        out.push(self.kind.as_byte());
+        out.push(self.suite.as_byte());
+        out.extend(encode_s243(self.epoch));
+        out.extend(encode_handle243(&self.identity_handle)?);
+        out.push(encode_braid243(self.phase, self.topic)?);
+        out.extend(encode_s243(self.payload.len() as u64));
+        out.extend_from_slice(&self.payload);
+        out.extend_from_slice(&self.tag);
+        Ok(out)
+    }
+}
+
+/// A v4 StreamData frame (carries a chunk; optional override semantic tail).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamDataFrame {
+    pub control: Control243,
+    pub suite: CryptoSuite,
+    pub epoch: u64,
+    pub stream_id: u64,
+    pub payload: Vec<u8>,
+    /// Optional 2-byte semantic tail: (braid243, state243).
+    pub override_semantic: Option<(u8, u8)>,
+    pub tag: [u8; 16],
+}
+
+impl StreamDataFrame {
+    /// Serialize this stream-data frame to canonical wire bytes.
+    pub fn serialize(&self) -> Result<Vec<u8>, V4Error> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&MAGIC);
+        out.push(self.control.encode()?);
+        out.push(FrameKind::StreamData.as_byte());
+        out.push(self.suite.as_byte());
+        out.extend(encode_s243(self.epoch));
+        out.extend(encode_s243(self.stream_id));
+        out.extend(encode_s243(self.payload.len() as u64));
+        out.extend_from_slice(&self.payload);
+        if let Some((braid, state)) = self.override_semantic {
+            out.push(braid);
+            out.push(state);
+        }
+        out.extend_from_slice(&self.tag);
+        Ok(out)
+    }
+}
+
+/// A v4 StreamClose frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamCloseFrame {
+    pub control: Control243,
+    pub suite: CryptoSuite,
+    pub epoch: u64,
+    pub stream_id: u64,
+    pub payload: Vec<u8>,
+    pub tag: [u8; 16],
+}
+
+impl StreamCloseFrame {
+    /// Serialize this stream-close frame to canonical wire bytes.
+    pub fn serialize(&self) -> Result<Vec<u8>, V4Error> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&MAGIC);
+        out.push(self.control.encode()?);
+        out.push(FrameKind::StreamClose.as_byte());
+        out.push(self.suite.as_byte());
+        out.extend(encode_s243(self.epoch));
+        out.extend(encode_s243(self.stream_id));
+        out.extend(encode_s243(self.payload.len() as u64));
+        out.extend_from_slice(&self.payload);
+        out.extend_from_slice(&self.tag);
+        Ok(out)
+    }
+}

--- a/rust/tritrpc_v1/tests/v4_frames_oracle.rs
+++ b/rust/tritrpc_v1/tests/v4_frames_oracle.rs
@@ -1,0 +1,124 @@
+//! Oracle-driven parity for the v4 Beacon / StreamData / StreamClose frames.
+//!
+//! Reads the shared Python-generated vectors (sample_vectors_v4.json), supplies each vector's real
+//! AES-GCM tag (its last 16 bytes), rebuilds the frame from the known field values, and asserts the
+//! Rust serializer produces the exact oracle bytes — verifying the Rust prefix layout matches Python.
+
+use std::fs;
+
+use tritrpc_v1::v4::frames::{
+    BeaconFrame, Control243, CryptoSuite, StreamCloseFrame, StreamDataFrame,
+};
+use tritrpc_v1::v4::handle243::HandleValue;
+use tritrpc_v1::v4::kind243::FrameKind;
+
+fn oracle() -> serde_json::Value {
+    let path = format!(
+        "{}/../../reference/experimental/tritrpc_requirements_impl_v4/generated/sample_vectors_v4.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read oracle {path}: {e}"));
+    serde_json::from_str(&raw).expect("parse oracle")
+}
+
+fn get(o: &serde_json::Value, k: &str) -> String {
+    o[k].as_str()
+        .unwrap_or_else(|| panic!("oracle missing {k}"))
+        .to_string()
+}
+
+fn tag_of(hex_str: &str) -> [u8; 16] {
+    let bytes = hex::decode(hex_str).expect("hex");
+    let mut t = [0u8; 16];
+    t.copy_from_slice(&bytes[bytes.len() - 16..]);
+    t
+}
+
+fn ctrl_a() -> Control243 {
+    Control243 {
+        profile: 0,
+        lane: 0,
+        evidence: 0,
+        fallback: 0,
+        routefmt: 1,
+    }
+}
+
+#[test]
+fn beacon_commit_matches_oracle() {
+    let o = oracle();
+    let want = get(&o, "beacon_commit");
+    let identity = get(&o, "beacon_identity");
+    let mut payload = vec![136u8]; // State243(active/verified/routine/fluid/cohort)
+    payload.extend_from_slice(identity.as_bytes());
+    let frame = BeaconFrame {
+        control: Control243 {
+            profile: 2,
+            lane: 2,
+            evidence: 2,
+            fallback: 2,
+            routefmt: 2,
+        },
+        suite: CryptoSuite::Cnsa2Ready,
+        kind: FrameKind::BeaconCommit,
+        epoch: 18,
+        identity_handle: HandleValue::Direct(19),
+        phase: 4,
+        topic: 21,
+        payload,
+        tag: tag_of(&want),
+    };
+    assert_eq!(hex::encode(frame.serialize().unwrap()), want);
+}
+
+#[test]
+fn stream_data_inherit_matches_oracle() {
+    let o = oracle();
+    let want = get(&o, "stream_data_inherit");
+    let frame = StreamDataFrame {
+        control: ctrl_a(),
+        suite: CryptoSuite::FipsClassical,
+        epoch: 18,
+        stream_id: 9,
+        payload: b"{\"chunk\":1}".to_vec(),
+        override_semantic: None,
+        tag: tag_of(&want),
+    };
+    assert_eq!(hex::encode(frame.serialize().unwrap()), want);
+}
+
+#[test]
+fn stream_data_override_matches_oracle() {
+    let o = oracle();
+    let want = get(&o, "stream_data_override");
+    let frame = StreamDataFrame {
+        control: ctrl_a(),
+        suite: CryptoSuite::FipsClassical,
+        epoch: 18,
+        stream_id: 9,
+        payload: b"{\"chunk\":1}".to_vec(),
+        override_semantic: Some((101, 136)),
+        tag: tag_of(&want),
+    };
+    assert_eq!(hex::encode(frame.serialize().unwrap()), want);
+}
+
+#[test]
+fn stream_close_serializes_canonically() {
+    // No oracle vector for close; assert the canonical structure round-trips a known prefix.
+    let frame = StreamCloseFrame {
+        control: ctrl_a(),
+        suite: CryptoSuite::FipsClassical,
+        epoch: 18,
+        stream_id: 9,
+        payload: b"{}".to_vec(),
+        tag: [0u8; 16],
+    };
+    let bytes = frame.serialize().unwrap();
+    // f32a | ctrl(01) | kind(04) | suite(01) | epoch(12) | stream_id(09) | len(02) | {} | 16B tag
+    assert_eq!(
+        &bytes[..8],
+        &[0xf3, 0x2a, 0x01, 0x04, 0x01, 0x12, 0x09, 0x02]
+    );
+    assert_eq!(bytes.len(), 8 + 2 + 16);
+}


### PR DESCRIPTION
## Rust frame family now matches Go, all oracle-verified

Rust had only `HotUnary` + `StreamOpen` serializers; Go has the full family. This adds the missing three:

- **`BeaconFrame`** — control + kind + suite + epoch + identity handle + **Braid243(phase, topic)** + payload (+ an `encode_braid243` helper).
- **`StreamDataFrame`** — stream id + optional 2-byte **override** semantic tail.
- **`StreamCloseFrame`** — stream id.

**Parity (`tests/v4_frames_oracle.rs`):** reads the shared `sample_vectors_v4.json`, supplies each vector's real AES-GCM tag, and asserts the Rust serializer reproduces **beacon_commit**, **stream_data_inherit**, and **stream_data_override** byte-for-byte; stream_close serializes canonically (no oracle vector exists for it).

Rust v4 frame parity is now **complete** — hot_unary / beacon / stream_open / stream_data / stream_close — matching the Go port. rustfmt clean, full `cargo test` green. Additive — no v1 wire change.