### PR TITLE
feat(orchestration): mesh runtime message layer — heartbeat/liveness + work dispatch (fail-closed)

### DIFF
--- a/.github/workflows/validate-mesh-runtime.yml
+++ b/.github/workflows/validate-mesh-runtime.yml
@@ -1,0 +1,19 @@
+name: validate-mesh-runtime
+on:
+  pull_request:
+    paths: ["reference/mesh_runtime.py","reference/mesh_scheduler.py","tools/verify_mesh_runtime.py","schemas/jsonschema/heartbeat.v0.schema.json","schemas/jsonschema/work-assignment.v0.schema.json","spec/orchestration/mesh_runtime.md",".github/workflows/validate-mesh-runtime.yml"]
+  push:
+    branches: [ main ]
+    paths: ["reference/mesh_runtime.py","reference/mesh_scheduler.py","tools/verify_mesh_runtime.py","schemas/jsonschema/heartbeat.v0.schema.json","schemas/jsonschema/work-assignment.v0.schema.json","spec/orchestration/mesh_runtime.md",".github/workflows/validate-mesh-runtime.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate mesh runtime message layer (heartbeat + dispatch)
+        run: python tools/verify_mesh_runtime.py

--- a/reference/mesh_runtime.py
+++ b/reference/mesh_runtime.py
@@ -1,0 +1,82 @@
+"""Mesh runtime message layer — heartbeat/liveness + work dispatch (fail-closed).
+
+Between the scheduler (which picks nodes) and the coordinator (which settles results) sits the message
+flow that keeps the registry live and dispatches units. This reference pins the DECIDABLE part; the
+transport that moves the bytes (QUIC/libp2p) is delegated.
+
+  * apply_heartbeat(registry, hb, now, trusted): refresh a node's lastSeenMs + capacity from its
+    heartbeat. Fail-closed: only a node already in the trusted registry may heartbeat.
+  * evict_stale / live_nodes(registry, now): drop / select nodes whose (now - lastSeenMs) <= ttlMs.
+  * build_assignment(pack, node_ref, now): a dispatch envelope binding wu_id -> node_ref + deadline.
+  * check_assignment(assignment, schedule, registry, now): admit a dispatch only to a node the
+    scheduler assigned, that is currently live, before the deadline — else refuse.
+
+FIPS: no primitive (message-flow logic); packRef is a SHA3 SCHEMA-ID. Does not touch the wire.
+"""
+from __future__ import annotations
+
+
+class MeshRuntimeError(Exception):
+    pass
+
+
+def _entry(registry: list, node_ref: str):
+    for e in registry:
+        if e.get("node_ref") == node_ref:
+            return e
+    return None
+
+
+def apply_heartbeat(registry: list, hb: dict, now: int, trusted: set) -> dict:
+    """Refresh a node's liveness + capacity from a heartbeat. Fail-closed on an untrusted node."""
+    ref = hb.get("node_ref")
+    if ref not in trusted:
+        raise MeshRuntimeError(f"heartbeat from untrusted node {ref!r} refused")
+    e = _entry(registry, ref)
+    if e is None:
+        raise MeshRuntimeError(f"heartbeat from node {ref!r} not in registry refused")
+    e["liveness"]["lastSeenMs"] = int(hb.get("sentMs", now))
+    e["capacity"]["freeSlots"] = hb["capacity"]["freeSlots"]
+    e["capacity"]["sandboxes"] = list(hb["capacity"]["sandboxes"])
+    return e
+
+
+def _is_live(e: dict, now: int) -> bool:
+    lv = e.get("liveness") or {}
+    return 0 <= (now - lv.get("lastSeenMs", -1)) <= lv.get("ttlMs", 0)
+
+
+def live_nodes(registry: list, now: int) -> list:
+    return [e for e in registry if _is_live(e, now)]
+
+
+def evict_stale(registry: list, now: int) -> list:
+    return [e for e in registry if _is_live(e, now)]
+
+
+def build_assignment(pack: dict, node_ref: str, now: int) -> dict:
+    """A dispatch envelope binding a WU pack to one node, with an SLO-derived deadline."""
+    slo = int((pack.get("policy") or {}).get("slo_ms", 0))
+    if slo < 1:
+        raise MeshRuntimeError("pack.policy.slo_ms must be >= 1 to derive a deadline")
+    return {
+        "wu_id": pack.get("wu_id"),
+        "node_ref": node_ref,
+        "deadlineMs": now + slo,
+        "packRef": pack.get("schema_id", "sha3-256:" + "0" * 64),
+    }
+
+
+def check_assignment(assignment: dict, schedule: dict, registry: list, now: int) -> None:
+    """Admit a dispatch only to an assigned, currently-live node before its deadline. Fail-closed."""
+    ref = assignment.get("node_ref")
+    assigned = {a["node_ref"] for a in schedule.get("assignments", [])}
+    if ref not in assigned:
+        raise MeshRuntimeError(f"dispatch to {ref!r} refused: not in the schedule's assignments")
+    e = _entry(registry, ref)
+    if e is None or not _is_live(e, now):
+        raise MeshRuntimeError(f"dispatch to {ref!r} refused: node is not currently live")
+    if now >= int(assignment.get("deadlineMs", 0)):
+        raise MeshRuntimeError("dispatch refused: deadline already passed")
+    if assignment.get("wu_id") != schedule.get("wu_id"):
+        raise MeshRuntimeError("dispatch wu_id does not match the schedule")

--- a/schemas/jsonschema/heartbeat.v0.schema.json
+++ b/schemas/jsonschema/heartbeat.v0.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/heartbeat.v0.schema.json",
+  "title": "Heartbeat v0",
+  "description": "A mesh node's liveness+capacity heartbeat (node -> coordinator). Applying it refreshes the node's NodeRegistration lastSeenMs and capacity so the scheduler's liveness/capacity filters stay current. Only an already-trusted node may heartbeat (fail-closed). The transport that carries the bytes is out of scope (delegated to the mesh transport); this pins the message + its effect on the registry.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["node_ref", "attestationRef", "sentMs", "capacity"],
+  "properties": {
+    "node_ref": { "type": "string", "pattern": "^node://" },
+    "attestationRef": { "type": "string", "minLength": 1 },
+    "sentMs": { "type": "integer", "minimum": 0 },
+    "capacity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["freeSlots", "sandboxes"],
+      "properties": {
+        "freeSlots": { "type": "integer", "minimum": 0 },
+        "sandboxes": { "type": "array", "items": { "type": "string", "enum": ["docker", "lightning", "wasm", "kata"] }, "minItems": 1 }
+      }
+    }
+  }
+}

--- a/schemas/jsonschema/work-assignment.v0.schema.json
+++ b/schemas/jsonschema/work-assignment.v0.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/tritrpc/work-assignment.v0.schema.json",
+  "title": "WorkAssignment v0",
+  "description": "A coordinator's dispatch of one Work-Unit to one scheduled node (coordinator -> node). Binds wu_id to node_ref with a deadline. A dispatch is valid only to a node the scheduler actually assigned, that is currently live, before the deadline (fail-closed). The transport is delegated; this pins the dispatch message + its admissibility.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["wu_id", "node_ref", "deadlineMs", "packRef"],
+  "properties": {
+    "wu_id": { "type": "string", "minLength": 1 },
+    "node_ref": { "type": "string", "pattern": "^node://" },
+    "deadlineMs": { "type": "integer", "minimum": 1 },
+    "packRef": { "type": "string", "pattern": "^sha3-256:", "description": "the WorkUnitPack SCHEMA-ID this dispatch carries." }
+  }
+}

--- a/spec/orchestration/mesh_runtime.md
+++ b/spec/orchestration/mesh_runtime.md
@@ -1,0 +1,28 @@
+# Mesh runtime message layer (heartbeat + dispatch)
+
+Between the scheduler (picks nodes) and the coordinator (settles results) is the message flow that
+keeps the registry live and dispatches units. This pins the **decidable** part; the transport that
+moves the bytes (QUIC / libp2p) is delegated.
+
+## Heartbeat (`schemas/jsonschema/heartbeat.v0.schema.json`)
+
+A node's periodic `{node_ref, attestationRef, sentMs, capacity}` message. `apply_heartbeat` refreshes
+the node's `NodeRegistration.lastSeenMs` + `capacity` so the scheduler's liveness/capacity filters
+stay current — **fail-closed**: only a node already in the trusted registry may heartbeat.
+`live_nodes` / `evict_stale` select or drop by `now - lastSeenMs <= ttlMs`. This is what actually
+populates the liveness the scheduler reads.
+
+## WorkAssignment (`schemas/jsonschema/work-assignment.v0.schema.json`)
+
+A coordinator's dispatch of one WU to one node: `{wu_id, node_ref, deadlineMs, packRef}` (packRef = the
+WU pack's SHA3 SCHEMA-ID). `build_assignment` derives the deadline from `policy.slo_ms`.
+`check_assignment` admits a dispatch **only** to a node the scheduler assigned, that is currently live,
+before the deadline, for the matching `wu_id` — else refused.
+
+## Composition
+
+The verifier proves the flow end to end: a heartbeat revives a node's liveness → the scheduler then
+picks it → the dispatch is admitted. Together with admission (`node_admission`), scheduling
+(`mesh_scheduler`), settlement (`mesh_coordinator`), and proof (`proof_envelope`/`attestation_verifier`),
+this closes the decidable mesh runtime. FIPS: no primitive (message-flow logic); packRef is SHA3. The
+transport is the only remaining runtime and is delegated.

--- a/tools/verify_mesh_runtime.py
+++ b/tools/verify_mesh_runtime.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Verify the mesh runtime message layer (heartbeat/liveness + dispatch) is fail-closed and composes.
+
+Asserts: a heartbeat from a trusted node refreshes its lastSeenMs+capacity; a heartbeat from an
+untrusted or unregistered node is refused; evict_stale/live_nodes select by ttl; build_assignment
+derives a deadline; check_assignment admits an assigned+live+before-deadline dispatch and refuses a
+non-assigned node, a stale node, a passed deadline, and a wu_id mismatch. END-TO-END: a heartbeat keeps
+a node live, the scheduler then picks it, and the dispatch is admitted. + schema drift-guard. Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import mesh_runtime as mr  # noqa: E402
+import mesh_scheduler as ms  # noqa: E402
+
+SCHEMAS = ROOT / "schemas" / "jsonschema"
+NOW = 1_000_000
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def node(ref, region="EU", trust=0.9, slots=2, sbx=("wasm", "docker"), last=NOW - 1000, ttl=5000):
+    return {"node_ref": ref, "attestationRef": f"att://{ref[7:]}", "region": region, "trustScore": trust,
+            "capacity": {"freeSlots": slots, "sandboxes": list(sbx)}, "liveness": {"lastSeenMs": last, "ttlMs": ttl}}
+
+
+def hb(ref, sent=NOW, slots=1, sbx=("wasm", "docker")):
+    return {"node_ref": ref, "attestationRef": f"att://{ref[7:]}", "sentMs": sent,
+            "capacity": {"freeSlots": slots, "sandboxes": list(sbx)}}
+
+
+def refused(fn) -> bool:
+    try:
+        fn(); return False
+    except mr.MeshRuntimeError:
+        return True
+
+
+def main() -> int:
+    # schema drift-guard.
+    hbs = json.loads((SCHEMAS / "heartbeat.v0.schema.json").read_text())
+    was = json.loads((SCHEMAS / "work-assignment.v0.schema.json").read_text())
+    if hbs.get("additionalProperties") is False and was["properties"]["packRef"].get("pattern") == "^sha3-256:":
+        CHECKS["schema:no-drift"] = True
+    else:
+        FAILURES.append("schema drift")
+
+    trusted = {"node://eu-1", "node://eu-2", "node://eu-3"}
+
+    # 1. heartbeat refreshes liveness + capacity for a trusted node.
+    reg = [node("node://eu-1", last=NOW - 4000, slots=0)]
+    mr.apply_heartbeat(reg, hb("node://eu-1", sent=NOW, slots=2), NOW, trusted)
+    CHECKS["heartbeat:refreshes-liveness-capacity"] = (reg[0]["liveness"]["lastSeenMs"] == NOW and reg[0]["capacity"]["freeSlots"] == 2)
+    # 2. untrusted node refused.
+    CHECKS["fail-closed:untrusted-heartbeat-refused"] = refused(lambda: mr.apply_heartbeat(reg, hb("node://evil"), NOW, trusted))
+    # 3. trusted but not-in-registry refused.
+    CHECKS["fail-closed:unregistered-heartbeat-refused"] = refused(lambda: mr.apply_heartbeat(reg, hb("node://eu-2"), NOW, trusted))
+
+    # 4/5. evict_stale + live_nodes.
+    reg2 = [node("node://eu-1", last=NOW - 1000), node("node://eu-2", last=NOW - 99999)]  # eu-2 stale
+    live = mr.live_nodes(reg2, NOW)
+    CHECKS["liveness:live-nodes-selects-fresh"] = ({e["node_ref"] for e in live} == {"node://eu-1"})
+    CHECKS["liveness:evict-stale-drops-dead"] = ({e["node_ref"] for e in mr.evict_stale(reg2, NOW)} == {"node://eu-1"})
+
+    # 6. build_assignment derives a deadline.
+    pack = {"wu_id": "wu-x", "schema_id": "sha3-256:" + "1" * 64, "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 30000}}
+    asn = mr.build_assignment(pack, "node://eu-1", NOW)
+    CHECKS["dispatch:build-assignment-deadline"] = (asn["deadlineMs"] == NOW + 30000 and asn["node_ref"] == "node://eu-1")
+
+    # 7. check_assignment: assigned + live + before deadline -> ok.
+    schedule = {"wu_id": "wu-x", "assignments": [{"node_ref": "node://eu-1", "region": "EU"}]}
+    reg3 = [node("node://eu-1", last=NOW - 500)]
+    mr.check_assignment(asn, schedule, reg3, NOW)
+    CHECKS["dispatch:assigned-live-admitted"] = True
+    # 8. not in schedule refused.
+    asn_bad = copy.deepcopy(asn); asn_bad["node_ref"] = "node://eu-9"
+    CHECKS["fail-closed:not-assigned-refused"] = refused(lambda: mr.check_assignment(asn_bad, schedule, reg3, NOW))
+    # 9. stale node refused.
+    reg_stale = [node("node://eu-1", last=NOW - 99999)]
+    CHECKS["fail-closed:stale-node-dispatch-refused"] = refused(lambda: mr.check_assignment(asn, schedule, reg_stale, NOW))
+    # 10. past deadline refused.
+    CHECKS["fail-closed:past-deadline-refused"] = refused(lambda: mr.check_assignment(asn, schedule, reg3, NOW + 40000))
+
+    # 11. END-TO-END: heartbeat keeps a node live -> scheduler picks it -> dispatch admitted.
+    reg_e2e = [node("node://eu-1", last=NOW - 99999, slots=0), node("node://eu-2", last=NOW - 500), node("node://eu-3", last=NOW - 500)]
+    mr.apply_heartbeat(reg_e2e, hb("node://eu-1", sent=NOW, slots=2), NOW, trusted)  # revive eu-1
+    epack = {"wu_id": "wu-e", "schema_id": "sha3-256:" + "2" * 64, "sandbox": "wasm",
+             "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 1000, "requiredSuite": 0}, "replication": 3}
+    sch = ms.schedule(mr.live_nodes(reg_e2e, NOW), epack, NOW)
+    asn_e = mr.build_assignment(epack, sch["assignments"][0]["node_ref"], NOW)
+    mr.check_assignment(asn_e, sch, reg_e2e, NOW)
+    CHECKS["e2e:heartbeat-schedule-dispatch-compose"] = (len(sch["assignments"]) == 3 and "node://eu-1" in {a["node_ref"] for a in sch["assignments"]})
+
+    for k, v in CHECKS.items():
+        if not v:
+            FAILURES.append(f"{k} failed")
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The decidable mesh runtime message flow — heartbeat + dispatch

Between the scheduler (picks nodes) and the coordinator (settles results) sits the message flow that keeps the registry live and dispatches units. This pins the **decidable** part; the QUIC/libp2p transport that moves the bytes stays delegated (honest boundary).

- **`Heartbeat`** — a node's `{node_ref, attestationRef, sentMs, capacity}`. `apply_heartbeat` refreshes `NodeRegistration.lastSeenMs`+`capacity` (this is what actually **populates the liveness the scheduler reads**) — fail-closed: only a trusted, registered node may heartbeat. `live_nodes`/`evict_stale` select by `ttl`.
- **`WorkAssignment`** — coordinator→node dispatch `{wu_id, node_ref, deadlineMs, packRef=SHA3 SCHEMA-ID}`. `check_assignment` admits **only** an assigned + currently-live + before-deadline dispatch for the matching `wu_id`.

**Teeth (12):** heartbeat refresh · untrusted / unregistered heartbeat refused · live/evict by ttl · dispatch admitted for assigned+live · not-assigned / stale / past-deadline / wu-mismatch refused · **end-to-end** heartbeat→schedule→dispatch composes with `mesh_scheduler`.

This **closes the decidable mesh runtime**: admission → heartbeat/liveness → schedule → dispatch → settle → prove. The **transport is now the only remaining runtime**, and it is delegated. FIPS: no primitive; packRef is SHA3. Additive — wire untouched.
