### PR TITLE
fix(go): harden Path-B decoder into a fail-closed scanner (vNext gap #6)

### DIFF
--- a/go/tritrpcv1/pathb_dec.go
+++ b/go/tritrpcv1/pathb_dec.go
@@ -1,29 +1,50 @@
 package tritrpcv1
 
-// Minimal Path-B decoders for strings and union index (subset used in fixtures)
-func PBDecodeLen(buf []byte, off int) (int, int) {
-	// TLEB3 decode for length: reuse TLEB3 decoder by repacking; here we assume small inputs and just reuse TritUnpack on a byte-by-byte basis
-	// NOTE: For production, implement a proper scanner.
-	trits := []byte{}
+import (
+	"errors"
+	"fmt"
+)
+
+// Path-B (ternary-native) decoders. Hardened, fail-closed scanner (vNext gap #6): every read is
+// bounds-checked and every malformed input returns an error instead of panicking or reading out of
+// bounds, so Path-B can safely take larger wire responsibility. Subset used in fixtures: length,
+// string, union index.
+
+// maxPBLenTrits caps the scan so adversarial input without a terminator cannot loop unbounded.
+const maxPBLenTrits = 640 // >> any real length; a Path-B length that needs more is rejected
+
+// PBDecodeLen decodes a ternary-native length starting at off. Fail-closed: truncation, a missing
+// terminator, or an over-long run returns an error (never panics / reads out of bounds).
+func PBDecodeLen(buf []byte, off int) (val int, newOff int, err error) {
+	if off < 0 || off >= len(buf) {
+		return 0, 0, errors.New("path-b length: offset past end of buffer")
+	}
+	trits := make([]byte, 0, 16)
 	start := off
 	for {
+		if off >= len(buf) {
+			return 0, 0, errors.New("path-b length: truncated (no terminator before end of buffer)")
+		}
 		b := buf[off]
 		var ts []byte
-		var err error
+		var e error
 		if b >= 243 && b <= 246 {
 			if off+1 >= len(buf) {
-				panic("truncated tail marker")
+				return 0, 0, errors.New("path-b length: truncated tail marker")
 			}
-			ts, err = TritUnpack243(buf[off : off+2])
+			ts, e = TritUnpack243(buf[off : off+2])
 			off += 2
 		} else {
-			ts, err = TritUnpack243([]byte{b})
+			ts, e = TritUnpack243([]byte{b})
 			off++
 		}
-		if err != nil {
-			panic(err)
+		if e != nil {
+			return 0, 0, fmt.Errorf("path-b length: bad trit group: %w", e)
 		}
 		trits = append(trits, ts...)
+		if len(trits) > maxPBLenTrits {
+			return 0, 0, errors.New("path-b length: over-long run (no terminator) — refused")
+		}
 		if len(trits) >= 3 {
 			v := uint64(0)
 			used := 0
@@ -41,22 +62,27 @@ func PBDecodeLen(buf []byte, off int) (int, int) {
 				}
 			}
 			if used > 0 {
-				pack := TritPack243(trits[:used])
-				usedBytes := len(pack)
-				newOff := start + usedBytes
-				return int(v), newOff
+				usedBytes := len(TritPack243(trits[:used]))
+				return int(v), start + usedBytes, nil
 			}
 		}
 	}
 }
 
-func PBDecodeString(buf []byte, off int) (string, int) {
-	l, o2 := PBDecodeLen(buf, off)
-	s := string(buf[o2 : o2+l])
-	return s, o2 + l
+// PBDecodeString decodes a length-prefixed Path-B string. Fail-closed: a declared length that would
+// run past the buffer is rejected (no out-of-bounds slice).
+func PBDecodeString(buf []byte, off int) (string, int, error) {
+	l, o2, err := PBDecodeLen(buf, off)
+	if err != nil {
+		return "", 0, err
+	}
+	if l < 0 || o2 > len(buf) || l > len(buf)-o2 {
+		return "", 0, fmt.Errorf("path-b string: declared length %d exceeds %d remaining bytes", l, len(buf)-o2)
+	}
+	return string(buf[o2 : o2+l]), o2 + l, nil
 }
 
-func PBDecodeUnionIndex(buf []byte, off int) (int, int) {
-	l, o2 := PBDecodeLen(buf, off)
-	return l, o2
+// PBDecodeUnionIndex decodes a Path-B union index (a bare length), bounds-checked.
+func PBDecodeUnionIndex(buf []byte, off int) (int, int, error) {
+	return PBDecodeLen(buf, off)
 }

--- a/go/tritrpcv1/pathb_dec_test.go
+++ b/go/tritrpcv1/pathb_dec_test.go
@@ -1,0 +1,50 @@
+package tritrpcv1
+
+import "testing"
+
+// TestPBDecodeLenRoundtrip: a valid Path-B length (encoded via the shared TLEB3 lane) decodes back.
+func TestPBDecodeLenRoundtrip(t *testing.T) {
+	for _, v := range []uint64{0, 1, 8, 80, 1000} {
+		enc := TLEB3EncodeLen(v)
+		got, off, err := PBDecodeLen(enc, 0)
+		if err != nil {
+			t.Fatalf("PBDecodeLen(%d) errored: %v", v, err)
+		}
+		if uint64(got) != v || off != len(enc) {
+			t.Fatalf("PBDecodeLen(%d): got %d off %d (enc %d bytes)", v, got, off, len(enc))
+		}
+	}
+}
+
+// TestPBHardenedFailClosed: malformed inputs return errors and NEVER panic (the gap #6 fix).
+func TestPBHardenedFailClosed(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("hardened Path-B decoder panicked on malformed input: %v", r)
+		}
+	}()
+	// offset past end
+	if _, _, err := PBDecodeLen([]byte{}, 0); err == nil {
+		t.Fatal("empty buffer must error")
+	}
+	if _, _, err := PBDecodeLen([]byte{0x01}, 5); err == nil {
+		t.Fatal("offset past end must error")
+	}
+	// truncated tail marker (243..246 with no following byte)
+	if _, _, err := PBDecodeLen([]byte{243}, 0); err == nil {
+		t.Fatal("truncated tail marker must error")
+	}
+	// a run with no terminator (all-continuation-ish garbage) must be refused, not loop forever
+	garbage := make([]byte, 400)
+	for i := range garbage {
+		garbage[i] = 242
+	}
+	if _, _, err := PBDecodeLen(garbage, 0); err == nil {
+		t.Fatal("over-long / no-terminator run must be refused")
+	}
+	// string with a declared length longer than the remaining buffer
+	enc := TLEB3EncodeLen(100) // says "100 bytes follow" but buffer is short
+	if _, _, err := PBDecodeString(enc, 0); err == nil {
+		t.Fatal("over-long declared string length must error (no OOB slice)")
+	}
+}


### PR DESCRIPTION
## Closes vNext hot-path gap #6 — a real bounds-safety fix

The Path-B decoder literally carried `// NOTE: For production, implement a proper scanner` and had genuine bugs:
- `PBDecodeLen` read `buf[off]` with **no `off < len(buf)` check** → panic / OOB read on truncated input, and could loop unbounded with no terminator.
- `PBDecodeString` sliced `buf[o2:o2+l]` **without checking the declared length** against the remaining buffer.
- Every error path **panicked** instead of failing gracefully.

**Fix:** every read bounds-checked; `PBDecodeLen/String/UnionIndex` return errors (never panic / read OOB); a `maxPBLenTrits` cap refuses an over-long no-terminator run; an over-long declared string length is refused.

**Teeth:** valid lengths round-trip (via the shared TLEB3 lane); empty buffer / offset-past-end / truncated tail marker / no-terminator run / over-long declared string each return an error and **never panic** (a `recover()` guard asserts it). Only internal callers existed, updated in place. gofmt clean, full Go suite green — decoding hardened, the Path-B wire unchanged.

**This completes the vNext hot-path gap list** (#1/#2/#4 already satisfied by the v4 frames; #3 route dictionary #108; #5 nonce derivation #109; #6 here).