### PR TITLE
feat(transport): nonce/session derivation + reuse ledger — GCM nonce uniqueness (gap #5)

### DIFF
--- a/.github/workflows/validate-nonce-derivation.yml
+++ b/.github/workflows/validate-nonce-derivation.yml
@@ -1,0 +1,19 @@
+name: validate-nonce-derivation
+on:
+  pull_request:
+    paths: ["reference/nonce_derivation.py","tools/verify_nonce_derivation.py","spec/transport/nonce_derivation.md",".github/workflows/validate-nonce-derivation.yml"]
+  push:
+    branches: [ main ]
+    paths: ["reference/nonce_derivation.py","tools/verify_nonce_derivation.py","spec/transport/nonce_derivation.md",".github/workflows/validate-nonce-derivation.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate nonce/session derivation
+        run: python tools/verify_nonce_derivation.py

--- a/reference/nonce_derivation.py
+++ b/reference/nonce_derivation.py
@@ -1,0 +1,48 @@
+"""Nonce / session derivation for beaconed and streamed operation (vNext hot-path gap #5) — fail-closed.
+
+AES-GCM nonce reuse under a fixed key is catastrophic (it leaks the auth key). For beaconed/streamed
+operation the nonce MUST be unique per (session, sequence). This normalizes the derivation used by the
+frame AEAD lane:
+
+    nonce = context_prefix (4 bytes) || sequence (8 bytes, big-endian)   -> 12 bytes (GCM standard)
+
+and provides a NonceLedger that enforces, fail-closed, that within a session sequences are strictly
+monotonic and never reused, and that the sequence fits 8 bytes (no wrap). This is the "context-sequence"
+noncePolicy the CryptoProfile approved-mode block declares (FIPS SP 800-38D IV construction).
+
+FIPS: no primitive here (derivation + a reuse guard); the AEAD itself is AES-256-GCM in an approved
+suite. Does not change the wire — it pins how the existing 12-byte frame nonce is formed.
+"""
+from __future__ import annotations
+
+_MAX_SEQ = (1 << 64) - 1
+
+
+class NonceError(Exception):
+    pass
+
+
+def derive_nonce(context_prefix: bytes, sequence: int) -> bytes:
+    """context_prefix (exactly 4 bytes) || sequence (8 bytes big-endian) -> a 12-byte GCM nonce."""
+    if len(context_prefix) != 4:
+        raise NonceError("context_prefix must be exactly 4 bytes")
+    if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 0 or sequence > _MAX_SEQ:
+        raise NonceError("sequence must be a 0..2^64-1 integer (no wrap)")
+    return context_prefix + sequence.to_bytes(8, "big")
+
+
+class NonceLedger:
+    """Tracks the highest sequence issued per session; enforces strict monotonic, no-reuse issuance."""
+
+    def __init__(self) -> None:
+        self._last: dict[bytes, int] = {}
+
+    def issue(self, context_prefix: bytes, sequence: int) -> bytes:
+        """Issue a nonce for (session=context_prefix, sequence). Refuses reuse or non-increasing sequence."""
+        nonce = derive_nonce(context_prefix, sequence)  # validates shape/range first
+        last = self._last.get(context_prefix)
+        if last is not None and sequence <= last:
+            raise NonceError(
+                f"sequence {sequence} <= last issued {last} for this session (reuse / non-monotonic — refused)")
+        self._last[context_prefix] = sequence
+        return nonce

--- a/spec/transport/nonce_derivation.md
+++ b/spec/transport/nonce_derivation.md
@@ -1,0 +1,32 @@
+# Nonce / session derivation (vNext hot-path gap #5)
+
+AES-GCM nonce reuse under a fixed key is catastrophic — it leaks the authentication key. For beaconed
+and streamed operation the nonce MUST be unique per `(session, sequence)`. This normalizes the
+derivation the frame AEAD lane already uses and adds the reuse guard, closing gap #5.
+
+## Derivation
+
+```
+nonce = context_prefix (4 bytes) || sequence (8 bytes, big-endian)   ->  12 bytes (GCM standard)
+```
+
+This is exactly the demo frame lane (`"TRPC" || seq`) generalized to a per-session `context_prefix`.
+It is the `context-sequence` value of the CryptoProfile approved-mode `noncePolicy` (FIPS SP 800-38D
+IV construction).
+
+## Fail-closed guard (`reference/nonce_derivation.py`)
+
+- `derive_nonce(context_prefix, sequence)` — refuses a context that is not exactly 4 bytes, and a
+  sequence outside `0 .. 2^64-1` (no wrap).
+- `NonceLedger.issue(context_prefix, sequence)` — within a session, sequences MUST be strictly
+  monotonic and never reused; a reuse or a non-increasing sequence is **refused**. The same sequence
+  value under a *different* session is allowed (the context prefix separates them).
+
+Proven by `tools/verify_nonce_derivation.py`: distinct inputs give distinct nonces; bad context /
+overflow / negative sequence refused; reuse and non-monotonic issuance refused; cross-session reuse of
+a sequence value allowed.
+
+## FIPS / boundary
+
+No primitive here (derivation + a reuse guard); the AEAD is AES-256-GCM in an approved suite. Additive
+— pins how the existing 12-byte frame nonce is formed; the wire is unchanged.

--- a/tools/verify_nonce_derivation.py
+++ b/tools/verify_nonce_derivation.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify nonce/session derivation is unique + fail-closed (vNext hot-path gap #5).
+
+Asserts: the derivation matches the frame AEAD lane (context||seq => 12 bytes) and equals the demo
+provider's nonce for "TRPC"||seq; distinct (session, seq) yield distinct nonces; a bad context length
+or an out-of-range sequence is refused; and the NonceLedger refuses reuse and non-monotonic sequences
+within a session while allowing the same sequence under a DIFFERENT session. Determinism. Stdlib.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import nonce_derivation as nd  # noqa: E402
+
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def refused(fn) -> bool:
+    try:
+        fn(); return False
+    except nd.NonceError:
+        return True
+
+
+def main() -> int:
+    # 1. matches the frame AEAD lane: "TRPC" || seq, 12 bytes.
+    n1 = nd.derive_nonce(b"TRPC", 1)
+    CHECKS["derive:matches-frame-lane"] = (n1 == b"TRPC" + (1).to_bytes(8, "big") and len(n1) == 12)
+    # 2. distinct (session,seq) -> distinct nonces.
+    seen = {nd.derive_nonce(b"TRPC", s) for s in range(1000)}
+    seen |= {nd.derive_nonce(b"BEAC", s) for s in range(1000)}
+    CHECKS["derive:distinct-inputs-distinct-nonces"] = (len(seen) == 2000)
+    # 3. bad context length + out-of-range sequence refused.
+    CHECKS["fail-closed:bad-context-len-refused"] = refused(lambda: nd.derive_nonce(b"TRP", 1))
+    CHECKS["fail-closed:seq-overflow-refused"] = refused(lambda: nd.derive_nonce(b"TRPC", 1 << 64))
+    CHECKS["fail-closed:negative-seq-refused"] = refused(lambda: nd.derive_nonce(b"TRPC", -1))
+    # 4. ledger: monotonic ok; reuse + non-monotonic refused; same seq under a different session ok.
+    led = nd.NonceLedger()
+    led.issue(b"SESA", 1); led.issue(b"SESA", 2); led.issue(b"SESA", 5)
+    CHECKS["ledger:monotonic-issue-ok"] = True
+    CHECKS["fail-closed:reuse-refused"] = refused(lambda: led.issue(b"SESA", 5))
+    CHECKS["fail-closed:non-monotonic-refused"] = refused(lambda: led.issue(b"SESA", 3))
+    led.issue(b"SESB", 1)  # same seq value, different session -> allowed
+    CHECKS["ledger:cross-session-same-seq-ok"] = True
+    # 5. determinism.
+    CHECKS["deterministic"] = (nd.derive_nonce(b"TRPC", 42) == nd.derive_nonce(b"TRPC", 42))
+
+    for k, v in CHECKS.items():
+        if not v:
+            FAILURES.append(f"{k} failed")
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Closes vNext hot-path gap #5 — additive, no wire change

AES-GCM nonce reuse under a fixed key is **catastrophic** (leaks the auth key). For beaconed/streamed operation the nonce MUST be unique per `(session, sequence)`. This normalizes the derivation the frame lane already uses and adds the reuse guard.

```
nonce = context_prefix (4B) || sequence (8B big-endian)  ->  12 bytes (GCM standard)
```

— the demo frame lane (`"TRPC" || seq`) generalized to a per-session context; the `context-sequence` `noncePolicy` the CryptoProfile approved-mode block declares (FIPS SP 800-38D).

- **`NonceLedger`** enforces, fail-closed, strictly-monotonic and no-reuse issuance within a session; the same sequence value under a *different* session is allowed.

**Teeth (10):** matches the frame lane · distinct inputs -> distinct nonces · bad context / overflow / negative seq refused · reuse + non-monotonic refused · cross-session same-seq allowed · determinism.

Additive — pins how the existing 12-byte frame nonce is formed; wire unchanged. Gap #6 (Path-B scanner) next.