### PR TITLE
feat(transport): route-handle dictionary negotiation — resolves the hot-frame Handle243 (gap #3)

### DIFF
--- a/.github/workflows/validate-route-dictionary.yml
+++ b/.github/workflows/validate-route-dictionary.yml
@@ -1,0 +1,19 @@
+name: validate-route-dictionary
+on:
+  pull_request:
+    paths: ["reference/route_dictionary.py","tools/verify_route_dictionary.py","schemas/jsonschema/route-dictionary.v0.schema.json","examples/transport/route_dictionary.example.json","spec/transport/route_dictionary.md",".github/workflows/validate-route-dictionary.yml"]
+  push:
+    branches: [ main ]
+    paths: ["reference/route_dictionary.py","tools/verify_route_dictionary.py","schemas/jsonschema/route-dictionary.v0.schema.json","examples/transport/route_dictionary.example.json","spec/transport/route_dictionary.md",".github/workflows/validate-route-dictionary.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate route-handle dictionary negotiation
+        run: python tools/verify_route_dictionary.py

--- a/examples/transport/route_dictionary.example.json
+++ b/examples/transport/route_dictionary.example.json
@@ -1,0 +1,17 @@
+{
+  "dictionaryId": "sha256:b2351b7a6f88b9c52685b3289ee8da3916f47edf68f1b970a9c3292705aceca8",
+  "entries": [
+    {
+      "handle": 7,
+      "route": "route://agentplane/executor"
+    },
+    {
+      "handle": 9,
+      "route": "route://agentplane/planner"
+    },
+    {
+      "handle": 19,
+      "route": "route://identity/beacon"
+    }
+  ]
+}

--- a/reference/route_dictionary.py
+++ b/reference/route_dictionary.py
@@ -1,0 +1,66 @@
+"""Route-handle dictionary negotiation (vNext hot-path gap #3) — fail-closed.
+
+Hot frames carry a 1-byte Handle243 (direct 0..242) instead of a full route string. That byte only
+has meaning against an AGREED dictionary. This reference builds a dictionary, computes its agreement
+token (SHA-256 of the canonical entries), negotiates agreement between two peers, and resolves a
+handle to its route — refusing, fail-closed, an unknown handle, a duplicate handle, or a dictionary
+mismatch.
+
+FIPS: the agreement token is SHA-256 (FIPS 180-4). Additive — explains the existing route_handle byte;
+does not change the frame wire (TritPack243/S243/Handle243 unchanged).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+class RouteDictError(Exception):
+    pass
+
+
+def _canonical(entries: list) -> bytes:
+    # sort by handle; compact JSON; deterministic across platforms.
+    norm = sorted(({"handle": e["handle"], "route": e["route"]} for e in entries), key=lambda e: e["handle"])
+    return json.dumps(norm, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def build_dictionary(mappings: dict) -> dict:
+    """mappings: {handle:int -> route:str}. Returns a RouteDictionary with its SHA-256 agreement token."""
+    entries = []
+    seen = set()
+    for handle, route in mappings.items():
+        h = int(handle)
+        if not 0 <= h <= 242:
+            raise RouteDictError(f"handle {h} out of Handle243 direct range 0..242")
+        if h in seen:
+            raise RouteDictError(f"duplicate handle {h}")
+        if not str(route):
+            raise RouteDictError(f"empty route for handle {h}")
+        seen.add(h)
+        entries.append({"handle": h, "route": str(route)})
+    token = "sha256:" + hashlib.sha256(_canonical(entries)).hexdigest()
+    return {"dictionaryId": token, "entries": entries}
+
+
+def dictionary_id(d: dict) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(d["entries"])).hexdigest()
+
+
+def resolve(d: dict, handle: int) -> str:
+    """Resolve a handle to its route, fail-closed if the dictionary is inconsistent or the handle unknown."""
+    if dictionary_id(d) != d.get("dictionaryId"):
+        raise RouteDictError("dictionary agreement token does not match its entries (tampered/stale)")
+    for e in d["entries"]:
+        if e["handle"] == handle:
+            return e["route"]
+    raise RouteDictError(f"route_handle {handle} is not in the agreed dictionary (unresolvable — refused)")
+
+
+def negotiate(local: dict, remote: dict) -> dict:
+    """Two peers agree iff their dictionary tokens match; otherwise refuse (no ambiguous resolution)."""
+    if dictionary_id(local) != local.get("dictionaryId") or dictionary_id(remote) != remote.get("dictionaryId"):
+        raise RouteDictError("a peer's dictionary token does not match its entries")
+    if local["dictionaryId"] != remote["dictionaryId"]:
+        raise RouteDictError("dictionary mismatch — peers advertise different handle->route maps (refused)")
+    return local

--- a/schemas/jsonschema/route-dictionary.v0.schema.json
+++ b/schemas/jsonschema/route-dictionary.v0.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/route-dictionary.v0.schema.json",
+  "title": "RouteDictionary v0",
+  "description": "The handle->route agreement that gives a hot frame's 1-byte Handle243 its meaning. A peer advertises a dictionary (via a Beacon-A capability); a hot frame carrying route_handle=h is resolvable only if h is in the AGREED dictionary. Two peers agree iff their dictionaryId (SHA-256 of the canonical entries) matches. Fail-closed: an unknown handle, a duplicate handle, or a mismatched dictionary is refused — closing gap #3 of the vNext hot-path list. Additive: it explains the existing route_handle byte; it does not change the frame wire.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["dictionaryId", "entries"],
+  "properties": {
+    "dictionaryId": { "type": "string", "pattern": "^sha256:", "description": "SHA-256 of the canonical (sorted, compact) entries — the agreement token." },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["handle", "route"],
+        "properties": {
+          "handle": { "type": "integer", "minimum": 0, "maximum": 242, "description": "direct Handle243 value." },
+          "route": { "type": "string", "minLength": 1, "description": "the full route URI the handle abbreviates." }
+        }
+      }
+    }
+  }
+}

--- a/spec/transport/route_dictionary.md
+++ b/spec/transport/route_dictionary.md
@@ -1,0 +1,28 @@
+# Route-handle dictionary negotiation (vNext hot-path gap #3)
+
+A v4 hot frame carries a 1-byte `Handle243` (direct 0..242) in place of a full route URI. That byte is
+meaningless without an **agreed dictionary** mapping handle → route. This closes gap #3 of the vNext
+"open gaps that still need code" list — additive: it explains the existing `route_handle` byte and
+changes no wire.
+
+## `RouteDictionary` (`schemas/jsonschema/route-dictionary.v0.schema.json`)
+
+`entries[{handle 0..242, route}]` plus a `dictionaryId` — **SHA-256 of the canonical (handle-sorted,
+compact) entries** — which is the agreement token.
+
+## Negotiation + resolution (`reference/route_dictionary.py`) — fail-closed
+
+- `build_dictionary(map)` — rejects duplicate or out-of-range handles; computes the SHA-256 token.
+- `resolve(dict, handle)` — returns the route, or **refuses** if the dictionary's token no longer
+  matches its entries (tampered/stale) or the handle is not present (unresolvable route).
+- `negotiate(local, remote)` — two peers agree **iff** their tokens match; a mismatch is refused (no
+  ambiguous resolution — a peer must never guess a route for a handle it did not agree to).
+
+A hot frame's `route_handle` is thus resolvable only against a negotiated dictionary; an unknown or
+disagreed handle fails closed rather than routing somewhere unintended. Advertised via a Beacon-A
+(capability) frame.
+
+## FIPS / boundary
+
+The agreement token is SHA-256 (FIPS 180-4). Additive — does not change the TritPack243 / S243 /
+Handle243 wire.

--- a/tools/verify_route_dictionary.py
+++ b/tools/verify_route_dictionary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Verify route-handle dictionary negotiation is fail-closed (vNext hot-path gap #3).
+
+Builds a dictionary, resolves a known handle, and asserts fail-closed refusals: an unknown handle, a
+duplicate handle, an out-of-range handle, a tampered dictionary (token no longer matches entries), and
+a peer mismatch during negotiation are each refused. Plus determinism (same map -> same SHA-256 token),
+a schema drift-guard, and example conformance. Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import route_dictionary as rd  # noqa: E402
+
+SCHEMA = ROOT / "schemas" / "jsonschema" / "route-dictionary.v0.schema.json"
+EX = ROOT / "examples" / "transport" / "route_dictionary.example.json"
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def refused(fn) -> bool:
+    try:
+        fn(); return False
+    except rd.RouteDictError:
+        return True
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    item = schema["properties"]["entries"]["items"]["properties"]
+    if schema.get("additionalProperties") is False and item["handle"]["maximum"] == 242 \
+       and schema["properties"]["dictionaryId"].get("pattern") == "^sha256:":
+        CHECKS["schema:no-drift"] = True
+    else:
+        FAILURES.append("schema drift (handle range / dictionaryId prefix)")
+
+    d = rd.build_dictionary({7: "route://agentplane/executor", 9: "route://agentplane/planner"})
+    # example matches a freshly-built dictionary (recompute-don't-trust).
+    ex = json.loads(EX.read_text())
+    CHECKS["example:token-recomputes"] = (rd.dictionary_id(ex) == ex["dictionaryId"])
+
+    # 1. resolve a known handle.
+    CHECKS["resolve:known-handle"] = (rd.resolve(d, 7) == "route://agentplane/executor")
+    # 2. unknown handle refused.
+    CHECKS["fail-closed:unknown-handle-refused"] = refused(lambda: rd.resolve(d, 200))
+    # 3. duplicate handle refused at build (a mapping whose items() yields the same handle twice).
+    CHECKS["fail-closed:duplicate-handle-refused"] = refused(lambda: rd.build_dictionary(_DupMap()))
+    # 4. out-of-range handle refused.
+    CHECKS["fail-closed:out-of-range-handle-refused"] = refused(lambda: rd.build_dictionary({243: "x"}))
+    # 5. tampered dictionary (entries changed, token stale) refused.
+    tampered = copy.deepcopy(d); tampered["entries"][0]["route"] = "route://evil"
+    CHECKS["fail-closed:tampered-dictionary-refused"] = refused(lambda: rd.resolve(tampered, 7))
+    # 6. negotiate: matching agree, mismatch refused.
+    d2 = rd.build_dictionary({7: "route://agentplane/executor", 9: "route://agentplane/planner"})
+    CHECKS["negotiate:matching-agree"] = (rd.negotiate(d, d2)["dictionaryId"] == d["dictionaryId"])
+    d3 = rd.build_dictionary({7: "route://different"})
+    CHECKS["fail-closed:mismatch-refused"] = refused(lambda: rd.negotiate(d, d3))
+    # 7. determinism.
+    CHECKS["deterministic:same-map-same-token"] = (
+        rd.build_dictionary({9: "route://b", 7: "route://a"})["dictionaryId"]
+        == rd.build_dictionary({7: "route://a", 9: "route://b"})["dictionaryId"])
+
+    for k, v in CHECKS.items():
+        if not v:
+            FAILURES.append(f"{k} failed")
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+class _DupMap(dict):
+    """A mapping whose items() yields the same handle twice — to exercise duplicate detection."""
+    def items(self):
+        return [(7, "route://a"), (7, "route://b")]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Closes vNext hot-path gap #3 — additive, no wire change

A v4 hot frame carries a 1-byte `Handle243` instead of a full route URI. That byte is meaningless without an **agreed dictionary** mapping handle -> route. This pins it.

- **`RouteDictionary`** — `entries[{handle 0..242, route}]` + `dictionaryId` = **SHA-256** of the canonical entries (the agreement token).
- **`reference/route_dictionary.py`** — build (rejects duplicate/out-of-range handles), **resolve** (refuses an unknown handle or a tampered/stale token), **negotiate** (peers agree iff tokens match; mismatch refused). A hot frame's `route_handle` is resolvable only against a negotiated dictionary — an unknown/disagreed handle **fails closed** rather than routing somewhere unintended.

**Teeth (10):** resolve known · unknown / duplicate / out-of-range / tampered / mismatch each refused · determinism · schema drift-guard.

FIPS: SHA-256 token (180-4). Additive — TritPack243/S243/Handle243 wire untouched.

**Note on the other 5 gaps:** #1 (S243 on hot path), #2 (Control243 encode/decode), #4 (StreamData/Close carry `stream_id`, not repeated route metadata) are **already satisfied** by the merged v4 frame/primitive work. Remaining: #5 nonce/session derivation, #6 Path-B scanner hardening (next).