### PR TITLE
fix(orchestration): coordinator ENFORCES requiredSuite via suite_gate (was declared-unenforced)

### DIFF
--- a/reference/mesh_coordinator.py
+++ b/reference/mesh_coordinator.py
@@ -27,7 +27,12 @@ touch the tritrpc v4/vNext wire format.
 """
 from __future__ import annotations
 
+import os
+import sys
 from typing import Any
+
+sys.path.insert(0, os.path.dirname(__file__))
+import suite_gate  # noqa: E402  (the coordinator ENFORCES the suite gate — not just declares it)
 
 PROOF_MODES = {"redundant", "spot_check", "tee", "zk"}
 # The material each proof mode's result MUST carry to be admissible (beyond schema shape).
@@ -80,6 +85,14 @@ def verify_result(pack: dict, result: dict, trusted: list) -> None:
     policy = pack.get("policy") or {}
     if not _residency_ok(policy.get("residency", "any"), result.get("region", "")):
         _fail(f"residency violation: pack requires {policy.get('residency')!r}, node in {result.get('region')!r}")
+
+    # Enforce the workload's required assurance suite against the executing node (fabric, not a patch):
+    # a suite-N workload MUST NOT settle on a node whose crypto profile suite is below N.
+    if int(policy.get("requiredSuite", 0)) > 0:
+        try:
+            suite_gate.require_suite(pack, node)
+        except suite_gate.SuiteError as exc:
+            _fail(str(exc))
 
     proof = result.get("proof") or {}
     if proof.get("mode") != mode:

--- a/tools/verify_mesh_coordinator.py
+++ b/tools/verify_mesh_coordinator.py
@@ -136,6 +136,19 @@ def main() -> int:
     else:
         FAILURES.append("reduce is not deterministic")
 
+    # 9. FABRIC: the coordinator ENFORCES pack.policy.requiredSuite via suite_gate (not just declares it).
+    #    A suite-2 (CNSA) workload must NOT settle on suite-1 (FIPS) nodes, but settles on suite-2 nodes.
+    cnsa_pack = copy.deepcopy(pack)
+    cnsa_pack["policy"]["requiredSuite"] = 2
+    fips_nodes = [{"node_ref": n["node_ref"], "attestationRef": n["attestationRef"], "region": n["region"], "suite": 1} for n in trusted]
+    cnsa_nodes = [{"node_ref": n["node_ref"], "attestationRef": n["attestationRef"], "region": n["region"], "suite": 2} for n in trusted]
+    on_fips = mc.reduce(cnsa_pack, results, fips_nodes)
+    on_cnsa = mc.reduce(cnsa_pack, results, cnsa_nodes)
+    if not on_fips["settled"] and len(on_fips["rejected"]) == len(results) and on_cnsa["settled"]:
+        CHECKS["fabric:coordinator-enforces-required-suite"] = True
+    else:
+        FAILURES.append(f"coordinator did not enforce requiredSuite: on_fips={on_fips['settled']} on_cnsa={on_cnsa['settled']}")
+
     for m in FAILURES:
         print(f"FAIL: {m}", file=sys.stderr)
     ok = not FAILURES and all(CHECKS.values())


### PR DESCRIPTION
## Fabric fix: the coordinator now *enforces* `requiredSuite` (it only *declared* it before)

A fabric audit ("what calls this?") found `suite_gate` was orphaned — only its own verifier called it. So the mesh coordinator's settlement path **never enforced** `pack.policy.requiredSuite`, meaning the **CNSA-workload-on-a-FIPS-node break that `suite_gate` was built to close was still open in practice.** A patch, not fabric.

- `mesh_coordinator.verify_result` now **calls `suite_gate.require_suite(pack, node)`** when `requiredSuite > 0`, refusing a result from a node whose crypto suite is below the workload's requirement. Backward-compatible (fires only when `requiredSuite` is set).
- **Teeth:** a suite-2 pack does **not** settle on suite-1 nodes (all results rejected) and **does** settle on suite-2 nodes — `fabric:coordinator-enforces-required-suite`.

`suite_gate` is now consumed by the runtime, not a standalone verifier. All composing verifiers (scheduler / admission / runtime / suite-gate) still green. Additive — no wire change. First of the fabric-integration fixes; tee/zk routing through `proof_envelope`+`attestation_verifier` next.
