### PR TITLE
fix(orchestration): coordinator ROUTES tee/zk through proof_envelope + attestation_verifier (fabric)

### DIFF
--- a/reference/mesh_coordinator.py
+++ b/reference/mesh_coordinator.py
@@ -33,6 +33,8 @@ from typing import Any
 
 sys.path.insert(0, os.path.dirname(__file__))
 import suite_gate  # noqa: E402  (the coordinator ENFORCES the suite gate — not just declares it)
+import proof_envelope  # noqa: E402  (tee/zk results are ROUTED through the envelope + verifier)
+import attestation_verifier  # noqa: E402
 
 PROOF_MODES = {"redundant", "spot_check", "tee", "zk"}
 # The material each proof mode's result MUST carry to be admissible (beyond schema shape).
@@ -97,9 +99,27 @@ def verify_result(pack: dict, result: dict, trusted: list) -> None:
     proof = result.get("proof") or {}
     if proof.get("mode") != mode:
         _fail(f"proof.mode {proof.get('mode')!r} != pack.proof_mode {mode!r} (mode mismatch)")
-    for field in REQUIRED_PROOF_FIELDS[mode]:
-        if not str(proof.get(field) or "").strip() and proof.get(field) != 0:
-            _fail(f"proof for mode {mode!r} is missing required material: {field!r}")
+
+    if mode in ("tee", "zk"):
+        # Route through the proof envelope (anti-replay binding) + the attestation verifier (decidable
+        # checks + abstain). This is the FABRIC wiring: the coordinator does not settle a tee/zk result
+        # on structural presence alone — it binds the proof to THIS result and demands a non-reject verdict.
+        binding = {"wu_id": result.get("wu_id"), "result_cid": result.get("result_cid")}
+        material = dict(proof)
+        if mode == "zk" and "proof" not in material and material.get("proof_blob"):
+            material["proof"] = material["proof_blob"]
+        try:
+            proof_envelope.precheck({"mode": mode, "binding": binding, "material": material}, pack, result)
+        except proof_envelope.ProofEnvelopeError as exc:
+            _fail(f"proof envelope refused the {mode} result: {exc}")
+        verdict = attestation_verifier.verify_tee(material, binding) if mode == "tee" \
+            else attestation_verifier.verify_zk(material, binding)
+        if verdict["verdict"] == "reject":
+            _fail(f"attestation verifier rejected the {mode} result: {verdict.get('reason')}")
+    else:
+        for field in REQUIRED_PROOF_FIELDS[mode]:
+            if not str(proof.get(field) or "").strip() and proof.get(field) != 0:
+                _fail(f"proof for mode {mode!r} is missing required material: {field!r}")
 
 
 def reduce(pack: dict, results: list, trusted: list) -> dict:

--- a/schemas/jsonschema/work-unit-result.v0.schema.json
+++ b/schemas/jsonschema/work-unit-result.v0.schema.json
@@ -5,25 +5,102 @@
   "description": "A volunteer node's returned result for a WorkUnitPack. Carries the content-addressed result (SHA-256 CID), the executing node anchor, its region (checked against pack.policy.residency), and a proof block whose mode MUST match the pack's proof_mode and MUST carry that mode's required material. The Mesh Coordinator collects these and settles fail-closed.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["wu_id", "node_ref", "region", "result_cid", "proof", "signature"],
+  "required": [
+    "wu_id",
+    "node_ref",
+    "region",
+    "result_cid",
+    "proof",
+    "signature"
+  ],
   "properties": {
-    "wu_id": { "type": "string", "minLength": 1 },
-    "node_ref": { "type": "string", "pattern": "^node://" },
-    "region": { "type": "string", "minLength": 1 },
-    "result_cid": { "type": "string", "pattern": "^sha256:" },
+    "wu_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "node_ref": {
+      "type": "string",
+      "pattern": "^node://"
+    },
+    "region": {
+      "type": "string",
+      "minLength": 1
+    },
+    "result_cid": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
     "proof": {
       "type": "object",
-      "required": ["mode"],
+      "required": [
+        "mode"
+      ],
       "properties": {
-        "mode": { "type": "string", "enum": ["redundant", "spot_check", "tee", "zk"] },
-        "challenge_index": { "type": "integer", "minimum": 0 },
-        "revealed_cid": { "type": "string", "pattern": "^sha256:" },
-        "quote": { "type": "string" },
-        "measurement": { "type": "string", "pattern": "^sha256:" },
-        "statement": { "type": "string" },
-        "proof_blob": { "type": "string" }
+        "mode": {
+          "type": "string",
+          "enum": [
+            "redundant",
+            "spot_check",
+            "tee",
+            "zk"
+          ]
+        },
+        "challenge_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "revealed_cid": {
+          "type": "string",
+          "pattern": "^sha256:"
+        },
+        "quote": {
+          "type": "string"
+        },
+        "measurement": {
+          "type": "string",
+          "pattern": "^sha256:"
+        },
+        "statement": {
+          "type": "string"
+        },
+        "proof_blob": {
+          "type": "string"
+        },
+        "nonce": {
+          "type": "string",
+          "minLength": 1,
+          "description": "tee: freshness nonce (anti-replay of the quote)."
+        },
+        "report_data": {
+          "type": "string",
+          "pattern": "^sha256:",
+          "description": "tee: SHA-256(nonce||result_cid) \u2014 binds the quote to THIS result."
+        },
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "groth16",
+            "plonk",
+            "stark"
+          ],
+          "description": "zk: proof system."
+        },
+        "publicInputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "zk: must include result_cid + SHA-256(statement)."
+        },
+        "proof": {
+          "type": "string",
+          "description": "zk: the proof blob (alias of proof_blob for the envelope)."
+        }
       }
     },
-    "signature": { "type": "string", "minLength": 1 }
+    "signature": {
+      "type": "string",
+      "minLength": 1
+    }
   }
 }

--- a/tools/verify_mesh_coordinator.py
+++ b/tools/verify_mesh_coordinator.py
@@ -120,15 +120,30 @@ def main() -> int:
     else:
         FAILURES.append(f"below-replication WU must NOT settle: {rec_few}")
 
-    # 7. tee mode: present quote+measurement settles; missing measurement refused.
+    # 7. tee mode: a proof BOUND to the result (report_data==SHA256(nonce||result_cid), allow-listed
+    #    measurement) settles via the envelope + attestation verifier; a missing/unbound proof refused.
+    import hashlib as _hl
     tee_pack = copy.deepcopy(pack); tee_pack["proof_mode"] = "tee"; tee_pack["replication"] = 1
-    r_tee = copy.deepcopy(results[0]); r_tee["proof"] = {"mode": "tee", "quote": "q", "measurement": "sha256:" + "e" * 64}
+    _rc = results[0]["result_cid"]; _nonce = "n-tee-1"
+    _rd = "sha256:" + _hl.sha256(f"{_nonce}|{_rc}".encode()).hexdigest()
+    r_tee = copy.deepcopy(results[0])
+    r_tee["proof"] = {"mode": "tee", "quote": "q", "measurement": "sha256:" + "e" * 64, "nonce": _nonce, "report_data": _rd}
     rec_tee = mc.reduce(tee_pack, [r_tee], trusted)
     r_tee_bad = copy.deepcopy(r_tee); r_tee_bad["proof"] = {"mode": "tee", "quote": "q"}
     if rec_tee["settled"] and refused(lambda: mc.verify_result(tee_pack, r_tee_bad, trusted)):
         CHECKS["tee:present-settles-missing-refused"] = True
     else:
         FAILURES.append("tee: a valid quote+measurement must settle and a missing measurement be refused")
+
+    # FABRIC: tee/zk are routed through proof_envelope + attestation_verifier, so a proof bound to a
+    # DIFFERENT result (report_data for another result_cid) is refused at SETTLEMENT — anti-replay the
+    # old structural check let through.
+    r_replay = copy.deepcopy(r_tee)
+    r_replay["proof"]["report_data"] = "sha256:" + _hl.sha256(f"{_nonce}|sha256:{'b' * 64}".encode()).hexdigest()
+    if refused(lambda: mc.verify_result(tee_pack, r_replay, trusted)):
+        CHECKS["fabric:tee-replayed-proof-refused-at-settlement"] = True
+    else:
+        FAILURES.append("a tee proof bound to a different result must be refused at settlement (anti-replay)")
 
     # 8. Determinism.
     if mc.reduce(pack, results, trusted) == rec:

--- a/tools/verify_node_admission.py
+++ b/tools/verify_node_admission.py
@@ -79,9 +79,14 @@ def main() -> int:
     pack = {"wu_id": "wu-x", "proof_mode": "tee", "sandbox": "wasm",
             "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 1000},
             "replication": 1}
+    import hashlib as _hl
+    _rc = "sha256:" + "a" * 64
+    _nonce = "n-adm-1"
+    _rd = "sha256:" + _hl.sha256(f"{_nonce}|{_rc}".encode()).hexdigest()
     result = {"wu_id": "wu-x", "node_ref": rep["node_ref"], "region": rep["region"],
-              "result_cid": "sha256:" + "a" * 64,
-              "proof": {"mode": "tee", "quote": "q", "measurement": "sha256:" + "b" * 64}}
+              "result_cid": _rc,
+              "proof": {"mode": "tee", "quote": "q", "measurement": "sha256:" + "e" * 64,
+                        "nonce": _nonce, "report_data": _rd}}
     rec = mc.reduce(pack, [result], trusted)
     if rec["settled"] and rec["rlc_credit"] == [rep["node_ref"]]:
         CHECKS["loop:admitted-node-settles-in-coordinator"] = True


### PR DESCRIPTION
## Fabric fix: the coordinator now *routes* tee/zk through the verifier (it ignored them before)

The fabric audit found `proof_envelope` and `attestation_verifier` orphaned — only their own verifiers called them. So the coordinator **settled tee/zk results on structural presence alone**; the **anti-replay binding and the verifier verdict never ran**. A patch, not fabric.

- `mesh_coordinator.verify_result` now, for tee/zk, builds a `ProofEnvelope` `{mode, binding:{wu_id, result_cid}, material}`, runs **`proof_envelope.precheck`** (anti-replay binding + routing) **and** **`attestation_verifier.verify_tee/verify_zk`**, and refuses on a `reject` verdict. Redundant/spot_check unchanged.
- `work-unit-result` proof gains `nonce`/`report_data` (tee) and `scheme`/`publicInputs`/`proof` (zk) — the fields needed to bind a proof to a result.
- **New teeth:** a tee proof bound to a **different** result is now **refused at settlement** — anti-replay the old structural check let through. (`fabric:tee-replayed-proof-refused-at-settlement`.)

`proof_envelope` + `attestation_verifier` are now consumed by the runtime. All 7 mesh verifiers green. Additive — no wire change.
