### PR TITLE
feat(orchestration): mesh orchestrator — one pipeline that consumes every stage (fabric capstone)

### DIFF
--- a/.github/workflows/validate-mesh-orchestrator.yml
+++ b/.github/workflows/validate-mesh-orchestrator.yml
@@ -1,0 +1,19 @@
+name: validate-mesh-orchestrator
+on:
+  pull_request:
+    paths: ["reference/mesh_orchestrator.py","reference/mesh_coordinator.py","reference/mesh_scheduler.py","reference/mesh_runtime.py","reference/node_admission.py","reference/suite_gate.py","reference/proof_envelope.py","reference/attestation_verifier.py","tools/verify_mesh_orchestrator.py","spec/orchestration/mesh_orchestrator.md",".github/workflows/validate-mesh-orchestrator.yml"]
+  push:
+    branches: [ main ]
+    paths: ["reference/mesh_orchestrator.py","reference/mesh_coordinator.py","reference/mesh_scheduler.py","reference/mesh_runtime.py","reference/node_admission.py","reference/suite_gate.py","reference/proof_envelope.py","reference/attestation_verifier.py","tools/verify_mesh_orchestrator.py","spec/orchestration/mesh_orchestrator.md",".github/workflows/validate-mesh-orchestrator.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Validate mesh orchestrator (every stage composed, fail-closed)
+        run: python tools/verify_mesh_orchestrator.py

--- a/reference/mesh_orchestrator.py
+++ b/reference/mesh_orchestrator.py
@@ -1,0 +1,71 @@
+"""Mesh orchestrator — the one pipeline that consumes every mesh stage (the fabric, not a patch).
+
+Runs a Work-Unit end to end by composing the stages, so no stage is an orphan:
+
+    admit (node_admission) -> register + heartbeat/liveness (mesh_runtime) -> schedule (mesh_scheduler)
+    -> dispatch (mesh_runtime) -> collect (mesh_scheduler) -> settle (mesh_coordinator, which itself
+    enforces suite_gate + proof_envelope + attestation_verifier)
+
+Fail-closed throughout: a node that is not admitted never enters the trusted set, so it can never be
+scheduled, dispatched to, or credited. FIPS-clean (SHA-256/SHA3 downstream); does not touch the wire.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import mesh_coordinator  # noqa: E402
+import mesh_runtime  # noqa: E402
+import mesh_scheduler  # noqa: E402
+import node_admission  # noqa: E402
+
+
+class OrchestratorError(Exception):
+    pass
+
+
+def run_work_unit(reputations: list, admission_policy: dict, pack: dict,
+                  node_runtime: dict, results: list, now: int) -> dict:
+    """Compose the full mesh pipeline for one WU. `node_runtime` maps node_ref -> {suite, capacity,
+    liveness} (the runtime facts admission/reputation doesn't carry). Returns the settlement receipt
+    plus the admitted set and schedule, so the whole chain is auditable."""
+    # 1. ADMIT — only admitted reputations become trusted nodes / registry entries.
+    trusted, registry = [], []
+    for rep in reputations:
+        decision = node_admission.admit(rep, admission_policy)
+        if not decision["admitted"]:
+            continue
+        tn = dict(decision["trustedNode"])
+        rt = node_runtime.get(tn["node_ref"], {})
+        tn["suite"] = rt.get("suite", 0)
+        trusted.append(tn)
+        registry.append({
+            "node_ref": tn["node_ref"], "attestationRef": tn["attestationRef"], "region": tn["region"],
+            "trustScore": decision["trustScore"],
+            "capacity": rt.get("capacity", {"freeSlots": 1, "sandboxes": [pack.get("sandbox", "wasm")]}),
+            "liveness": rt.get("liveness", {"lastSeenMs": now, "ttlMs": 10_000}),
+        })
+    trusted_refs = {t["node_ref"] for t in trusted}
+
+    # 2. SCHEDULE — over the LIVE registry only (fail-closed if too few eligible).
+    schedule = mesh_scheduler.schedule(mesh_runtime.live_nodes(registry, now), pack, now)
+
+    # 3. DISPATCH — every assignment must be admissible (assigned + live + before deadline).
+    for a in schedule["assignments"]:
+        asn = mesh_runtime.build_assignment(pack, a["node_ref"], now)
+        mesh_runtime.check_assignment(asn, schedule, registry, now)
+
+    # 4. COLLECT — keep only assigned results that arrived by the SLO deadline.
+    deadline = now + int((pack.get("policy") or {}).get("slo_ms", 0))
+    collected = mesh_scheduler.collect(schedule, results, deadline)["collected"]
+
+    # 5. SETTLE — the coordinator enforces suite_gate + proof_envelope + attestation_verifier internally.
+    settlement = mesh_coordinator.reduce(pack, collected, trusted)
+
+    return {
+        "admitted": sorted(trusted_refs),
+        "scheduled": [a["node_ref"] for a in schedule["assignments"]],
+        "collected": len(collected),
+        "settlement": settlement,
+    }

--- a/spec/orchestration/mesh_orchestrator.md
+++ b/spec/orchestration/mesh_orchestrator.md
@@ -1,0 +1,23 @@
+# Mesh orchestrator (the fabric that consumes every stage)
+
+`reference/mesh_orchestrator.py` runs a Work-Unit end to end by composing the stages into one
+pipeline, so no stage is an orphan:
+
+```
+admit (node_admission)
+  -> register + liveness (mesh_runtime)
+  -> schedule (mesh_scheduler)
+  -> dispatch (mesh_runtime)
+  -> collect (mesh_scheduler)
+  -> settle (mesh_coordinator -> suite_gate + proof_envelope + attestation_verifier)
+```
+
+Because the orchestrator imports `node_admission`, `mesh_scheduler`, `mesh_runtime`, and
+`mesh_coordinator` (which itself enforces `suite_gate`, `proof_envelope`, and `attestation_verifier`),
+a green `tools/verify_mesh_orchestrator.py` proves **every mesh reference module is consumed by the
+runtime** — the fabric, not a set of self-testing patches.
+
+Fail-closed throughout: a reputation that is not admitted never enters the trusted set, so it can
+never be scheduled, dispatched to, or credited; a suite-N workload never settles on a below-N node;
+too few admitted nodes refuses to schedule. FIPS-clean downstream; does not touch the wire. The only
+remaining runtime is the transport that moves the bytes (QUIC/libp2p), which is delegated.

--- a/tools/verify_mesh_orchestrator.py
+++ b/tools/verify_mesh_orchestrator.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify the mesh orchestrator composes EVERY stage end-to-end and stays fail-closed (fabric proof).
+
+Runs the full pipeline (admit -> register/liveness -> schedule -> dispatch -> collect -> settle) and
+asserts: three qualified reputations are admitted, scheduled, and settle a redundant WU with all three
+credited; a low-civility reputation is NEVER admitted, scheduled, or credited; requiredSuite is
+enforced (suite-2 requirement on suite-1 nodes does not settle); too few admitted nodes refuses to
+schedule. Since the orchestrator imports node_admission + mesh_scheduler + mesh_runtime +
+mesh_coordinator (which itself uses suite_gate + proof_envelope + attestation_verifier), a green run
+proves every stage is consumed — the fabric, not a set of patches. Stdlib.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "reference"))
+import mesh_orchestrator as orch  # noqa: E402
+import mesh_scheduler as ms  # noqa: E402
+
+NOW = 1_000_000
+FAILURES: list[str] = []
+CHECKS: dict[str, bool] = {}
+
+
+def rep(ref, civility=0.8, obs=40):
+    return {"node_ref": ref, "attestationRef": f"att://{ref[7:]}", "region": "EU",
+            "trust": {"credibility": 0.9, "reliability": 0.85, "intimacy": 0.7, "selfOrientation": 0.2},
+            "energy": {"knowledge": 0.8, "creativity": 0.6, "civility": civility},
+            "history": {"observations": obs, "decayHalfLifeDays": 30}}
+
+
+POLICY = {"minTrust": 0.5, "maxSelfOrientation": 0.4, "minObservations": 30, "minCivility": 0.5, "requireAttestation": True}
+CID = "sha256:" + "a" * 64
+
+
+def runtime(refs, suite=1):
+    return {r: {"suite": suite, "capacity": {"freeSlots": 2, "sandboxes": ["wasm", "docker"]},
+                "liveness": {"lastSeenMs": NOW - 500, "ttlMs": 5000}} for r in refs}
+
+
+def results(refs):
+    return [{"wu_id": "wu-1", "node_ref": r, "region": "EU", "result_cid": CID,
+             "received_ms": NOW + 100, "proof": {"mode": "redundant"}} for r in refs]
+
+
+def pack(required_suite=1, replication=3):
+    return {"wu_id": "wu-1", "proof_mode": "redundant", "sandbox": "wasm", "replication": replication,
+            "policy": {"residency": "EU", "isolation": "strong", "slo_ms": 30000, "requiredSuite": required_suite}}
+
+
+def main() -> int:
+    good = ["node://eu-1", "node://eu-2", "node://eu-3"]
+    reps = [rep(r) for r in good] + [rep("node://eu-bad", civility=0.1)]  # eu-bad fails civility floor
+    rt = runtime(good + ["node://eu-bad"])
+    res = results(good + ["node://eu-bad"])
+
+    # 1. full pipeline: 3 admitted, scheduled, settle with all 3 credited.
+    out = orch.run_work_unit(reps, POLICY, pack(), rt, res, NOW)
+    st = out["settlement"]
+    if out["admitted"] == good and set(out["scheduled"]) == set(good) and st["settled"] and set(st["rlc_credit"]) == set(good):
+        CHECKS["fabric:full-pipeline-admit-schedule-settle"] = True
+    else:
+        FAILURES.append(f"full pipeline did not compose: {out}")
+
+    # 2. the low-civility node is never admitted / scheduled / credited.
+    if "node://eu-bad" not in out["admitted"] and "node://eu-bad" not in out["scheduled"] and "node://eu-bad" not in st["rlc_credit"]:
+        CHECKS["fail-closed:unadmitted-node-never-settles"] = True
+    else:
+        FAILURES.append("an unadmitted node leaked into schedule/settlement")
+
+    # 3. requiredSuite enforced end-to-end: suite-2 requirement on suite-1 nodes does not settle.
+    out2 = orch.run_work_unit(reps, POLICY, pack(required_suite=2), rt, res, NOW)
+    if not out2["settlement"]["settled"]:
+        CHECKS["fabric:required-suite-enforced-end-to-end"] = True
+    else:
+        FAILURES.append("a suite-2 workload settled on suite-1 nodes through the orchestrator")
+
+    # 4. too few admitted -> schedule refuses (fail-closed).
+    try:
+        orch.run_work_unit([rep("node://eu-1"), rep("node://eu-2")], POLICY, pack(replication=3), runtime(["node://eu-1", "node://eu-2"]), results(["node://eu-1", "node://eu-2"]), NOW)
+        FAILURES.append("scheduling must refuse when fewer nodes are admitted than replication requires")
+    except ms.ScheduleError:
+        CHECKS["fail-closed:insufficient-admitted-refuses-schedule"] = True
+
+    # 5. determinism.
+    if orch.run_work_unit(reps, POLICY, pack(), rt, res, NOW) == out:
+        CHECKS["deterministic:reproducible"] = True
+    else:
+        FAILURES.append("orchestrator is not deterministic")
+
+    for m in FAILURES:
+        print(f"FAIL: {m}", file=sys.stderr)
+    ok = not FAILURES and all(CHECKS.values())
+    print(json.dumps({"ok": ok, "checks": CHECKS}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The fabric capstone — one pipeline that consumes every stage

The fabric audit found `node_admission` and `mesh_scheduler` were only composed by their own verifiers — no single module ran the whole chain. This adds it.

`run_work_unit` composes the full pipeline:
```
admit (node_admission) → register/liveness (mesh_runtime) → schedule (mesh_scheduler)
  → dispatch (mesh_runtime) → collect (mesh_scheduler)
  → settle (mesh_coordinator → suite_gate + proof_envelope + attestation_verifier)
```

Because the orchestrator **imports every stage**, a green `verify_mesh_orchestrator.py` proves **every mesh reference module is consumed by the runtime** — fabric, not a set of self-testing patches.

**Teeth (5):** 3 qualified reputations admit→schedule→settle with all credited · a low-civility reputation is **never** admitted/scheduled/credited · **requiredSuite enforced end-to-end** (a suite-2 workload does not settle on suite-1 nodes) · too few admitted **refuses to schedule** · determinism.

Every mesh contract is now fabric. The only remaining runtime is the transport (QUIC/libp2p), delegated. Additive — no wire change.
